### PR TITLE
fix(metrics): calibrate thresholds to baseline compliance for current main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,12 +218,12 @@ lint-metrics: ## Run rust-code-analysis complexity gate (auto-installs binary if
 	fi
 	@RCA_BIN="$(RCA_BIN)" \
 	RCA_VERSION="$(RCA_VERSION)" \
-	CC_MAX="10" \
-	COGNITIVE_MAX="15" \
+	CC_MAX="20" \
+	COGNITIVE_MAX="24" \
 	NARGS_MAX="5" \
-	NEXITS_MAX="4" \
-	MI_MIN="65" \
-	SLOC_MAX="50" \
+	NEXITS_MAX="15" \
+	MI_MIN="40" \
+	SLOC_MAX="157" \
 	sh scripts/lint-metrics.sh
 
 lint: lint-eslint lint-tsc lint-md lint-metrics ## Runs all linters: ESLint, TypeScript, Markdown, and rust-code-analysis metrics.


### PR DESCRIPTION
## Description

Implements the code-change portion of Story 2.2 by calibrating the committed thresholds to the measured baseline on current `main`.

What:
- run baseline `lint-metrics` against current `main`
- update the committed thresholds in `Makefile` to the worst observed passing values
- keep the workflow job name and follow-up branch-protection step aligned with the measured baseline

Why:
- enforcement should not be enabled with thresholds that already fail on the current baseline

Stacking:
- base branch is `story-2-1-rca-workflow` because baseline calibration depends on the workflow and enforcement from earlier stories

## Linked Issues

Closes #62.
Relates to #18.

## Notes

Draft PR for story-scoped review only.
Manual branch-protection registration remains outside the code diff.