### PR TITLE
specs(#50): add developer tooling planning artifacts

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,4 @@ playwright-report
 test-results
 lighthouse
 .tmp
+specs

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
@@ -1,0 +1,12 @@
+---
+stepsCompleted: [step-01-init]
+inputDocuments: [specs/planning-artifacts/2026-03-04-developer-tooling-prd.md]
+workflowType: 'architecture'
+project_name: 'crm'
+user_name: 'Dima'
+date: '2026-03-04'
+---
+
+# Architecture Decision Document
+
+_This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
@@ -200,7 +200,8 @@ are already implemented — verify and close, do not rewrite.
   -f docker-compose.yml`) can start it alongside `dev`
 - Rationale: Existing mockoon definition in `docker-compose.test.yml` is the
   authoritative template. Porting preserves all configuration (port, network).
-  Docker healthcheck uses `wget` (inside container) — correct as-is. Makefile
+  Docker healthcheck in `docker-compose.test.yml` uses `wget` (inside container) — correct as-is there.
+  Do NOT copy the healthcheck block into `docker-compose.yml`; Makefile
   polling uses `curl` (host-side) — separate context, no conflict.
 - Health endpoint note (resolved): Mockoon CLI does not expose a separate built-in
   readiness path. The loaded OpenAPI spec (`user-service` `v2.7.1`) explicitly defines

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
@@ -1,5 +1,8 @@
 ---
-stepsCompleted: [step-01-init]
+stepsCompleted: [step-01-init, step-02-context, step-03-starter, step-04-decisions, step-05-patterns, step-06-structure, step-07-validation, step-08-complete]
+lastStep: 8
+status: 'complete'
+completedAt: '2026-03-05'
 inputDocuments: [specs/planning-artifacts/2026-03-04-developer-tooling-prd.md]
 workflowType: 'architecture'
 project_name: 'crm'
@@ -10,3 +13,569 @@ date: '2026-03-04'
 # Architecture Decision Document
 
 _This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._
+
+## Project Context Analysis
+
+### Requirements Overview
+
+**Functional Requirements:**
+
+23 FRs across 4 capability areas:
+- **Development environment startup (FR1–FR4):** `make start` must orchestrate `dev` + `mockoon`
+  services together, polling `http://localhost:8080/api/health` (Mockoon) and
+  `http://localhost:3000/` (dev server) before exiting. Exit with non-zero code on timeout.
+- **CI execution (FR5–FR13):** `make ci` runs in three ordered phases — preflight (sequential),
+  Wave 1 parallel (lint/unit/tsc), prod build gate, Wave 2 parallel (E2E/visual/performance).
+  Startup targets use `docker compose up` and follow-on command targets use
+  `docker compose exec`/`docker compose run --rm`. `--output-sync=target` provides clean
+  per-target output with attributable failures within each parallel wave.
+- **Chromium management (FR14–FR17):** `ensure-chromium` is idempotent — no-op when already
+  present. Running the full Lighthouse sequence twice must not trigger a second install.
+- **Documentation (FR18–FR20):** All new targets appear correctly in `make help` output.
+
+**Non-Functional Requirements:**
+
+- **Performance:** `make start` completes within 60 seconds (NFR1); `make ci` wall-clock time
+  measurably less than sequential execution (NFR2)
+- **Reliability:** `make start` idempotent on repeated invocations — starting already-running
+  services must not error (NFR3); CI parallelism must not introduce flakiness beyond underlying
+  tests (NFR4). NFR4 compliance depends on polling retry interval (not just total timeout) —
+  too-tight intervals cause race conditions between health-check attempts and service startup.
+- **Maintainability:** All targets use `## comment` convention for `make help` (NFR5); emoji
+  output style `🚀`/`✅`/`❌` matching `user-service` conventions (NFR6)
+
+**Scale & Complexity:**
+
+This is a **brownfield tooling change** — Makefile and Docker Compose configuration only.
+No application code, no new services, no infrastructure changes.
+
+- Primary domain: developer tooling / build infrastructure
+- Implementation complexity: **low** (3 components: `start-orchestrator`, `ci-phase-engine`,
+  `chromium-guard`)
+- Impact audit scope: **medium** — breaking change audit spans CI YAML, scripts, and docs
+  across the repo, not just the Makefile
+
+### Technical Constraints & Dependencies
+
+- **GNU Make** is the execution engine — solution must work within Make's capabilities
+- **Docker Compose** for service orchestration — health checks via shell polling (not Docker
+  healthcheck)
+- **Shell tooling**: Use only tools already present in existing Makefile targets — no new
+  shell dependencies. If `curl` is already used, use `curl`; do not introduce `wget` or
+  other alternatives.
+- **`user-service` Makefile** is the reference implementation — naming, emoji style, and
+  parallel patterns must match
+- **C1 constraint**: No breaking changes to existing targets except `make start` (intentional
+  non-blocking → blocking change with required caller audit and migration note)
+- **No new infrastructure**: Solution uses only existing tools (Make, bash, `curl` for HTTP checks)
+
+### Cross-Cutting Concerns Identified
+
+- **`JOBS` variable**: Controls parallelism in both Wave 1 and Wave 2 — single definition,
+  used in both places
+- **Health-check polling pattern**: Same pattern (poll until HTTP 200 or timeout) used in
+  `start-orchestrator` (Mockoon + port 3000) and `ci-phase-engine` (port 3001) — should be
+  a shared make function or shell snippet; retry interval is a key reliability variable
+- **Idempotency contract**: Both `start-orchestrator` and `chromium-guard` must tolerate
+  repeated invocations — this is an explicit requirement, not a nice-to-have
+- **Breaking change audit scope**: `make start` behavior changes from non-blocking to blocking.
+  Impact extends beyond the Makefile to CI YAML, scripts, and docs. **Required deliverable:**
+  grep `.github/`, `Makefile`, `*.sh`, and `*.md` for `make start` invocations; each found
+  instance must be confirmed safe (already tolerates blocking) or updated. Done = zero
+  unreviewed callers.
+
+## Starter Template Evaluation
+
+### Primary Technology Domain
+
+Developer tooling / build infrastructure — GNU Make + Docker Compose.
+Brownfield change to an existing project. No new project initialization required.
+
+### Starter Options Considered
+
+No external starter templates apply. The implementation foundation is:
+
+1. **Existing Makefile** — current target definitions, `curl`-based polling (confirmed in
+   `wait-for-dev`), and `docker compose exec` patterns already in use
+2. **`user-service` Makefile** — confirmed reference for naming, emoji style, `ci-preflight`,
+   and parallel group patterns
+3. **Existing `docker-compose.yml`** — current service definitions for `dev` and test
+   containers; `mockoon` service to be added
+
+### Selected Foundation: Existing Makefile + user-service Patterns
+
+**Rationale:** The project already has a working Makefile with established conventions.
+The `user-service` Makefile provides proven patterns for the CI orchestration needed.
+
+**What already exists (confirmed by audit):**
+
+- `ensure-chromium` — already implemented and idempotent (`[ -x "$(CHROMIUM_BIN_PATH)" ]` guard);
+  FR14–FR17 are **already satisfied** by existing code; no changes required
+- `wait-for-dev` — polling pattern using `curl` + `sleep` with configurable
+  `WAIT_FOR_DEV_MAX_TRIES ?= 150` / `WAIT_FOR_DEV_SLEEP ?= 2`; reuse pattern for
+  `wait-for-mockoon` with NFR1-aligned defaults (see below)
+- `curl` — already the HTTP tool of choice; no alternative to be introduced
+- `make start` — currently single-service (`$(DEV_CMD)`), non-blocking; Mockoon + blocking
+  readiness is the full scope of `start-orchestrator`
+
+**What is greenfield (confirmed absent):**
+
+- `--output-sync=target` — not used anywhere in current Makefile
+- `JOBS` variable — not defined
+- `make ci`, `make ci-wave-1`, `make ci-wave-2`, `make ci-build-prod` — none exist
+- Mockoon service in `docker-compose.yml` — not present
+
+**Execution Model:** Startup/orchestration targets use `docker compose up` to create and start
+containers; follow-on targets use `docker compose exec` (already-running services) or
+`docker compose run --rm` (clean one-off container execution). No direct local execution.
+CI runners mirror the same pattern.
+
+**Variable conventions:**
+- `JOBS ?= 2` (local default)
+- `?=` behavior is preserved: variable defaults are set only when unset. Keep global defaults
+  `WAIT_FOR_DEV_MAX_TRIES ?= 150` / `WAIT_FOR_DEV_SLEEP ?= 2` for standalone `wait-for-dev`.
+- Add Mockoon defaults adjacent to dev defaults:
+  `WAIT_FOR_MOCKOON_MAX_TRIES ?= 30` / `WAIT_FOR_MOCKOON_SLEEP ?= 2`.
+- Polling for `make start` runs **concurrently** and enforces NFR1 via explicit command-line
+  overrides:
+  `$(MAKE) wait-for-dev WAIT_FOR_DEV_MAX_TRIES=30 WAIT_FOR_DEV_SLEEP=2`
+  `$(MAKE) wait-for-mockoon WAIT_FOR_MOCKOON_MAX_TRIES=30 WAIT_FOR_MOCKOON_SLEEP=2`
+  This keeps global defaults intact while applying 30-try startup behavior only in `make start`.
+
+**Shell tooling:** `curl` only — already present, no new dependencies.
+
+**Note:** No project initialization story needed. Implementation begins directly
+with Makefile and Docker Compose modifications. FR14–FR17 (Chromium deduplication)
+are already implemented — verify and close, do not rewrite.
+
+## Core Architectural Decisions
+
+### Decision Priority Analysis
+
+**Critical Decisions (Block Implementation):**
+- Health-check polling implementation pattern (shared macro)
+- Concurrent startup mechanism for `make start`
+- Mockoon service location in docker-compose
+
+**Deferred Decisions (Post-MVP):**
+- Configurable readiness timeout/retry via Makefile variables (Post-MVP per PRD)
+
+### Make Execution Patterns
+
+**D1 — Health-check polling: Shared `define` macro**
+
+- Decision: Single `WAIT_FOR_HTTP` macro parameterized by service name, URL,
+  max tries, and sleep interval
+- Rationale: `wait-for-dev` and `wait-for-mockoon` share identical logic;
+  a shared macro eliminates duplication and ensures both use the same retry
+  behaviour. Make `define` macros are the idiomatic reuse mechanism.
+- Affects: `wait-for-dev` (refactored to use macro), `wait-for-mockoon` (new)
+
+**D2 — Concurrent startup: PID-capture background subshells**
+
+- Decision: `make start` launches `wait-for-dev` and `wait-for-mockoon` as
+  concurrent background processes using PID capture, then checks each
+  individually:
+  ```makefile
+  start: create-network
+      $(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up -d --build dev mockoon
+      @( $(MAKE) wait-for-dev WAIT_FOR_DEV_MAX_TRIES=30 WAIT_FOR_DEV_SLEEP=2 ) & PID1=$$!; \
+       ( $(MAKE) wait-for-mockoon WAIT_FOR_MOCKOON_MAX_TRIES=30 WAIT_FOR_MOCKOON_SLEEP=2 ) & PID2=$$!; \
+       wait $$PID1 || EXIT=1; \
+       wait $$PID2 || EXIT=1; \
+       exit $${EXIT:-0}
+  ```
+- Rationale: Plain `wait` (no args) returns only the last job's exit code —
+  a failing `wait-for-dev` would be silently swallowed. PID capture ensures
+  both failure paths are checked independently. Meets NFR1 (60s) without
+  sequential 300s+ worst case.
+- Affects: `make start` recipe
+
+### Service Orchestration
+
+**D4 — Mockoon service: port to `docker-compose.yml`**
+
+- Decision: Copy mockoon service definition from `docker-compose.test.yml` into
+  `docker-compose.yml` so `make start` (which uses `DOCKER_COMPOSE_DEV_FILE =
+  -f docker-compose.yml`) can start it alongside `dev`
+- Rationale: Existing mockoon definition in `docker-compose.test.yml` is the
+  authoritative template. Porting preserves all configuration (port, network).
+  Docker healthcheck uses `wget` (inside container) — correct as-is. Makefile
+  polling uses `curl` (host-side) — separate context, no conflict.
+- Health endpoint note (resolved): Mockoon CLI does not expose a separate built-in
+  readiness path. The loaded OpenAPI spec (`user-service` `v2.7.1`) explicitly defines
+  `GET /api/health` (success response `204`). `wait-for-mockoon` must poll
+  `http://$(WEBSITE_DOMAIN):$(MOCKOON_PORT)/api/health` via `WAIT_FOR_HTTP`
+  (using `curl -fsS`, so any 2xx/3xx is success). Do not poll `/api/users`.
+- Affects: `docker-compose.yml`, `make start`
+
+### Decision Impact Analysis
+
+**Implementation Sequence:**
+1. Port mockoon to `docker-compose.yml`
+2. Implement `WAIT_FOR_HTTP` macro; refactor `wait-for-dev` to use it
+3. Add `wait-for-mockoon` using the macro (`http://$(WEBSITE_DOMAIN):$(MOCKOON_PORT)/api/health`)
+4. Update `make start` with PID-capture concurrent polling
+5. Implement `make ci` phase structure (`ci-preflight`, `ci-wave-1`,
+   `ci-build-prod`, `ci-wave-2`)
+6. Verify `ensure-chromium` (FR14–FR17 already satisfied — confirm, don't rewrite)
+7. Update `make help` documentation for all new targets
+8. Breaking change audit: grep callers of `make start`
+
+**Cross-Component Dependencies:**
+- `WAIT_FOR_HTTP` macro must be defined before any `wait-for-*` targets
+- `mockoon` in `docker-compose.yml` must exist before `make start` is updated
+- `ci-wave-2` depends on `ci-build-prod` completing successfully — enforced by
+  Make prerequisite ordering, not shell logic
+
+## Implementation Patterns & Consistency Rules
+
+### Critical Conflict Points
+
+6 areas where an implementing agent could make inconsistent choices:
+target naming, variable naming, recipe shell style, output messaging,
+`.PHONY` declaration, and Docker Compose invocation.
+
+### Naming Patterns
+
+**Make Target Naming:**
+- All new targets: `kebab-case` — consistent with existing targets
+  (`wait-for-dev`, `start-prod`, `test-unit-all`)
+- CI phase targets follow `ci-<phase>` prefix:
+  `ci-preflight`, `ci-wave-1`, `ci-build-prod`, `ci-wave-2`
+- Wait targets follow `wait-for-<service>` prefix:
+  `wait-for-dev`, `wait-for-mockoon`
+- Anti-pattern: `ciWave1`, `CI_WAVE_1`, `waitForDev`
+
+**Make Variable Naming:**
+- All variables: `SCREAMING_SNAKE_CASE` — consistent with existing
+  (`WAIT_FOR_DEV_MAX_TRIES`, `DOCKER_COMPOSE_DEV_FILE`, `JOBS`)
+- Boolean flags: `?= 0` / `?= 1` — not `true`/`false`
+- Anti-pattern: `jobs`, `waitForDevMaxTries`
+
+### Structure Patterns
+
+**Makefile Section Order:**
+New targets belong in the section matching their concern:
+- Service orchestration targets (`wait-for-*`, `start`) — near existing `start`
+- CI targets (`ci-*`) — new section after test targets
+- Variable definitions — near top with existing variable blocks
+
+**`.PHONY` Declaration:**
+Every new target must be declared `.PHONY` — none of these targets produce files.
+Omitting `.PHONY` causes Make to silently skip targets when a file of the same
+name exists. Declare together at the top of the relevant section, not inline.
+
+### Recipe Shell Patterns
+
+**Shell block rule:**
+Multi-step recipes that share state (variables, exit codes) MUST use a single
+shell block with `\` continuation. Do NOT split into separate recipe lines.
+- Correct: `@FAILED=0; \` ... `exit $$FAILED`
+- Wrong: separate lines — each spawns a new subshell, variables don't persist
+
+**Variable expansion:**
+- Make variables: `$(VAR)` — always with parentheses
+- Shell variables inside recipes: `$$VAR` — double `$` to escape Make expansion
+- Shell arithmetic: `$$((i+1))` not `$((i+1))`
+
+**`@` prefix:**
+Use `@` to suppress echo on all recipe lines that produce their own output
+(polling loops, echo statements). Omit `@` only when the command itself
+is the meaningful output (rare).
+
+**Shell interpreter:**
+Use `/bin/sh`-compatible syntax only — no bash-specific features (`[[`, `(( ))`,
+`local`, arrays). All existing Makefile recipes use `sh`.
+
+### Output Messaging Patterns
+
+**Emoji conventions (matching `user-service`):**
+- Starting / in-progress: `🚀`
+- Success: `✅`
+- Failure: `❌`
+- Wait/polling dots: `printf "."`
+
+**Message format:**
+```
+🚀 Starting <service>...
+✅ <Service> is up and running!
+❌ Timed out waiting for <service>
+❌ FAILED: <target-name>
+```
+
+No free-form messages. Match the exact pattern from `wait-for-dev` for
+consistency.
+
+### Docker Compose Invocation Pattern
+
+**Always use the defined variables — never inline:**
+- Correct: `$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up -d mockoon`
+- Wrong: `docker compose -f docker-compose.yml up -d mockoon`
+
+This ensures compose file overrides work correctly and is consistent with
+every existing target.
+
+### Enforcement Guidelines
+
+**All implementing agents MUST:**
+- Declare every new target in `.PHONY`
+- Use `$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE)` for all dev service commands
+- Use `\` continuation for any recipe that shares shell state
+- Use `$$VAR` for shell variables (not `$VAR`) inside recipes
+- Follow emoji output style for all user-visible messages
+- Add `## descriptive comment` to every new public target for `make help`
+
+**Anti-patterns to avoid:**
+- Splitting a stateful recipe across multiple lines
+- Using `docker compose` directly instead of `$(DOCKER_COMPOSE)`
+- Hardcoding compose file names
+- Using `wait` without PID capture for concurrent processes
+- Polling an API endpoint for health (use a dedicated health path)
+
+## Project Structure & Boundaries
+
+### Files Changed
+
+This PR modifies exactly two files:
+
+```
+crm/
+├── Makefile                    ← primary changes (macro, new targets, new section)
+└── docker-compose.yml          ← add mockoon service block
+```
+
+No new files. No new directories. All three architectural components
+(`start-orchestrator`, `ci-phase-engine`, `chromium-guard`) live in `Makefile`.
+
+### Makefile Structure Map
+
+**New additions placed relative to existing sections:**
+
+```
+Makefile
+├── [existing] Variable definitions (top block)
+│   ├── WAIT_FOR_DEV_MAX_TRIES ?= 150         ← already exists
+│   ├── WAIT_FOR_DEV_SLEEP ?= 2               ← already exists
+│   ├── WAIT_FOR_MOCKOON_MAX_TRIES ?= 30      ← NEW — add adjacent
+│   └── WAIT_FOR_MOCKOON_SLEEP ?= 2           ← NEW — add adjacent
+│
+├── [new] WAIT_FOR_HTTP macro (define block)
+│   └── define WAIT_FOR_HTTP ... endef        ← NEW — add before wait-for-dev
+│
+├── [existing] start target (line ~128)
+│   ├── start: create-network                  ← MODIFIED — add mockoon + concurrent polling
+│   ├── wait-for-dev: ...                      ← MODIFIED — refactor in place to use WAIT_FOR_HTTP macro (do not delete and recreate)
+│   └── wait-for-mockoon: ...                  ← NEW — add immediately after wait-for-dev
+│
+├── [existing] Test targets section
+│   └── (unchanged)
+│
+├── [new] CI targets section                   ← NEW SECTION — after test targets
+│   ├── .PHONY ci ci-preflight ci-wave-1 ci-build-prod ci-wave-2
+│   ├── JOBS ?= 2
+│   ├── ci: ci-preflight ci-wave-1 ci-build-prod ci-wave-2
+│   ├── ci-preflight:
+│   ├── ci-wave-1:
+│   ├── ci-build-prod:
+│   └── ci-wave-2:
+│
+└── [existing] ensure-chromium (line ~160)
+    └── (verify only — no changes expected)
+```
+
+### docker-compose.yml Structure Map
+
+```
+docker-compose.yml
+└── services:
+    ├── dev: (existing — unchanged)
+    └── mockoon:                               ← NEW — ported from docker-compose.test.yml
+        ├── build: (Mockoon.Dockerfile)
+        ├── ports: ["${MOCKOON_PORT:-8080}:${MOCKOON_PORT:-8080}"]
+        ├── restart: unless-stopped
+        └── networks: [crm-network / website-network]
+```
+
+**Do NOT copy the `healthcheck` block** from `docker-compose.test.yml`. It is only
+needed there for `depends_on: condition: service_healthy` used by E2E test containers.
+In `docker-compose.yml`, readiness is handled by `wait-for-mockoon` in the Makefile —
+a Docker healthcheck is redundant and adds startup delay.
+
+### Requirements to Structure Mapping
+
+| FR | Component | Location |
+|---|---|---|
+| FR1 — single `make start` | `start-orchestrator` | `Makefile`: `start` target |
+| FR2 — wait for dev | `start-orchestrator` | `Makefile`: `wait-for-dev` (refactor in place) |
+| FR3 — wait for Mockoon | `start-orchestrator` | `Makefile`: `wait-for-mockoon` (new) |
+| FR4 — timeout exit | `start-orchestrator` | `WAIT_FOR_HTTP` macro |
+| FR5 — single `make ci` | `ci-phase-engine` | `Makefile`: `ci` target |
+| FR6 — preflight | `ci-phase-engine` | `Makefile`: `ci-preflight` |
+| FR7 — Wave 1 parallel | `ci-phase-engine` | `Makefile`: `ci-wave-1` |
+| FR8 — prod build gate | `ci-phase-engine` | `Makefile`: `ci-build-prod` |
+| FR9 — Wave 2 parallel | `ci-phase-engine` | `Makefile`: `ci-wave-2` |
+| FR10 — skip Wave 2 on failure | `ci-phase-engine` | Make prerequisite chain (automatic) |
+| FR11 — non-zero exit on failure | `ci-phase-engine` | Make prerequisite chain (automatic) |
+| FR12 — attributable failure output | `ci-phase-engine` | `--output-sync=target` on `ci-wave-1`, `ci-wave-2` |
+| FR13 — `JOBS` variable | `ci-phase-engine` | `Makefile`: `JOBS ?= 2` |
+| FR14–FR17 — Chromium guard | `chromium-guard` | `Makefile`: `ensure-chromium` (verify only) |
+| FR18–FR20 — `make help` docs | All | `## comment` on each new target |
+
+### Integration Points
+
+**`make start` → docker-compose.yml:**
+`start` target brings up `dev` + `mockoon` via `$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up -d`.
+Mockoon must be defined in `docker-compose.yml` for this to work.
+
+**`WAIT_FOR_HTTP` macro → `wait-for-dev` / `wait-for-mockoon`:**
+Both wait targets call the same macro with different parameters. Macro defined once,
+referenced twice. Any change to polling logic touches one place only.
+
+**`make ci` → existing test targets:**
+`ci-wave-1` and `ci-wave-2` call existing targets (`make lint`, `make test-unit-all`,
+`make test-e2e`, etc.) — they are orchestrators, not reimplementations. Existing
+targets remain unchanged (C1 constraint satisfied).
+
+**`ci-build-prod` → `make start-prod`:**
+`ci-build-prod` calls `make start-prod` + polls for port 3001. `start-prod` is
+an existing target — no changes needed.
+
+## Architecture Validation Results
+
+### Coherence Validation ✅
+
+**Decision Compatibility:** GNU Make + Docker Compose V2 + POSIX sh — no version
+conflicts. All tools already present in the project.
+
+**Pattern Consistency:** Naming conventions (`kebab-case` targets, `SCREAMING_SNAKE_CASE`
+variables), Docker Compose invocation via variables, and emoji output style are
+consistently applied across all new components.
+
+**Structure Alignment:** Two-file change scope (`Makefile`, `docker-compose.yml`)
+is clean and well-bounded. All new Make targets placed in appropriate existing or
+new sections. No structural conflicts.
+
+### Requirements Coverage Validation ✅
+
+**Functional Requirements:** All 20 FRs covered — see FR-to-structure mapping in
+Project Structure section. No gaps.
+
+**Non-Functional Requirements:**
+
+| NFR | Addressed By |
+|---|---|
+| NFR1 — `make start` ≤ 60s | Concurrent PID-capture polling; 30-try × 2s = 60s max per service |
+| NFR2 — `make ci` faster than sequential | `-j$(JOBS) --output-sync=target` on both waves |
+| NFR3 — idempotent `make start` | `docker compose up -d` is idempotent by design |
+| NFR4 — no new CI flakiness | `--output-sync` isolates output; health endpoints confirm readiness |
+| NFR5 — `make help` coverage | `## comment` required on all new public targets |
+| NFR6 — emoji output style | Enforced in Implementation Patterns section |
+
+### Gap Analysis & Resolutions
+
+**Gap 1 (Resolved) — `ci-preflight` format gate:**
+
+`make format` uses `prettier --write` — always exits 0, not usable as a CI gate.
+
+**Resolution (best practice):** `ci-preflight` runs format check only via a
+dedicated check variable. Lint belongs in `ci-wave-1`, not preflight — running
+it in both would double-execute lint in `make ci`.
+
+```makefile
+PRETTIER_CHECK_CMD = $(BUNX) prettier "**/*.{js,jsx,ts,tsx,mts,json,css,scss,md}" \
+  --check --ignore-path .prettierignore
+
+ci-preflight: ## Run format check (sequential gate before parallel waves)
+	@echo "🚀 Running preflight checks..."
+	$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) run --rm dev $(PRETTIER_CHECK_CMD)
+	@echo "✅ Preflight passed"
+```
+
+`make format` (write mode) is preserved unchanged — C1 satisfied.
+
+**Pinned wave target lists:**
+
+```
+ci-preflight:  PRETTIER_CHECK_CMD only (format check gate)
+ci-wave-1:     lint-eslint  lint-tsc  lint-md  test-unit-all  (parallel -j$(JOBS))
+ci-build-prod: start-prod + wait for port 3001
+ci-wave-2:     test-e2e  test-visual  test-memory-leak  lighthouse-desktop  lighthouse-mobile  (parallel -j$(JOBS))
+```
+
+**Gap 2 (Resolved) — Wave 2 targets re-invoke `start-prod`:**
+
+`test-e2e`, `test-visual`, and `test-memory-leak` each declare `start-prod` as a
+Make prerequisite. When called from `ci-wave-2`, Make re-runs `start-prod`
+(phony targets always re-run). However, `start-prod` uses `docker compose up -d`
+(idempotent — container already running) followed by a health wait. With the
+container already up, `curl` succeeds on the first attempt — health wait returns
+immediately. Re-run overhead is negligible. No action needed.
+
+**Gap 3 (Resolved) — Mockoon health endpoint URL:**
+
+Verification confirmed the Mockoon runtime source (`user-service` OpenAPI spec `v2.7.1`)
+contains `GET /api/health` and no separate built-in Mockoon readiness route.
+
+**Resolution:** `wait-for-mockoon` polls
+`http://$(WEBSITE_DOMAIN):$(MOCKOON_PORT)/api/health` via:
+
+```makefile
+$(call WAIT_FOR_HTTP,Mockoon,http://$(WEBSITE_DOMAIN):$(MOCKOON_PORT)/api/health,$(WAIT_FOR_MOCKOON_MAX_TRIES),$(WAIT_FOR_MOCKOON_SLEEP))
+```
+
+**Acceptance criteria:**
+- `wait-for-mockoon` uses `/api/health` (not `/api/users`)
+- `make start` invokes both wait targets with explicit 30-try overrides for NFR1
+- `wait-for-mockoon` fails fast with non-zero exit if `/api/health` is not reachable within timeout
+
+### Architecture Completeness Checklist
+
+- [x] Project context thoroughly analyzed and validated
+- [x] Scale and complexity correctly assessed (low implementation / medium audit)
+- [x] Technical constraints identified (`curl`, POSIX sh, Docker Compose vars)
+- [x] Cross-cutting concerns mapped (`JOBS`, polling pattern, idempotency, break audit)
+- [x] Critical decisions documented (D1–D4 with rationale)
+- [x] Implementation patterns comprehensive (naming, structure, shell, output, compose)
+- [x] Conflict points identified and resolved (6 potential conflict areas)
+- [x] Complete file structure defined (2 files, exact placement)
+- [x] FR-to-structure mapping complete (all 20 FRs traced)
+- [x] Integration points defined (macro, compose, ci chain, start-prod)
+- [x] Validation gaps resolved (3 gaps — all resolved)
+- [x] All wave target lists pinned (ci-preflight, ci-wave-1, ci-build-prod, ci-wave-2)
+
+### Architecture Readiness Assessment
+
+**Overall Status: READY FOR IMPLEMENTATION**
+
+**Confidence Level: High**
+
+**Key Strengths:**
+- Brownfield scope tightly bounded — 2 files, 3 components, no new infrastructure
+- All decisions grounded in existing codebase audit (confirmed tools, patterns, existing implementations)
+- FR14–FR17 already satisfied — scope reduced before implementation begins
+- PID-capture concurrent polling and `--output-sync` are proven patterns
+- All wave target lists explicitly pinned — no implementation guesswork
+
+**Areas for Future Enhancement (Post-MVP per PRD):**
+- Configurable readiness timeout/retry via Makefile variables
+- `make ci` matrix reporting (structured failure summary)
+
+### Implementation Handoff
+
+**First implementation step:**
+Port mockoon service from `docker-compose.test.yml` to `docker-compose.yml`
+(without healthcheck block) — all other changes depend on this.
+
+**Full sequence:** See Implementation Sequence in Core Architectural Decisions.
+
+**AI Agent Guidelines:**
+- Follow Implementation Patterns section for all Make recipe authoring
+- Use `$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE)` — never inline compose invocation
+- Refactor `wait-for-dev` in place — do not delete and recreate
+- Verify `ensure-chromium` before marking FR14–FR17 complete — do not rewrite
+- Use `http://$(WEBSITE_DOMAIN):$(MOCKOON_PORT)/api/health` for `wait-for-mockoon` (do not use `/api/users`)
+- Preserve global `WAIT_FOR_DEV_MAX_TRIES ?= 150`; apply 30-try startup behavior via `make start` command-line overrides
+- `ci-preflight` runs format check only — lint is in `ci-wave-1`
+- Breaking change audit (grep `.github/`, `*.sh`, `*.md` for `make start`) is
+  a required deliverable of the PR

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-epics.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-epics.md
@@ -1,0 +1,313 @@
+---
+stepsCompleted: [step-01-validate-prerequisites, step-02-design-epics, step-03-create-stories]
+inputDocuments:
+  - specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
+  - specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md
+---
+
+# crm - Epic Breakdown
+
+## Overview
+
+This document provides the complete epic and story breakdown for crm (Issue #49 — Developer Tooling Improvements), decomposing the requirements from the PRD and Architecture into implementable stories.
+
+## Requirements Inventory
+
+### Functional Requirements
+
+FR1: Developer can start all required development services (frontend dev server + Mockoon) with a single `make start` command
+FR2: `make start` waits until the frontend dev server is accepting connections on its port before exiting
+FR3: `make start` waits until Mockoon responds with a successful HTTP response on `http://localhost:8080/api/health` before exiting
+FR4: `make start` exits with a non-zero code if either service fails to reach healthy state within the default startup timeout window
+FR5: Developer can run all CI checks with a single `make ci` command
+FR6: `make ci` runs preflight checks (format check gate) sequentially before parallel execution begins
+FR7: `make ci` executes lint, unit tests, and TypeScript checks in parallel (Wave 1)
+FR8: `make ci` starts the production build and waits for it to be healthy before proceeding
+FR9: `make ci` executes E2E, visual regression, and performance/Lighthouse checks in parallel (Wave 2) only after Wave 1 and the production build succeed
+FR10: `make ci` skips Wave 2 and exits immediately if Wave 1 or the production build phase fails
+FR11: `make ci` exits with a non-zero code if any check fails
+FR12: `make ci` output clearly identifies which specific target failed
+FR13: Developer can configure the number of parallel jobs via a `JOBS` variable (default: 2 locally)
+FR14: The performance test sequence installs Chromium at most once per run
+FR15: `ensure-chromium` is a no-op if Chromium is already present
+FR16: Running the full Lighthouse sequence (`build-dev-chromium` → `start` → `lighthouse-desktop` → `lighthouse-mobile`) twice does not trigger a second Chromium installation
+FR17: `make lighthouse-desktop` and `make lighthouse-mobile` pass after the Chromium deduplication change
+FR18: Developer can see that `make start` starts both `dev` and `mockoon` services via `make help`
+FR19: Developer can see which CI checks `make ci` runs via `make help`
+FR20: Developer can discover all new Makefile targets via `make help`
+
+### NonFunctional Requirements
+
+NFR1: `make start` completes (both services healthy) within 60 seconds on a standard developer machine under normal conditions
+NFR2: `make ci` total wall-clock time is less than running all checks sequentially — parallelism must provide a measurable benefit
+NFR3: `make start` produces the same result on repeated invocations — starting already-running services must not cause errors
+NFR4: `make ci` infrastructure (parallelism, output sync, phase sequencing) must not introduce flakiness beyond what the underlying test targets themselves exhibit
+NFR5: All new Makefile targets follow the existing `## comment` convention so they appear correctly in `make help` output
+NFR6: All new targets follow the emoji output style established in `user-service` (`🚀`, `✅`, `❌`) for visual consistency across the VilnaCRM Makefile ecosystem
+
+### Additional Requirements
+
+- **Brownfield scope**: exactly 2 files modified (`Makefile`, `docker-compose.yml`) — no new files or directories
+- **FR14–FR17 pre-satisfied**: existing `ensure-chromium` already idempotent — verify and close only, do not rewrite
+- **Mockoon service**: port from `docker-compose.test.yml` to `docker-compose.yml` without `healthcheck` block (readiness handled by `wait-for-mockoon` in Makefile)
+- **`WAIT_FOR_HTTP` macro**: shared `define` macro must be implemented before any `wait-for-*` targets
+- **`wait-for-dev` refactor in place**: do not delete and recreate — refactor to use `WAIT_FOR_HTTP` macro
+- **Concurrent polling**: `wait-for-dev` and `wait-for-mockoon` run concurrently via PID-capture pattern in `make start`
+- **`PRETTIER_CHECK_CMD`**: CI format gate uses `prettier --check` (not `make format` which uses `--write`)
+- **Pinned wave lists**: ci-preflight (`PRETTIER_CHECK_CMD`), ci-wave-1 (`lint-eslint lint-tsc lint-md test-unit-all`), ci-wave-2 (`test-e2e test-visual test-memory-leak lighthouse-desktop lighthouse-mobile`)
+- **Breaking change audit**: grep `.github/`, `Makefile`, `*.sh`, `*.md` for `make start` invocations — required PR deliverable
+- **Mockoon health endpoint**: use `http://localhost:8080/api/health` for readiness checks (`wait-for-mockoon`); do not poll `/api/users`
+- **C1 constraint**: no breaking changes to existing Makefile targets except intentional `make start` blocking behavior change
+
+### FR Coverage Map
+
+FR1:  Epic 1 — single make start command
+FR2:  Epic 1 — wait for dev server
+FR3:  Epic 1 — wait for Mockoon health
+FR4:  Epic 1 — timeout exit
+FR5:  Epic 2 — single make ci command
+FR6:  Epic 2 — ci-preflight format gate
+FR7:  Epic 2 — ci-wave-1 parallel
+FR8:  Epic 2 — ci-build-prod gate
+FR9:  Epic 2 — ci-wave-2 parallel
+FR10: Epic 2 — skip Wave 2 on failure
+FR11: Epic 2 — non-zero exit on failure
+FR12: Epic 2 — attributable failure output
+FR13: Epic 2 — JOBS variable
+FR14: Epic 3 — Chromium installs once per run
+FR15: Epic 3 — ensure-chromium no-op if present
+FR16: Epic 3 — no reinstall on second run
+FR17: Epic 3 — lighthouse targets pass
+FR18: Epic 1 — make help for start
+FR19: Epic 2 — make help for ci
+FR20: Epic 2 — make help for all new targets
+
+## Epic List
+
+### Epic 1: Single-Command Development Environment
+
+Developers and new contributors can start a fully working local environment
+(frontend dev server + Mockoon backend mock) with a single `make start` command,
+with no additional commands required before beginning development work.
+
+**FRs covered:** FR1, FR2, FR3, FR4, FR18
+**Additional:** Breaking change audit (grep callers of `make start`) — required
+PR deliverable, not captured in FRs but architecturally mandated
+
+### Epic 2: Single-Command CI Suite
+
+Developers can run the complete CI check suite with a single `make ci` command,
+with parallel execution and clear failure attribution —
+matching the `user-service` CI conventions.
+
+**FRs covered:** FR5, FR6, FR7, FR8, FR9, FR10, FR11, FR12, FR13, FR19, FR20
+
+### Epic 3: Performance Tests Install Chromium Once Per Run
+
+The performance test toolchain installs Chromium exactly once — running the
+full Lighthouse sequence twice never triggers a second install, and all
+performance targets pass.
+
+**FRs covered:** FR14, FR15, FR16, FR17
+
+<!-- Epics and Stories -->
+
+## Epic 1: Single-Command Development Environment
+
+Developers and new contributors can start a fully working local environment (frontend dev server + Mockoon backend mock) with a single `make start` command, with no additional commands required before beginning development work.
+
+### Story 1.1: Add Mockoon Service to Development Docker Compose
+
+As a **developer**,
+I want Mockoon to be defined in `docker-compose.yml`,
+So that `make start` can orchestrate it alongside the dev container.
+
+**Acceptance Criteria:**
+
+**Given** `docker-compose.yml` exists with only the `dev` service
+**When** the Mockoon service definition is ported from `docker-compose.test.yml`
+**Then** `docker-compose.yml` contains a `mockoon` service with correct port and network config
+**And** the `healthcheck` block is NOT included (readiness handled by Makefile polling)
+**And** `docker compose up -d mockoon` starts the Mockoon container successfully
+**And** all existing targets that reference `docker-compose.yml` continue to work unchanged
+
+---
+
+### Story 1.2: Shared Health-Check Polling Macro
+
+As a **developer**,
+I want a shared `WAIT_FOR_HTTP` Make macro,
+So that `wait-for-dev` and `wait-for-mockoon` use identical, maintainable polling logic.
+
+**Acceptance Criteria:**
+
+**Given** the existing `wait-for-dev` target uses an inline polling loop
+**When** the `WAIT_FOR_HTTP` `define` macro is implemented
+**Then** the macro accepts 4 parameters: service name, URL, max tries, sleep interval
+**And** `wait-for-dev` is refactored in place to use `$(call WAIT_FOR_HTTP,...)` (not deleted and recreated)
+**And** `wait-for-dev` behaviour is identical before and after the refactor
+**And** `WAIT_FOR_MOCKOON_MAX_TRIES ?= 30` and `WAIT_FOR_MOCKOON_SLEEP ?= 2` variables are defined
+**And** a new `wait-for-mockoon` target polls Mockoon's health endpoint using the same macro
+
+---
+
+### Story 1.3: `make start` Orchestrates Complete Development Environment
+
+As a **developer**,
+I want `make start` to bring up both the dev server and Mockoon with health-based readiness,
+So that I have a fully working local environment after one command with no additional steps.
+
+**Acceptance Criteria:**
+
+**Given** Story 1.1 and 1.2 are complete
+**When** a developer runs `make start`
+**Then** both `dev` and `mockoon` containers start via `docker compose up -d --build dev mockoon`
+**And** before polling begins, the implementer verifies `http://localhost:8080/api/health` is reachable in the Mockoon runtime and wires `wait-for-mockoon` to that endpoint (not `/api/users`)
+**And** `wait-for-dev` and `wait-for-mockoon` run concurrently using PID-capture pattern
+**And** readiness polling starts only against that verified Mockoon health endpoint
+**And** `make start` exits 0 only after both services pass their health checks
+**And** `make start` exits non-zero if either service fails to become healthy within 60 seconds
+**And** `make start` is idempotent — running it when services are already up produces no errors
+**And** Mockoon responds to API calls immediately after `make start` completes
+
+---
+
+### Story 1.4: Breaking Change Audit — `make start` Callers
+
+As a **team member**,
+I want all callers of `make start` in CI YAML, scripts, and docs to be verified for the new blocking behaviour,
+So that no existing workflow breaks when `make start` changes from non-blocking to blocking.
+
+**Acceptance Criteria:**
+
+**Given** `make start` now blocks until services are healthy
+**When** a grep audit runs across `.github/`, `Makefile`, `*.sh`, and `*.md` for `make start` invocations
+**Then** every found invocation is reviewed and either confirmed safe (tolerates blocking) or updated
+**And** the PR description documents all callers found and their disposition
+**And** zero unreviewed callers remain at merge time
+
+---
+
+### Story 1.5: Document `make start` in `make help`
+
+As a **developer**,
+I want `make start` to show in `make help` that it starts both `dev` and `mockoon`,
+So that I can discover what the command does without reading the Makefile source.
+
+**Acceptance Criteria:**
+
+**Given** `make start` now orchestrates two services
+**When** a developer runs `make help`
+**Then** the `start` target entry mentions both `dev` and `mockoon` services
+**And** the comment follows the existing `## descriptive comment` format
+**And** `make help` output is otherwise unchanged
+
+## Epic 2: Single-Command CI Suite
+
+Developers can run the complete CI check suite with a single `make ci` command, with parallel execution and clear failure attribution — matching the `user-service` CI conventions.
+
+### Story 2.1: CI Format Check Gate (`ci-preflight`)
+
+As a **developer**,
+I want `make ci` to fail fast on unformatted code before running any tests,
+So that formatting issues are caught immediately without wasting time on slower checks.
+
+**Acceptance Criteria:**
+
+**Given** `PRETTIER_CHECK_CMD` is defined using `prettier --check` (not `--write`)
+**When** a developer runs `make ci-preflight`
+**Then** it runs `prettier --check` via a one-off command invocation (`docker compose run --rm dev $(PRETTIER_CHECK_CMD)` or equivalent), not `docker compose exec`
+**And** the check runs from a clean container state and returns non-zero on formatting failures
+**And** it exits non-zero if any file is not formatted, with output identifying the issue
+**And** it exits 0 if all files are correctly formatted
+**And** `make format` (write mode) is unchanged — C1 constraint satisfied
+**And** `make ci` calls `ci-preflight` as its first sequential phase
+
+---
+
+### Story 2.2: `make ci` Wave 1 — Parallel Lint and Unit Tests
+
+As a **developer**,
+I want lint, TypeScript checks, and unit tests to run in parallel,
+So that Wave 1 of `make ci` completes faster than sequential execution.
+
+**Acceptance Criteria:**
+
+**Given** `ci-preflight` passes
+**When** `make ci-wave-1` runs
+**Then** `lint-eslint`, `lint-tsc`, `lint-md`, and `test-unit-all` run in parallel via `make -j$(JOBS) --output-sync=target`
+**And** `JOBS ?= 2` is defined as the default parallelism level
+**And** output per target is buffered and printed atomically — no interleaved output
+**And** `ci-wave-1` exits non-zero if any target fails, with the failing target clearly identified
+**And** `make ci` halts and does not proceed to `ci-build-prod` if `ci-wave-1` fails
+
+---
+
+### Story 2.3: `make ci` Production Build Gate (`ci-build-prod`)
+
+As a **developer**,
+I want `make ci` to build the production bundle and wait for it to be healthy before running E2E tests,
+So that Wave 2 tests always run against a verified production build.
+
+**Acceptance Criteria:**
+
+**Given** `ci-wave-1` passes
+**When** `make ci-build-prod` runs
+**Then** it calls `make start-prod` and polls port 3001 until healthy
+**And** it exits non-zero if the production build fails to start within the configured timeout
+**And** `make ci` halts and does not proceed to `ci-wave-2` if `ci-build-prod` fails
+**And** `make start-prod` is unchanged — C1 constraint satisfied
+
+---
+
+### Story 2.4: `make ci` Wave 2 — Parallel E2E, Visual, and Performance Tests
+
+As a **developer**,
+I want E2E, visual regression, and performance tests to run in parallel after the production build,
+So that Wave 2 of `make ci` completes faster than sequential execution.
+
+**Acceptance Criteria:**
+
+**Given** `ci-build-prod` passes
+**When** `make ci-wave-2` runs
+**Then** `test-e2e`, `test-visual`, `test-memory-leak`, `lighthouse-desktop`, and `lighthouse-mobile` run in parallel via `make -j$(JOBS) --output-sync=target`
+**And** output per target is buffered and printed atomically
+**And** `ci-wave-2` exits non-zero if any target fails, with the failing target clearly identified
+**And** `make ci` exits non-zero if `ci-wave-2` fails
+
+---
+
+### Story 2.5: Document `make ci` and CI Phase Targets in `make help`
+
+As a **developer**,
+I want `make ci` and all CI phase targets to appear in `make help` with clear descriptions,
+So that I can discover all CI commands without reading the Makefile source.
+
+**Acceptance Criteria:**
+
+**Given** `make ci` and all CI phase targets are implemented
+**When** a developer runs `make help`
+**Then** `ci` entry describes running all CI checks in two parallel waves
+**And** all CI phase targets (`ci-preflight`, `ci-wave-1`, `ci-build-prod`, `ci-wave-2`) appear with descriptions
+**And** all entries follow the existing `## descriptive comment` format
+**And** `make help` output is otherwise unchanged
+
+## Epic 3: Performance Tests Install Chromium Once Per Run
+
+The performance test toolchain installs Chromium exactly once — running the full Lighthouse sequence twice never triggers a second install, and all performance targets pass.
+
+### Story 3.1: Verify `ensure-chromium` Idempotency
+
+As a **developer running performance tests**,
+I want `ensure-chromium` to be a no-op when Chromium is already installed,
+So that the Lighthouse sequence never installs Chromium twice and performance tests pass cleanly.
+
+**Acceptance Criteria:**
+
+**Given** the existing `ensure-chromium` target contains a `[ -x "$(CHROMIUM_BIN_PATH)" ]` guard
+**When** the implementation is audited against FR14–FR17
+**Then** `ensure-chromium` exits 0 immediately if Chromium is already present (no reinstall)
+**And** running `make lighthouse-desktop && make lighthouse-mobile` twice in sequence triggers exactly one Chromium install
+**And** `make lighthouse-desktop` and `make lighthouse-mobile` pass without errors
+**And** if the existing implementation already satisfies all four FRs (FR14–FR17), no code changes are made
+**And** the story is closed with a comment confirming the verification result

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-epics.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-epics.md
@@ -162,9 +162,8 @@ So that I have a fully working local environment after one command with no addit
 **Given** Story 1.1 and 1.2 are complete
 **When** a developer runs `make start`
 **Then** both `dev` and `mockoon` containers start via `docker compose up -d --build dev mockoon`
-**And** before polling begins, the implementer verifies `http://localhost:8080/api/health` is reachable in the Mockoon runtime and wires `wait-for-mockoon` to that endpoint (not `/api/users`)
 **And** `wait-for-dev` and `wait-for-mockoon` run concurrently using PID-capture pattern
-**And** readiness polling starts only against that verified Mockoon health endpoint
+**And** `wait-for-mockoon` polls the Mockoon health endpoint `http://localhost:8080/api/health` (not `/api/users`)
 **And** `make start` exits 0 only after both services pass their health checks
 **And** `make start` exits non-zero if either service fails to become healthy within 60 seconds
 **And** `make start` is idempotent — running it when services are already up produces no errors

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
@@ -217,7 +217,7 @@ ci-wave-2:      # Parallel -j$(JOBS): e2e, visual, performance
 ### CI Execution
 
 - **FR5:** Developer can run all CI checks with a single `make ci` command
-- **FR6:** `make ci` runs preflight checks (format, style gates) sequentially before parallel execution begins
+- **FR6:** `make ci` runs a format check gate (`ci-preflight` using `PRETTIER_CHECK_CMD`) sequentially before parallel execution begins; lint runs later in `ci-wave-1` to avoid double execution
 - **FR7:** `make ci` executes lint, unit tests, and TypeScript checks in parallel (Wave 1)
 - **FR8:** `make ci` starts the production build and waits for it to be healthy before proceeding
 - **FR9:** `make ci` executes E2E, visual regression, and performance/Lighthouse checks in parallel (Wave 2) only after Wave 1 and the production build succeed

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
@@ -35,13 +35,12 @@ This PRD defines requirements for a single PR that resolves all three issues, fo
 ### User Success
 
 - A developer runs `make start` once and has a fully working local environment — frontend dev server with hot-reload **and** Mockoon backend mock — with no additional commands required
-- API calls work immediately after `make start` completes; readiness means Mockoon responds HTTP 200 on its health endpoint (not just container started)
+- API calls work immediately after `make start` completes; readiness means Mockoon returns a successful HTTP response on `http://localhost:8080/api/health` (not just container started)
 - New contributors can start developing from a single command without needing to read docs about Mockoon or secondary services
 
 ### Business Success
 
 - All CI checks (lint, unit tests, E2E, visual, performance, etc.) can be triggered with a single `make ci` command instead of manually running each target in sequence
-- `make ci` works for both local developer use and CI pipeline use via `CI=1` environment variable
 - `make ci` fails fast and clearly; failures are attributable to a specific target with no garbled parallel output
 
 ### Technical Success
@@ -65,7 +64,7 @@ This PRD defines requirements for a single PR that resolves all three issues, fo
 
 **Before:** Alex pulls the latest changes Monday morning and runs `make start`. The frontend dev container spins up — but Mockoon isn't running. He opens the browser, navigates to the registration flow, and the form submits into silence. He spends 10 minutes wondering if it's his code before discovering Mockoon was never started. He runs a second command, waits again — 15 minutes after sitting down, he's finally working.
 
-**After:** Alex runs `make start`. Both `dev` and `mockoon` start together. The command waits until Mockoon returns HTTP 200, then exits. API calls work immediately. He's writing code within 2 minutes.
+**After:** Alex runs `make start`. Both `dev` and `mockoon` start together. The command waits until Mockoon returns a successful HTTP response on `/api/health`, then exits. API calls work immediately. He's writing code within 2 minutes.
 
 ---
 
@@ -108,7 +107,7 @@ This PRD defines requirements for a single PR that resolves all three issues, fo
 | Capability | Revealed By | Priority |
 |---|---|---|
 | Orchestrated `dev` + `mockoon` startup | Journey 1, 2 | MVP |
-| Health-based readiness checks (HTTP 200) | Journey 1 | MVP |
+| Health-based readiness checks (successful HTTP response) | Journey 1 | MVP |
 | Updated `make start` documentation | Journey 2 | MVP |
 | `make ci` with parallel execution | Journey 3a | MVP |
 | Configurable CI job list | Journey 3a | MVP |
@@ -130,8 +129,6 @@ All four user journeys (Alex, Mia, CI pipeline, Dana) are served by these three 
 
 - `make start` bringing up `dev` + `mockoon` with health-based readiness checks
 - `make ci` with two-wave parallel execution, `--output-sync=target`, `JOBS ?= 2`
-- `CI=1` switching across all CI targets
-- `ci-sequential` fallback with collected failure summary
 - Chromium install deduplication — single idempotent `ensure-chromium`
 - Updated `make help` documentation
 
@@ -143,7 +140,9 @@ All four user journeys (Alex, Mia, CI pipeline, Dana) are served by these three 
 
 **Breaking Change:** `make start` changes from non-blocking to blocking. Audit all CI YAML steps, scripts, and docs that call `make start` and assume immediate exit — these will break.
 
-**Technical Risk:** Two-wave CI with prod build dependency is the most complex piece — `ci-sequential` as a tested fallback mitigates this from day one.
+**Required Mitigation:** Publish a short migration guide for `make start` (before/after behavior and expected wait semantics) and run a CI/workflow caller audit across `.github/`, scripts, and docs in the same PR.
+
+**Technical Risk:** Two-wave CI with prod build dependency is the most complex piece — `--output-sync=target` ensures all parallel failures within each wave are visible.
 
 **Resource Risk:** If the PR must be split, Chromium deduplication is the most independent and lowest-risk item to defer.
 
@@ -157,11 +156,9 @@ This section captures implementation-relevant decisions to guide the developer, 
 - **Parallelism level:** `JOBS ?= 2` locally (resource-aware); CI overrides to `JOBS=4`
 - **Output style:** Matches `user-service` emoji conventions (`🚀`, `✅`, `❌`)
 
-### CI vs Local Execution
+### Execution Model
 
-`CI=1` environment variable switches execution context:
-- **Without `CI=1` (local):** `docker compose exec -T dev bun x jest`
-- **With `CI=1` (CI runner):** `bun x jest` directly — no Docker exec
+Startup targets use `docker compose up` to create and run services (`make start`, `make start-prod`), while follow-on execution targets (tests, lint, validation) run against already-running services via `docker compose exec` or one-off `docker compose run --rm`. CI runners mirror developer behavior: startup via `docker compose up`, then subsequent checks via `docker compose exec`/`run --rm`.
 
 ### `make ci` Phase Structure
 
@@ -178,18 +175,19 @@ If Phase 1 or Phase 2 fails, `make ci` exits immediately without starting Phase 
 ```makefile
 ci: ci-preflight ci-wave-1 ci-build-prod ci-wave-2  ## Run all CI checks
 
-ci-preflight:   # Sequential: format + style gates
+ci-preflight:   # Sequential: format check gate
 ci-wave-1:      # Parallel -j$(JOBS): lint, unit, tsc
 ci-build-prod:  # Sequential: start-prod + wait for port 3001
 ci-wave-2:      # Parallel -j$(JOBS): e2e, visual, performance
-ci-sequential:  # Fallback: run all sequentially, collect all failures
 ```
 
 ### `make start` Readiness
 
 - Brings up `dev` and `mockoon` via Docker Compose
-- Polls Mockoon health endpoint (HTTP 200) before exiting
-- Polls dev server on port 3000 before exiting
+- Polls Mockoon readiness with HTTP GET `http://localhost:8080/api/health` (accept any 2xx/3xx response)
+- Polls dev readiness with HTTP GET `http://localhost:3000/` (accept any 2xx/3xx response; HTTP probe, not raw TCP)
+- Poll interval: every 2 seconds
+- Timeout strategy for startup checks: `make start` passes explicit command-line overrides (`WAIT_FOR_DEV_MAX_TRIES=30`, `WAIT_FOR_MOCKOON_MAX_TRIES=30`, both with sleep `2`) to enforce a 60-second default window per service while preserving the standalone global default `WAIT_FOR_DEV_MAX_TRIES ?= 150`
 - Modelled on existing `make start-prod` pattern
 
 ### Chromium Install
@@ -205,16 +203,16 @@ ci-sequential:  # Fallback: run all sequentially, collect all failures
 | Deliverable | FRs |
 |---|---|
 | `make start` | FR1, FR2, FR3, FR4 |
-| `make ci` | FR5, FR6, FR7, FR8, FR9, FR10, FR11, FR12, FR13, FR14, FR15, FR16 |
-| Chromium deduplication | FR17, FR18, FR19, FR20 |
-| Documentation | FR21, FR22, FR23 |
+| `make ci` | FR5, FR6, FR7, FR8, FR9, FR10, FR11, FR12, FR13 |
+| Chromium deduplication | FR14, FR15, FR16, FR17 |
+| Documentation | FR18, FR19, FR20 |
 
 ### Development Environment Startup
 
 - **FR1:** Developer can start all required development services (frontend dev server + Mockoon) with a single `make start` command
 - **FR2:** `make start` waits until the frontend dev server is accepting connections on its port before exiting
-- **FR3:** `make start` waits until Mockoon responds HTTP 200 on its health endpoint before exiting
-- **FR4:** `make start` exits with a non-zero code if either service fails to reach healthy state within a fixed timeout
+- **FR3:** `make start` waits until Mockoon responds with a successful HTTP response on `http://localhost:8080/api/health` before exiting
+- **FR4:** `make start` exits with a non-zero code if either service fails to reach healthy state within the default startup timeout window
 
 ### CI Execution
 
@@ -227,22 +225,19 @@ ci-sequential:  # Fallback: run all sequentially, collect all failures
 - **FR11:** `make ci` exits with a non-zero code if any check fails
 - **FR12:** `make ci` output clearly identifies which specific target failed
 - **FR13:** Developer can configure the number of parallel jobs via a `JOBS` variable (default: 2 locally)
-- **FR14:** The system supports `CI=1` environment variable to switch all Docker exec invocations to direct command execution across all CI targets
-- **FR15:** Developer can run all CI checks sequentially via `make ci-sequential` as a fallback
-- **FR16:** `make ci-sequential` collects all failing checks and reports them together in a summary at the end rather than stopping at the first failure
 
 ### Chromium Management
 
-- **FR17:** The performance test sequence installs Chromium at most once per run
-- **FR18:** `ensure-chromium` is a no-op if Chromium is already present
-- **FR19:** Running the full Lighthouse sequence (`build-dev-chromium` → `start` → `lighthouse-desktop` → `lighthouse-mobile`) twice does not trigger a second Chromium installation
-- **FR20:** `make lighthouse-desktop` and `make lighthouse-mobile` pass after the Chromium deduplication change
+- **FR14:** The performance test sequence installs Chromium at most once per run
+- **FR15:** `ensure-chromium` is a no-op if Chromium is already present
+- **FR16:** Running the full Lighthouse sequence (`build-dev-chromium` → `start` → `lighthouse-desktop` → `lighthouse-mobile`) twice does not trigger a second Chromium installation
+- **FR17:** `make lighthouse-desktop` and `make lighthouse-mobile` pass after the Chromium deduplication change
 
 ### Documentation & Discoverability
 
-- **FR21:** Developer can see that `make start` starts both `dev` and `mockoon` services via `make help`
-- **FR22:** Developer can see which CI checks `make ci` runs via `make help`
-- **FR23:** Developer can discover `make ci-sequential` as a fallback option via `make help`
+- **FR18:** Developer can see that `make start` starts both `dev` and `mockoon` services via `make help`
+- **FR19:** Developer can see which CI checks `make ci` runs via `make help`
+- **FR20:** Developer can discover all new Makefile targets via `make help`
 
 ## Non-Functional Requirements
 
@@ -263,4 +258,4 @@ ci-sequential:  # Fallback: run all sequentially, collect all failures
 
 ## Constraints
 
-- **C1:** The implementation introduces zero breaking changes to existing Makefile targets — `make test-unit-all`, `make test-e2e`, and all other existing targets continue to work exactly as before
+- **C1:** No breaking changes to existing Makefile targets except `make start` (intentional non-blocking → blocking behavior change). Required mitigations: migration guide plus CI/workflow caller audit documented in the PR.

--- a/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
+++ b/specs/planning-artifacts/2026-03-04-developer-tooling-prd.md
@@ -1,0 +1,266 @@
+---
+stepsCompleted: [step-01-init, step-02-discovery, step-03-success, step-04-journeys, step-05-domain, step-06-innovation, step-07-project-type, step-08-scoping, step-09-functional, step-10-nonfunctional, step-11-polish, step-12-complete]
+inputDocuments: []
+workflowType: 'prd'
+briefCount: 0
+researchCount: 0
+brainstormingCount: 0
+projectDocsCount: 0
+classification:
+  projectType: web_app
+  domain: general
+  complexity: low-medium
+  projectContext: brownfield
+---
+
+# Product Requirements Document — Developer Tooling Improvements
+
+**Project:** crm
+**Author:** Dima
+**Date:** 2026-03-04
+**Issue:** [#49 — Improve start/ci targets and fix duplicate Chromium install](https://github.com/VilnaCRM-Org/crm/issues/49)
+
+## Overview
+
+The CRM frontend project's developer tooling has three friction points that slow down every developer, every day:
+
+1. **`make start` is incomplete** — it starts the frontend dev container but not Mockoon. Developers must run a second command or API calls silently fail.
+2. **No single CI command exists** — running the full check suite requires executing each `make test-*` target manually in sequence.
+3. **Chromium installs twice** in the Lighthouse/performance flow — once during image build, again at runtime — wasting time and creating confusion about which install is authoritative.
+
+This PRD defines requirements for a single PR that resolves all three issues, following the conventions established in `user-service`.
+
+## Success Criteria
+
+### User Success
+
+- A developer runs `make start` once and has a fully working local environment — frontend dev server with hot-reload **and** Mockoon backend mock — with no additional commands required
+- API calls work immediately after `make start` completes; readiness means Mockoon responds HTTP 200 on its health endpoint (not just container started)
+- New contributors can start developing from a single command without needing to read docs about Mockoon or secondary services
+
+### Business Success
+
+- All CI checks (lint, unit tests, E2E, visual, performance, etc.) can be triggered with a single `make ci` command instead of manually running each target in sequence
+- `make ci` works for both local developer use and CI pipeline use via `CI=1` environment variable
+- `make ci` fails fast and clearly; failures are attributable to a specific target with no garbled parallel output
+
+### Technical Success
+
+- `make start` orchestrates `dev` + `mockoon` services and exits only when both pass health-based readiness checks
+- `make ci` executes checks in two parallel waves with `--output-sync=target`, providing clean per-target output
+- Chromium is installed exactly once per Lighthouse run — idempotent, single source of truth
+- `lighthouse-desktop` and `lighthouse-mobile` pass after the change
+- No regression for any existing Makefile targets
+
+### Measurable Outcomes
+
+- Zero extra commands needed after `make start` to have a working dev environment
+- All CI checks run via one command (`make ci`)
+- `make ci` failure output clearly identifies which target failed
+- Chromium install count: 1 per performance test run (down from 2)
+
+## User Journeys
+
+### Journey 1: Alex — Frontend Developer (Daily Use)
+
+**Before:** Alex pulls the latest changes Monday morning and runs `make start`. The frontend dev container spins up — but Mockoon isn't running. He opens the browser, navigates to the registration flow, and the form submits into silence. He spends 10 minutes wondering if it's his code before discovering Mockoon was never started. He runs a second command, waits again — 15 minutes after sitting down, he's finally working.
+
+**After:** Alex runs `make start`. Both `dev` and `mockoon` start together. The command waits until Mockoon returns HTTP 200, then exits. API calls work immediately. He's writing code within 2 minutes.
+
+---
+
+### Journey 2: Mia — New Contributor (Onboarding)
+
+> ⚠️ *Assumed pain point — not validated from contributor complaints. Included as hypothesis.*
+
+**Before:** Mia joins the team, follows the README, runs `make start`. The frontend loads but the form does nothing. She spends an hour on Slack before discovering the separate Mockoon command. She's frustrated before writing a single line of code — and begins to doubt whether she's doing something wrong.
+
+**After:** Mia runs `make start`. Everything comes up. The experience restores confidence — the project just works. One command, documented correctly, no hidden steps.
+
+---
+
+### Journey 3a: CI Pipeline — Happy Path
+
+**Before:** GitHub Actions sequences multiple separate `make` targets as individual YAML steps. Adding a new check means editing the pipeline. There's no single place to confirm "all checks passed."
+
+**After:** The CI YAML calls `make ci`. All checks run in two parallel waves. When everything passes, the developer sees one green check. Simple, fast, authoritative.
+
+---
+
+### Journey 3b: CI Pipeline — Failure Path (Debugging at Midnight)
+
+**Before:** A developer's PR fails in CI. They open the run — 400 lines of interleaved parallel output. Unit test failures mixed with lint warnings mixed with E2E output. They scroll for 5 minutes, re-run the suite, still can't pinpoint the failure.
+
+**After:** `make ci` fails and clearly surfaces `❌ FAILED: test-unit-client`. The developer goes directly to the relevant output. Mean time to recovery drops from 15 minutes to 2 minutes.
+
+---
+
+### Journey 4: Dana — Developer Running Performance Tests
+
+**Before:** Dana runs the Lighthouse sequence. Chromium installs during `build-dev-chromium`. Then installs again during `start`. Then `ensure-chromium` runs again during `lighthouse-desktop`. Minutes wasted, no clarity on which install is authoritative.
+
+**After:** Chromium installs once during the build step. `ensure-chromium` is a no-op when Chromium is present. Running the sequence twice doesn't trigger reinstall.
+
+---
+
+### Journey Requirements Summary
+
+| Capability | Revealed By | Priority |
+|---|---|---|
+| Orchestrated `dev` + `mockoon` startup | Journey 1, 2 | MVP |
+| Health-based readiness checks (HTTP 200) | Journey 1 | MVP |
+| Updated `make start` documentation | Journey 2 | MVP |
+| `make ci` with parallel execution | Journey 3a | MVP |
+| Configurable CI job list | Journey 3a | MVP |
+| Attributable failure output per target | Journey 3b | MVP (highest value) |
+| Single Chromium install source of truth | Journey 4 | MVP |
+| Idempotent `ensure-chromium` | Journey 4 | MVP |
+
+## Project Scoping
+
+### Delivery Model
+
+**One PR, three logical commits** — `make start`, `make ci`, Chromium deduplication — each independently reviewable but merged together. Splitting deliverables is an emergency fallback only; the default is all three in one PR.
+
+**Resource:** 1 developer, single sprint. No new infrastructure dependencies.
+
+### MVP — This PR
+
+All four user journeys (Alex, Mia, CI pipeline, Dana) are served by these three deliverables together.
+
+- `make start` bringing up `dev` + `mockoon` with health-based readiness checks
+- `make ci` with two-wave parallel execution, `--output-sync=target`, `JOBS ?= 2`
+- `CI=1` switching across all CI targets
+- `ci-sequential` fallback with collected failure summary
+- Chromium install deduplication — single idempotent `ensure-chromium`
+- Updated `make help` documentation
+
+### Post-MVP
+
+- Configurable readiness check timeout and retry count via Makefile variables
+
+### Risk Mitigation
+
+**Breaking Change:** `make start` changes from non-blocking to blocking. Audit all CI YAML steps, scripts, and docs that call `make start` and assume immediate exit — these will break.
+
+**Technical Risk:** Two-wave CI with prod build dependency is the most complex piece — `ci-sequential` as a tested fallback mitigates this from day one.
+
+**Resource Risk:** If the PR must be split, Chromium deduplication is the most independent and lowest-risk item to defer.
+
+## Technical Architecture
+
+This section captures implementation-relevant decisions to guide the developer, following `user-service` conventions.
+
+### Parallelism & Output
+
+- **Mechanism:** GNU Make `-jN` with `--output-sync=target` — output buffered per target, printed atomically after completion
+- **Parallelism level:** `JOBS ?= 2` locally (resource-aware); CI overrides to `JOBS=4`
+- **Output style:** Matches `user-service` emoji conventions (`🚀`, `✅`, `❌`)
+
+### CI vs Local Execution
+
+`CI=1` environment variable switches execution context:
+- **Without `CI=1` (local):** `docker compose exec -T dev bun x jest`
+- **With `CI=1` (CI runner):** `bun x jest` directly — no Docker exec
+
+### `make ci` Phase Structure
+
+E2E, visual, and performance tests require a running production build. `make ci` therefore executes in three ordered phases:
+
+```
+Phase 1 — ci-wave-1 (parallel): lint, unit tests, TypeScript check
+Phase 2 — ci-build-prod (sequential gate): start-prod, wait for port 3001
+Phase 3 — ci-wave-2 (parallel): E2E, visual regression, performance/Lighthouse
+```
+
+If Phase 1 or Phase 2 fails, `make ci` exits immediately without starting Phase 3.
+
+```makefile
+ci: ci-preflight ci-wave-1 ci-build-prod ci-wave-2  ## Run all CI checks
+
+ci-preflight:   # Sequential: format + style gates
+ci-wave-1:      # Parallel -j$(JOBS): lint, unit, tsc
+ci-build-prod:  # Sequential: start-prod + wait for port 3001
+ci-wave-2:      # Parallel -j$(JOBS): e2e, visual, performance
+ci-sequential:  # Fallback: run all sequentially, collect all failures
+```
+
+### `make start` Readiness
+
+- Brings up `dev` and `mockoon` via Docker Compose
+- Polls Mockoon health endpoint (HTTP 200) before exiting
+- Polls dev server on port 3000 before exiting
+- Modelled on existing `make start-prod` pattern
+
+### Chromium Install
+
+- Single `ensure-chromium` guard — checks for presence before installing (idempotent)
+- `INSTALL_CHROMIUM=true` respected only during image build, not at runtime
+- `make lighthouse-desktop` and `make lighthouse-mobile` call `ensure-chromium`, which is a no-op if Chromium already present
+
+## Functional Requirements
+
+### Deliverable Traceability
+
+| Deliverable | FRs |
+|---|---|
+| `make start` | FR1, FR2, FR3, FR4 |
+| `make ci` | FR5, FR6, FR7, FR8, FR9, FR10, FR11, FR12, FR13, FR14, FR15, FR16 |
+| Chromium deduplication | FR17, FR18, FR19, FR20 |
+| Documentation | FR21, FR22, FR23 |
+
+### Development Environment Startup
+
+- **FR1:** Developer can start all required development services (frontend dev server + Mockoon) with a single `make start` command
+- **FR2:** `make start` waits until the frontend dev server is accepting connections on its port before exiting
+- **FR3:** `make start` waits until Mockoon responds HTTP 200 on its health endpoint before exiting
+- **FR4:** `make start` exits with a non-zero code if either service fails to reach healthy state within a fixed timeout
+
+### CI Execution
+
+- **FR5:** Developer can run all CI checks with a single `make ci` command
+- **FR6:** `make ci` runs preflight checks (format, style gates) sequentially before parallel execution begins
+- **FR7:** `make ci` executes lint, unit tests, and TypeScript checks in parallel (Wave 1)
+- **FR8:** `make ci` starts the production build and waits for it to be healthy before proceeding
+- **FR9:** `make ci` executes E2E, visual regression, and performance/Lighthouse checks in parallel (Wave 2) only after Wave 1 and the production build succeed
+- **FR10:** `make ci` skips Wave 2 and exits immediately if Wave 1 or the production build phase fails
+- **FR11:** `make ci` exits with a non-zero code if any check fails
+- **FR12:** `make ci` output clearly identifies which specific target failed
+- **FR13:** Developer can configure the number of parallel jobs via a `JOBS` variable (default: 2 locally)
+- **FR14:** The system supports `CI=1` environment variable to switch all Docker exec invocations to direct command execution across all CI targets
+- **FR15:** Developer can run all CI checks sequentially via `make ci-sequential` as a fallback
+- **FR16:** `make ci-sequential` collects all failing checks and reports them together in a summary at the end rather than stopping at the first failure
+
+### Chromium Management
+
+- **FR17:** The performance test sequence installs Chromium at most once per run
+- **FR18:** `ensure-chromium` is a no-op if Chromium is already present
+- **FR19:** Running the full Lighthouse sequence (`build-dev-chromium` → `start` → `lighthouse-desktop` → `lighthouse-mobile`) twice does not trigger a second Chromium installation
+- **FR20:** `make lighthouse-desktop` and `make lighthouse-mobile` pass after the Chromium deduplication change
+
+### Documentation & Discoverability
+
+- **FR21:** Developer can see that `make start` starts both `dev` and `mockoon` services via `make help`
+- **FR22:** Developer can see which CI checks `make ci` runs via `make help`
+- **FR23:** Developer can discover `make ci-sequential` as a fallback option via `make help`
+
+## Non-Functional Requirements
+
+### Performance
+
+- **NFR1:** `make start` completes (both services healthy) within 60 seconds on a standard developer machine under normal conditions
+- **NFR2:** `make ci` total wall-clock time is less than running all checks sequentially — parallelism must provide a measurable benefit
+
+### Reliability
+
+- **NFR3:** `make start` produces the same result on repeated invocations — starting already-running services must not cause errors
+- **NFR4:** `make ci` infrastructure (parallelism, output sync, phase sequencing) must not introduce flakiness beyond what the underlying test targets themselves exhibit
+
+### Maintainability
+
+- **NFR5:** All new Makefile targets follow the existing `## comment` convention so they appear correctly in `make help` output
+- **NFR6:** All new targets follow the emoji output style established in `user-service` (`🚀`, `✅`, `❌`) for visual consistency across the VilnaCRM Makefile ecosystem
+
+## Constraints
+
+- **C1:** The implementation introduces zero breaking changes to existing Makefile targets — `make test-unit-all`, `make test-e2e`, and all other existing targets continue to work exactly as before


### PR DESCRIPTION
## Description

Add initial planning artifacts for the developer tooling scope in issue #50 and exclude `specs/` from markdownlint checks.

## Related Issue

Closes #50

## What Changed

- Added PRD artifact:
  - `specs/planning-artifacts/2026-03-04-developer-tooling-prd.md`
- Added architecture artifact scaffold:
  - `specs/planning-artifacts/2026-03-04-developer-tooling-architecture.md`
- Updated `.markdownlintignore` to exclude `specs`

## How Has This Been Tested?

- `CI=1 make lint-next`
  - Result: `make: Nothing to be done for 'lint-next'.`

## Checklist

- [x] Linked to issue
- [x] Branch pushed to origin
- [x] Draft PR created