### PR TITLE
refactor(#90): drop data-testid from source; gate semantic test selectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,12 @@ Key variables in `.env`:
    - E2E tests for user flows
    - Visual tests for UI regression
    - Mutation tests for code quality
+   - **Selectors**: source ships **no `data-testid`** — locate elements by
+     user-facing semantics (`getByRole`, `getByLabelText`, `getByText`), falling
+     back to a stable `id` only when no semantic query fits. Enforced in
+     `eslint.config.mjs` via `no-restricted-syntax`: `error` on `data-testid` in
+     `src/**`, `warn` on `*ByTestId` in tests (mock-stub queries stay valid).
+     Satisfy the gate by refactoring, never with `eslint-disable`.
 
 5. **Docker Network**: External network `website-network` used for service communication
 

--- a/agents.md
+++ b/agents.md
@@ -613,9 +613,10 @@ export const UIComponentName: React.FC<UIComponentNameProps> = (props) => {
      constructor(private page: Page) {}
 
      async login(email: string, password: string) {
-       await this.page.fill('[data-testid="email"]', email);
-       await this.page.fill('[data-testid="password"]', password);
-       await this.page.click('[data-testid="submit"]');
+       // Query by user-facing semantics — source ships no data-testid (issue #90).
+       await this.page.getByLabel('Email').fill(email);
+       await this.page.getByLabel('Password').fill(password);
+       await this.page.getByRole('button', { name: 'Sign in' }).click();
      }
    }
    ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -283,6 +283,49 @@ export default [
     },
   },
 
