### PR TITLE
feat(ci): add GitHub Actions workflow for rust-code-analysis

### DIFF
--- a/.github/workflows/rust-code-analysis.yml
+++ b/.github/workflows/rust-code-analysis.yml
@@ -1,0 +1,25 @@
+name: rust-code-analysis
+
+on:
+  pull_request:
+    branches: ['main']
+
+env:
+  # Must match RCA_VERSION in Makefile — used as the binary cache key.
+  RCA_VERSION: '0.0.25'
+
+jobs:
+  rust-code-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache rust-code-analysis binary
+        uses: actions/cache@v4
+        with:
+          path: ./bin/rust-code-analysis-cli
+          key: rca-${{ env.RCA_VERSION }}-linux-x86_64
+
+      - name: Run lint-metrics
+        run: make lint-metrics


### PR DESCRIPTION
## Description

Implements Story 2.1 by adding the dedicated pull-request workflow for rust-code-analysis.

What:
- add `.github/workflows/rust-code-analysis.yml`
- trigger on pull requests targeting `main`
- define the required job name `rust-code-analysis`
- cache the pinned CLI binary and run `make lint-metrics`

Why:
- CI needs to enforce the same committed policy that local runs use

Stacking:
- base branch is `story-1-2-lint-metrics` because the workflow depends on the local enforcement target from Story 1.2

## Linked Issues

Closes #61.
Relates to #18.

## Notes

Draft PR for story-scoped review only.