+  // Source (issue #90): production source must not ship `data-testid`. Expose a
+  // stable `id` where a non-semantic hook is unavoidable; tests query by
+  // role/label/text. Stories are excluded.
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    ignores: ['**/*.stories.*', '**/*.test.*', '**/*.spec.*'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXAttribute[name.name='data-testid']",
+          message:
+            'No data-testid in source — expose a stable id or query by role/label/text (issue #90).',
+        },
+        {
+          selector: "Property[key.value='data-testid']",
+          message: 'No data-testid prop in source — use an id instead (issue #90).',
+        },
+        {
+          selector: "TSPropertySignature[key.value='data-testid']",
+          message: 'No data-testid prop type in source — expose an id prop instead (issue #90).',
+        },
+      ],
+    },
+  },
+
+  // Tests (issue #90): discourage *ByTestId — prefer getByRole/getByLabelText/
+  // getByText, falling back to a stable id. `warn` during staged migration
+  // (mock-stub queries remain valid); promote to `error` once the suite is clean.
+  {
+    files: testFilePatterns,
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: 'CallExpression[callee.property.name=/^(get|query|find)(All)?ByTestId$/]',
+          message:
+            'Prefer getByRole/getByLabelText/getByText; *ByTestId is a last resort (issue #90).',
+        },
+      ],
+    },
+  },
+
   // K6 load test scripts: console output is the idiomatic logging channel.
   {
     files: ['tests/load/**/*.js'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -287,7 +287,7 @@ export default [
   // stable `id` where a non-semantic hook is unavoidable; tests query by
   // role/label/text. Stories are excluded.
   {
-    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    files: ['src/**/*.ts', 'src/**/*.tsx', 'src/**/*.js', 'src/**/*.jsx'],
     ignores: ['**/*.stories.*', '**/*.test.*', '**/*.spec.*'],
     rules: {
       'no-restricted-syntax': [
@@ -318,7 +318,8 @@ export default [
       'no-restricted-syntax': [
         'warn',
         {
-          selector: 'CallExpression[callee.property.name=/^(get|query|find)(All)?ByTestId$/]',
+          selector:
+            'CallExpression[callee.property.name=/^(get|query|find)(All)?ByTestId$/], CallExpression[callee.name=/^(get|query|find)(All)?ByTestId$/]',
           message:
             'Prefer getByRole/getByLabelText/getByText; *ByTestId is a last resort (issue #90).',
         },

--- a/src/modules/user/features/auth/components/auth-error-boundary/index.tsx
+++ b/src/modules/user/features/auth/components/auth-error-boundary/index.tsx
@@ -54,14 +54,9 @@ function FallbackContainer({
   const resolvedFallback = fallback === DEFAULT_FALLBACK_KEY ? t(DEFAULT_FALLBACK_KEY) : fallback;
 
   return (
-    <div
-      role="alert"
-      aria-live="assertive"
-      aria-atomic="true"
-      data-testid="auth-error-boundary-fallback"
-    >
+    <div role="alert" aria-live="assertive" aria-atomic="true">
       {resolvedFallback}
-      <RetryButton type="button" data-testid="auth-error-boundary-try-again" onClick={onReset}>
+      <RetryButton type="button" onClick={onReset}>
         {t('auth.error.tryAgain')}
       </RetryButton>
       {shouldShowErrorDetails(error) && <ErrorDetails error={error} />}

--- a/src/modules/user/features/auth/components/form-section/auth-forms/registration-success-view.tsx
+++ b/src/modules/user/features/auth/components/form-section/auth-forms/registration-success-view.tsx
@@ -78,11 +78,7 @@ function MessageContainer({
 }): JSX.Element {
   return (
     <Box sx={styles.messageContainer}>
-      <UITypography
-        component="h4"
-        sx={styles.successMessageTitle}
-        data-testid="success-notification-title"
-      >
+      <UITypography component="h4" sx={styles.successMessageTitle}>
         {title}
       </UITypography>
       <UITypography component="span" sx={styles.successMessageDescription}>

--- a/src/modules/user/features/auth/components/form-section/index.tsx
+++ b/src/modules/user/features/auth/components/form-section/index.tsx
@@ -59,7 +59,6 @@ function SwitcherButton({
       onFocus={onIntent}
       onTouchStart={onIntent}
       disabled={disabled}
-      data-testid="signup-switcher"
     >
       {label}
     </UIButton>
@@ -136,11 +135,7 @@ function FormSectionLayout({
     <Box component="section" sx={styles.formSection}>
       <Box sx={styles.formWrapper}>
         <AuthBody mode={mode} onViewChange={onRegistrationViewChange} />
-        <InertBox
-          id="auth-provider-buttons-container"
-          data-testid="auth-provider-buttons-container"
-          inert={showNotification}
-        >
+        <InertBox id="auth-provider-buttons-container" inert={showNotification}>
           <AuthProviderButtons />
         </InertBox>
       </Box>

--- a/src/modules/user/features/auth/components/form-section/inert-box.tsx
+++ b/src/modules/user/features/auth/components/form-section/inert-box.tsx
@@ -5,7 +5,6 @@ interface InertBoxProps {
   id: string;
   inert: boolean;
   children: ReactNode;
-  'data-testid'?: string;
 }
 
 function applyInert(el: HTMLDivElement | null, inert: boolean): void {
@@ -14,19 +13,14 @@ function applyInert(el: HTMLDivElement | null, inert: boolean): void {
   else el.removeAttribute('inert');
 }
 
-export default function InertBox({
-  id,
-  inert,
-  children,
-  'data-testid': dataTestId,
-}: InertBoxProps): JSX.Element {
+export default function InertBox({ id, inert, children }: InertBoxProps): JSX.Element {
   const setInertRef = useCallback(
     (el: HTMLDivElement | null): void => applyInert(el, inert),
     [inert]
   );
 
   return (
-    <Box id={id} data-testid={dataTestId} ref={setInertRef}>
+    <Box id={id} ref={setInertRef}>
       {children}
     </Box>
   );

--- a/tests/memory-leak/tests/signup.js
+++ b/tests/memory-leak/tests/signup.js
@@ -8,7 +8,6 @@ const logger = require('../utils/logger');
 const ROUTE_PATH = '/authentication';
 const DEFAULT_TIMEOUT = 5000;
 const NETWORK_IDLE_TIMEOUT = 30000;
-const SIGNUP_SWITCHER_SELECTOR = '[data-testid="signup-switcher"]';
 const PAGE_STATE_KEY = '__MEMLAB_SIGNUP_BASELINE__';
 
 const scenarioBuilder = new ScenarioBuilder(ROUTE_PATH);
@@ -48,6 +47,27 @@ async function waitForLoginForm(page, timeout = DEFAULT_TIMEOUT) {
   );
 }
 
+// Click the mode switcher by its visible label text (the button has no test
+// hook by design — see issue #90: source ships no data-testid).
+async function clickSwitcherByText(page, switcherText) {
+  await page.waitForFunction(
+    (text) =>
+      Array.from(document.querySelectorAll('button')).some((button) =>
+        button.textContent.trim().includes(text)
+      ),
+    { timeout: DEFAULT_TIMEOUT },
+    switcherText
+  );
+  await page.evaluate((text) => {
+    const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent.trim().includes(text)
+    );
+    if (button) {
+      button.click();
+    }
+  }, switcherText);
+}
+
 async function ensureRegistrationForm(page) {
   const isRegistrationForm = await page.$('input[name="fullName"]');
 
@@ -55,60 +75,14 @@ async function ensureRegistrationForm(page) {
     return false;
   }
 
-  const switcherText = t('sign_up.form.switcher_text_no_account');
-  const switcherByTestId = await page.$(SIGNUP_SWITCHER_SELECTOR);
-
-  if (switcherByTestId) {
-    await page.click(SIGNUP_SWITCHER_SELECTOR);
-  } else {
-    await page.waitForFunction(
-      (text) =>
-        Array.from(document.querySelectorAll('button')).some((button) =>
-          button.textContent.trim().includes(text)
-        ),
-      { timeout: DEFAULT_TIMEOUT },
-      switcherText
-    );
-    await page.evaluate((text) => {
-      const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
-        candidate.textContent.trim().includes(text)
-      );
-      if (button) {
-        button.click();
-      }
-    }, switcherText);
-  }
-
+  await clickSwitcherByText(page, t('sign_up.form.switcher_text_no_account'));
   await waitForRegistrationForm(page);
 
   return true;
 }
 
 async function restoreLoginView(page) {
-  const switcherText = t('sign_up.form.switcher_text_have_account');
-  const switcherByTestId = await page.$(SIGNUP_SWITCHER_SELECTOR);
-
-  if (switcherByTestId) {
-    await page.click(SIGNUP_SWITCHER_SELECTOR);
-  } else {
-    await page.waitForFunction(
-      (text) =>
-        Array.from(document.querySelectorAll('button')).some((button) =>
-          button.textContent.trim().includes(text)
-        ),
-      { timeout: DEFAULT_TIMEOUT },
-      switcherText
-    );
-    await page.evaluate((text) => {
-      const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
-        candidate.textContent.trim().includes(text)
-      );
-      if (button) {
-        button.click();
-      }
-    }, switcherText);
-  }
-
+  await clickSwitcherByText(page, t('sign_up.form.switcher_text_have_account'));
   await waitForLoginForm(page);
 }
 

--- a/tests/unit/modules/user/features/auth/components/auth-error-boundary/index.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/auth-error-boundary/index.test.tsx
@@ -94,7 +94,7 @@ describe('AuthErrorBoundary', () => {
       </AuthErrorBoundary>
     );
 
-    expect(screen.getByTestId('auth-error-boundary-fallback')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
 
     shouldThrow = false;
     rerender(
@@ -103,7 +103,7 @@ describe('AuthErrorBoundary', () => {
       </AuthErrorBoundary>
     );
 
-    await userEvent.click(screen.getByTestId('auth-error-boundary-try-again'));
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
 
     expect(screen.getByTestId('child')).toBeInTheDocument();
   });

--- a/tests/unit/modules/user/features/auth/components/form-section.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section.test.tsx
@@ -124,6 +124,12 @@ jest.mock(
 type FormSectionModule = typeof import('@/modules/user/features/auth/components/form-section');
 let FormSection!: FormSectionModule['default'];
 
+function getAuthProviderContainer(view: ReturnType<typeof render>): HTMLElement {
+  return view
+    .getAllByRole('generic')
+    .find((element) => element.id === 'auth-provider-buttons-container') as HTMLElement;
+}
+
 describe('FormSection', () => {
   beforeAll(async () => {
     ({ default: FormSection } =
@@ -269,9 +275,7 @@ describe('FormSection', () => {
 
   it('marks auth provider buttons as inert when notification view is active', () => {
     const view = render(<FormSection />);
-    const authProviderContainer = view
-      .getAllByRole('generic')
-      .find((element) => element.id === 'auth-provider-buttons-container') as HTMLElement;
+    const authProviderContainer = getAuthProviderContainer(view);
 
     expect(authProviderContainer).not.toHaveAttribute('inert');
 
@@ -282,9 +286,7 @@ describe('FormSection', () => {
 
   it('clears notification view when switching modes', async () => {
     const view = render(<FormSection />);
-    const authProviderContainer = view
-      .getAllByRole('generic')
-      .find((element) => element.id === 'auth-provider-buttons-container') as HTMLElement;
+    const authProviderContainer = getAuthProviderContainer(view);
 
     fireEvent.click(view.getByTestId('trigger-success-view'));
     expect(authProviderContainer).toHaveAttribute('inert');

--- a/tests/unit/modules/user/features/auth/components/form-section.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section.test.tsx
@@ -269,19 +269,25 @@ describe('FormSection', () => {
 
   it('marks auth provider buttons as inert when notification view is active', () => {
     const view = render(<FormSection />);
+    const authProviderContainer = view
+      .getAllByRole('generic')
+      .find((element) => element.id === 'auth-provider-buttons-container') as HTMLElement;
 
-    expect(view.getByTestId('auth-provider-buttons-container')).not.toHaveAttribute('inert');
+    expect(authProviderContainer).not.toHaveAttribute('inert');
 
     fireEvent.click(view.getByTestId('trigger-success-view'));
 
-    expect(view.getByTestId('auth-provider-buttons-container')).toHaveAttribute('inert');
+    expect(authProviderContainer).toHaveAttribute('inert');
   });
 
   it('clears notification view when switching modes', async () => {
     const view = render(<FormSection />);
+    const authProviderContainer = view
+      .getAllByRole('generic')
+      .find((element) => element.id === 'auth-provider-buttons-container') as HTMLElement;
 
     fireEvent.click(view.getByTestId('trigger-success-view'));
-    expect(view.getByTestId('auth-provider-buttons-container')).toHaveAttribute('inert');
+    expect(authProviderContainer).toHaveAttribute('inert');
 
     fireEvent.click(view.getByText('sign_up.form.switcher_text_have_account'));
 
@@ -291,6 +297,6 @@ describe('FormSection', () => {
 
     fireEvent.click(view.getByText('sign_up.form.switcher_text_no_account'));
 
-    expect(view.getByTestId('auth-provider-buttons-container')).not.toHaveAttribute('inert');
+    expect(authProviderContainer).not.toHaveAttribute('inert');
   });
 });

--- a/tests/unit/modules/user/features/auth/index.test.tsx
+++ b/tests/unit/modules/user/features/auth/index.test.tsx
@@ -63,7 +63,7 @@ describe('Authentication shell', () => {
     render(<Authentication />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('auth-error-boundary-fallback')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Enforces the convention from #90: **production source must not ship `data-testid`**, and tests locate elements through user-facing / semantic queries (`getByRole`, `getByLabelText`, `getByText`), falling back to a stable `id` only when no semantic query fits.

Closes #90.

## Source — all `data-testid` removed

| File | Element | After removal |
| --- | --- | --- |
| `form-section/index.tsx` | switcher button | keeps its visible label → `getByRole('button', { name })` |
| `form-section/index.tsx` | InertBox container | testid was redundant with `id="auth-provider-buttons-container"` (kept) |
| `form-section/inert-box.tsx` | `'data-testid'?` prop + pass-through | removed; `id` + `inert` ref unchanged |
| `auth-error-boundary/index.tsx` | fallback `<div>` | keeps `role="alert"` |
| `auth-error-boundary/index.tsx` | retry `<button>` | keeps text `t('auth.error.tryAgain')` |
| `registration-success-view.tsx` | success title | keeps `<h4>` + title text |

Accessibility was reviewed: every element retains its native role / accessible name / text, so removal is an a11y no-op (net-positive — querying by role/label keeps the markup honest).

## Tests — real-DOM offenders migrated

- `form-section.test.tsx`: query the inert container by its `id` (mirrors the already-migrated `form-section/index.test.tsx`).
- `auth-error-boundary/index.test.tsx` + auth shell `index.test.tsx`: query by role (`alert` / button name).
- `tests/memory-leak/tests/signup.js`: click the mode switcher by its visible label (the existing fallback path); `data-testid` selector dropped.

Remaining `*ByTestId` calls target **`jest.mock` stubs** (not production DOM) — a legitimate exception — and are left for the staged migration (see below).

## CI enforcement (`eslint.config.mjs`, wired into `make lint`)

- **`src/**`** — `no-restricted-syntax` at **`error`** forbidding `data-testid` via three AST forms: `JSXAttribute`, object/destructure `Property`, and the typed `TSPropertySignature` (the issue's "inert-box typed prop"). Stories/tests excluded.
- **Tests** — `no-restricted-syntax` at **`warn`** on `CallExpression[...ByTestId]` to allow staged migration (mock-stub queries stay valid); promote to `error` once the suite is clean.
- Satisfied by **refactoring, not `eslint-disable`**.

## Docs

- `CLAUDE.md`: selector convention added to Testing Philosophy.
- `agents.md`: Page Object example updated to `getByLabel` / `getByRole`.

## Verification

- `src/` has zero `data-testid`; ESLint over `src/` is clean (0 errors); the gate was proven to fire on all three selector forms.
- `tsc --noEmit`: 0 errors.
- Full client unit suite: **1298 passed / 1298**.
- Prettier + markdownlint clean.

> e2e / memory-leak suites require Docker + Mockoon and were not run locally; the memory-leak change only swaps the switcher selector to the pre-existing label-based path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all `data-testid` from production source and tightened ESLint to enforce semantic selectors across TS/JS files. Aligns with #90; tests now query by role/label/text, falling back to a stable `id` only when no semantic query fits.

- **Refactors**
  - Source: dropped all `data-testid`; `InertBox` no longer accepts/passes it; kept roles/labels and `id="auth-provider-buttons-container"`.
  - Tests: migrated to `getByRole`/`getByLabelText`/`getByText`; memory-leak signup clicks the switcher by visible label; container queried by `id`; extracted `getAuthProviderContainer` helper.
  - ESLint: `error` in `src/**/*.{ts,tsx,js,jsx}` for `data-testid` (JSXAttribute, object Property, TSPropertySignature); `warn` in tests for `*ByTestId`, including destructured/identifier callees; stories/tests excluded.
  - Docs: added selector convention in `CLAUDE.md`; updated Page Object example in `agents.md`.

<sup>Written for commit e6d2875b6142528f8263146b735cbcaa9b1ec437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

