### PR TITLE
test(#101): adopt Faker builders for test data across all test types

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -145,7 +145,7 @@ module.exports = {
         "or there's something in the test folder that isn't a test.",
       severity: 'error',
       from: {
-        pathNot: '^(tests)',
+        pathNot: '^(tests)|^jest\\.setup\\.ts$',
       },
       to: {
         path: '^(tests)',
@@ -431,12 +431,12 @@ module.exports = {
     {
       name: 'tests-top-level-allowed-folders',
       comment:
-        'Tests root may only contain allowed folders: apollo-server, e2e, ' +
-        'integration, load, memory-leak, unit, visual.',
+        'Tests root may only contain allowed folders: apollo-server, builders, ' +
+        'e2e, integration, load, memory-leak, unit, utils, visual.',
       severity: 'error',
       from: {
         path:
-          '^tests/(?!(?:apollo-server|e2e|integration|' +
+          '^tests/(?!(?:apollo-server|builders|e2e|integration|' +
           'load|memory-leak|unit|utils|visual)/)[^/]+/',
       },
       to: {},

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,6 +587,19 @@ Key variables in `.env`:
    `auth/repositories/`, and the API error classes to `lib/api-errors/` (pattern 1).
    Satisfy the gate by moving code, never with disable directives.
 
+8. **Test data — Faker builders (issue #101)**: Tests generate arbitrary user/auth domain
+   data (emails, names, passwords, ids, tokens) with `@faker-js/faker` via shared builders in
+   `tests/builders/` (`buildUser`, `buildCredentials`, `buildEmail`, `buildLoginResponse`,
+   `buildCreateUserInput`, `buildGraphqlUser`, …), imported through the `@tests/*` alias.
+   Builders return domain-valid data by construction and take an `overrides` object. Faker is
+   seeded deterministically (`seedFaker()` in each runner's setup; default `DEFAULT_FAKER_SEED`,
+   override with `FAKER_SEED=<integer>`; the seed is reported once per worker) so the suite is
+   reproducible and visual snapshots stay stable. Bind a generated value to a `const` once and
+   reuse it across input and assertion. Keep hardcoded literals only when the value IS the test
+   case or a fixed contract (invalid/edge-case inputs, golden text, config, URLs, error
+   codes/messages, i18n strings, mock sentinels). See the "Test Data — Faker builders" section
+   in `agents.md` for the full convention and review guideline.
+
 ## Node Version Management
 
 Check Node version compatibility:

--- a/agents.md
+++ b/agents.md
@@ -213,6 +213,76 @@ same Docker-backed environment and avoid host-specific drift.
    `docker compose exec -T dev env TEST_ENV=client node ./node_modules/jest/bin/jest.js -u`
    (use cautiously)
 
+## Test Data — Faker builders (issue #101)
+
+Tests generate domain data with [`@faker-js/faker`](https://fakerjs.dev/) through shared
+builders instead of hardcoding magic literals. Generated, intention-revealing data exposes
+hidden assumptions and stops tests from coupling to a specific string.
+
+### Builders
+
+Import factories from the `@tests/builders` alias (resolves in Jest and Playwright). Every
+builder returns domain-VALID data by construction (passing the app's email, password, and
+name validators) and accepts an `overrides` object to pin specific fields:
+
+- `buildUser(overrides?)` → `{ fullName, email, password }` (`RegisterUserDto`).
+- `buildCredentials(overrides?)` → `{ email, password }` (`LoginUserDto`).
+- `buildEmail()` / `buildFullName()` / `buildPassword()` → a single valid field.
+- `buildToken()` / `buildUserId()` / `buildClientMutationId()` → opaque token / uuid.
+- `buildLoginResponse(overrides?)` → `{ token }`.
+- `buildRegistrationResponse(overrides?)` → `{ fullName, email }`.
+- `buildCreateUserInput(overrides?)` → `{ email, initials, clientMutationId }`.
+- `buildGraphqlUser(overrides?)` → `{ id, confirmed, email, initials }`.
+
+```ts
+import { buildUser, buildEmail } from '@tests/builders';
+
+const user = buildUser(); // fully generated, all fields valid
+const pinned = buildUser({ email: buildEmail() }); // pin a field, generate the rest
+```
+
+Bind a generated value to a `const` once and reuse it across the input and the assertion —
+never call a builder twice expecting the two values to be equal:
+
+```ts
+const email = buildEmail();
+const result = await repo.create({ email });
+expect(result.email).toBe(email);
+```
+
+### Deterministic seeding
+
+`@tests/builders/seed` seeds Faker so runs are reproducible. `seedFaker()` is wired into
+every runner's setup — `jest.setup.ts` (client), `tests/integration/setup.ts`,
+`tests/apollo-server/setup.ts`, and the Playwright e2e/visual shared constants. The seed
+defaults to `DEFAULT_FAKER_SEED` and is reported once per worker
+(`[faker] deterministic seed=...`). Reproduce a specific failing run by exporting the seed:
+
+```bash
+FAKER_SEED=12345 make test-unit-client
+```
+
+Determinism keeps visual snapshots stable. The shared integration mock server
+(`tests/integration/mocks/server.ts`) exposes its generated defaults
+(`defaultLoginResponse`, `defaultGraphqlUser`, `defaultClientMutationId`) so tests assert
+against those exports rather than literals.
+
+### When NOT to use a builder
+
+Keep a hardcoded literal when the value IS the test case or a fixed contract: intentional
+invalid / edge-case inputs (malformed emails like `test@`, boundary passwords), golden text,
+config values, URLs, error codes / messages, i18n keys / strings, mocked return sentinels,
+and placeholders that must equal a rendered string. A generated value must stay in the same
+validity / equivalence class so branch coverage is unchanged.
+
+### Review guideline
+
+New tests SHOULD generate arbitrary user / auth domain data (emails, names, passwords, ids,
+tokens) with `@tests/builders` rather than introducing fresh hardcoded fixtures. This is a
+review-gate convention: "hardcoded fixture vs intentional literal" is a semantic distinction
+that a static rule cannot reliably tell apart (the same reasoning the repo applies to the
+issue #89 class-only gate), so reviewers enforce it rather than ESLint.
+
 ## Code Review Workflow and PR Refactoring
 
 ### Automated Code Review Comment Retrieval

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,7 +34,7 @@ let setupFiles: string[] = [];
 if (isIntegration) {
   setupFiles = ['<rootDir>/tests/integration/setup.ts'];
 } else if (TEST_ENV === 'server') {
-  setupFiles = [];
+  setupFiles = ['<rootDir>/tests/apollo-server/setup.ts'];
 } else {
   setupFiles = ['<rootDir>/jest.setup.ts'];
 }
@@ -72,13 +72,18 @@ const config: Config = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(mts)$': ['ts-jest', { useESM: true }],
-    '^.+\\.js$': 'babel-jest',
+    '^.+\\.(js|mjs)$': [
+      'babel-jest',
+      { presets: [['@babel/preset-env', { targets: { node: 'current' } }]] },
+    ],
   },
+  transformIgnorePatterns: ['/node_modules/(?!@faker-js/)', '\\.pnp\\.[^\\/]+$'],
   setupFilesAfterEnv: setupFiles,
   modulePathIgnorePatterns: ['<rootDir>/.stryker-tmp/'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'mts', 'json', 'node'],
   moduleNameMapper: {
     '^@auth/(.*)$': '<rootDir>/src/modules/user/features/auth/$1',
+    '^@tests/(.*)$': '<rootDir>/tests/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^(\\.{1,2}/.+)\\.js$': '$1',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,10 @@
 import 'reflect-metadata';
 import '@testing-library/jest-dom';
 
+import { seedFaker } from './tests/builders/seed';
+
+seedFaker();
+
 // jsdom does not provide a global fetch. Apollo Client's HttpLink requires one to
 // exist at construction time; individual tests that exercise network code stub it.
 if (!globalThis.fetch) {

--- a/tests/apollo-server/resolvers.test.ts
+++ b/tests/apollo-server/resolvers.test.ts
@@ -1,5 +1,7 @@
 import { GraphQLError } from 'graphql';
 
+import { buildCreateUserInput, buildFullName } from '@tests/builders';
+
 import { resolvers, clearUsers, __test__ } from '../../docker/apollo-server/lib/resolvers';
 import { CreateUserInput } from '../../docker/apollo-server/lib/types';
 
@@ -15,11 +17,7 @@ describe('resolvers Mutation createUser', () => {
 
   describe('successful user creation', () => {
     it('should create a user with valid input', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
 
@@ -27,41 +25,28 @@ describe('resolvers Mutation createUser', () => {
         user: {
           id: 'mocked-uuid-1234',
           confirmed: true,
-          email: 'test@example.com',
-          initials: 'John Doe',
+          email: input.email,
+          initials: input.initials,
         },
-        clientMutationId: 'mutation-123',
+        clientMutationId: input.clientMutationId,
       });
     });
 
     it('should create multiple users with different emails', async () => {
-      const input1: CreateUserInput = {
-        email: 'user1@example.com',
-        initials: 'User One',
-        clientMutationId: 'mutation-1',
-      };
-
-      const input2: CreateUserInput = {
-        email: 'user2@example.com',
-        initials: 'User Two',
-        clientMutationId: 'mutation-2',
-      };
+      const input1: CreateUserInput = buildCreateUserInput();
+      const input2: CreateUserInput = buildCreateUserInput();
 
       const result1 = await resolvers.Mutation.createUser(undefined, { input: input1 });
       const result2 = await resolvers.Mutation.createUser(undefined, { input: input2 });
 
-      expect(result1.user.email).toBe('user1@example.com');
-      expect(result2.user.email).toBe('user2@example.com');
+      expect(result1.user.email).toBe(input1.email);
+      expect(result2.user.email).toBe(input2.email);
     });
   });
 
   describe('email validation', () => {
     it('should throw error for missing email', async () => {
-      const input = {
-        email: '',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      } as CreateUserInput;
+      const input: CreateUserInput = buildCreateUserInput({ email: '' });
 
       const promise = resolvers.Mutation.createUser(undefined, { input });
       await expect(promise).rejects.toThrow(GraphQLError);
@@ -75,11 +60,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should throw error for invalid email format - missing @', async () => {
-      const input: CreateUserInput = {
-        email: 'invalidemail.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'invalidemail.com' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toThrow(
         GraphQLError
@@ -87,11 +68,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should throw error for invalid email format - missing domain', async () => {
-      const input: CreateUserInput = {
-        email: 'test@',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'test@' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toThrow(
         GraphQLError
@@ -99,11 +76,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should throw error for invalid email format - invalid characters', async () => {
-      const input: CreateUserInput = {
-        email: 'test @example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'test @example.com' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toThrow(
         GraphQLError
@@ -111,11 +84,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should accept valid email with special characters', async () => {
-      const input: CreateUserInput = {
-        email: 'test.user+tag@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'test.user+tag@example.com' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.email).toBe('test.user+tag@example.com');
@@ -124,11 +93,7 @@ describe('resolvers Mutation createUser', () => {
 
   describe('initials validation', () => {
     it('should throw error for missing initials', async () => {
-      const input = {
-        email: 'test@example.com',
-        initials: '',
-        clientMutationId: 'mutation-123',
-      } as CreateUserInput;
+      const input: CreateUserInput = buildCreateUserInput({ initials: '' });
 
       const promise = resolvers.Mutation.createUser(undefined, { input });
       await expect(promise).rejects.toThrow(GraphQLError);
@@ -142,11 +107,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should throw error for initials shorter than 2 characters', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'A',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: 'A' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toThrow(
         GraphQLError
@@ -154,41 +115,30 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should accept initials with exactly 2 characters', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'AB',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: 'AB' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.initials).toBe('AB');
     });
 
     it('should accept initials longer than 2 characters', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe Smith',
-        clientMutationId: 'mutation-123',
-      };
+      const initials = buildFullName();
+      const input: CreateUserInput = buildCreateUserInput({ initials });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
-      expect(result.user.initials).toBe('John Doe Smith');
+      expect(result.user.initials).toBe(initials);
     });
   });
 
   describe('duplicate email handling', () => {
     it('should throw error when creating user with duplicate email', async () => {
-      const input: CreateUserInput = {
-        email: 'duplicate@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-1',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       // First creation should succeed
       await resolvers.Mutation.createUser(undefined, { input });
 
       // Second creation with same email should fail
-      const input2 = { ...input, clientMutationId: 'mutation-2' };
+      const input2 = { ...input, clientMutationId: buildCreateUserInput().clientMutationId };
       const promise = resolvers.Mutation.createUser(undefined, { input: input2 });
       await expect(promise).rejects.toThrow(GraphQLError);
       await expect(promise).rejects.toMatchObject({
@@ -234,46 +184,30 @@ describe('resolvers Mutation createUser', () => {
 
   describe('user properties', () => {
     it('should set confirmed to true by default', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.confirmed).toBe(true);
     });
 
     it('should generate a unique ID for the user', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.id).toBe('mocked-uuid-1234');
     });
 
     it('should return clientMutationId in response', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'custom-mutation-id',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
-      expect(result.clientMutationId).toBe('custom-mutation-id');
+      expect(result.clientMutationId).toBe(input.clientMutationId);
     });
   });
 
   describe('validation order', () => {
     it('should validate email before checking duplicates', async () => {
-      const input: CreateUserInput = {
-        email: 'invalid-email',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'invalid-email' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toMatchObject({
         message: 'Invalid email format',
@@ -281,11 +215,7 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should validate initials before checking duplicates', async () => {
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'A',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: 'A' });
 
       await expect(resolvers.Mutation.createUser(undefined, { input })).rejects.toMatchObject({
         message: 'Invalid initials',
@@ -303,11 +233,7 @@ describe('resolvers Mutation createUser', () => {
         throw new Error('UUID generation failed');
       });
 
-      const input: CreateUserInput = {
-        email: 'test@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput();
 
       const promise = resolvers.Mutation.createUser(undefined, { input });
       await expect(promise).rejects.toThrow(GraphQLError);
@@ -330,11 +256,7 @@ describe('resolvers Mutation createUser', () => {
 
   describe('edge cases', () => {
     it('should reject email with only spaces', async () => {
-      const input: CreateUserInput = {
-        email: '   ',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: '   ' });
 
       const promise = resolvers.Mutation.createUser(undefined, { input });
       await expect(promise).rejects.toThrow(GraphQLError);
@@ -344,44 +266,28 @@ describe('resolvers Mutation createUser', () => {
     });
 
     it('should accept email with subdomain', async () => {
-      const input: CreateUserInput = {
-        email: 'user@mail.example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'user@mail.example.com' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.email).toBe('user@mail.example.com');
     });
 
     it('should accept email with numbers', async () => {
-      const input: CreateUserInput = {
-        email: 'user123@example456.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'user123@example456.com' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.email).toBe('user123@example456.com');
     });
 
     it('should accept email with consecutive dots (current regex allows this)', async () => {
-      const input: CreateUserInput = {
-        email: 'user..name@example.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'user..name@example.com' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.email).toBe('user..name@example.com');
     });
 
     it('should accept initials with only spaces if length >= 2 (current validation)', async () => {
-      const input: CreateUserInput = {
-        email: 'test-spaces@example.com',
-        initials: '   ',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: '   ' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.initials).toBe('   ');
@@ -389,44 +295,28 @@ describe('resolvers Mutation createUser', () => {
 
     it('should handle very long initials', async () => {
       const longInitials = 'A'.repeat(200);
-      const input: CreateUserInput = {
-        email: 'test-long@example.com',
-        initials: longInitials,
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: longInitials });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.initials).toBe(longInitials);
     });
 
     it('should handle unicode characters in initials', async () => {
-      const input: CreateUserInput = {
-        email: 'unicode@example.com',
-        initials: 'Иван Петров',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: 'Иван Петров' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.initials).toBe('Иван Петров');
     });
 
     it('should handle special characters in initials', async () => {
-      const input: CreateUserInput = {
-        email: 'special@example.com',
-        initials: "O'Brien-Smith",
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ initials: "O'Brien-Smith" });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.initials).toBe("O'Brien-Smith");
     });
 
     it('should handle email with hyphen in domain', async () => {
-      const input: CreateUserInput = {
-        email: 'user@ex-ample.com',
-        initials: 'John Doe',
-        clientMutationId: 'mutation-123',
-      };
+      const input: CreateUserInput = buildCreateUserInput({ email: 'user@ex-ample.com' });
 
       const result = await resolvers.Mutation.createUser(undefined, { input });
       expect(result.user.email).toBe('user@ex-ample.com');
@@ -435,11 +325,7 @@ describe('resolvers Mutation createUser', () => {
 
   describe('concurrent operations', () => {
     it('should handle multiple users being created concurrently', async () => {
-      const inputs = Array.from({ length: 5 }, (_, i) => ({
-        email: `user${i}@example.com`,
-        initials: `User ${i}`,
-        clientMutationId: `mutation-${i}`,
-      }));
+      const inputs = Array.from({ length: 5 }, () => buildCreateUserInput());
 
       const results = await Promise.all(
         inputs.map((input) => resolvers.Mutation.createUser(undefined, { input }))
@@ -447,8 +333,8 @@ describe('resolvers Mutation createUser', () => {
 
       expect(results).toHaveLength(5);
       results.forEach((result, i) => {
-        expect(result.user.email).toBe(`user${i}@example.com`);
-        expect(result.user.initials).toBe(`User ${i}`);
+        expect(result.user.email).toBe(inputs[i].email);
+        expect(result.user.initials).toBe(inputs[i].initials);
       });
     });
   });

--- a/tests/apollo-server/setup.ts
+++ b/tests/apollo-server/setup.ts
@@ -1,0 +1,3 @@
+import { seedFaker } from '@tests/builders/seed';
+
+seedFaker();

--- a/tests/builders/auth.ts
+++ b/tests/builders/auth.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker';
+
+import type {
+  LoginResponse,
+  RegistrationResponse,
+} from '@/modules/user/features/auth/types/api-responses';
+
+import { buildEmail, buildFullName } from './user';
+
+export function buildToken(): string {
+  return faker.internet.jwt();
+}
+
+export function buildUserId(): string {
+  return faker.string.uuid();
+}
+
+export function buildClientMutationId(): string {
+  return faker.string.uuid();
+}
+
+export function buildLoginResponse(overrides: Partial<LoginResponse> = {}): LoginResponse {
+  return {
+    token: buildToken(),
+    ...overrides,
+  };
+}
+
+export function buildRegistrationResponse(
+  overrides: Partial<RegistrationResponse> = {}
+): RegistrationResponse {
+  return {
+    fullName: buildFullName(),
+    email: buildEmail(),
+    ...overrides,
+  };
+}

--- a/tests/builders/credentials.ts
+++ b/tests/builders/credentials.ts
@@ -1,0 +1,11 @@
+import type { LoginUserDto } from '@/modules/user/features/auth/types/credentials';
+
+import { buildEmail, buildPassword } from './user';
+
+export function buildCredentials(overrides: Partial<LoginUserDto> = {}): LoginUserDto {
+  return {
+    email: buildEmail(),
+    password: buildPassword(),
+    ...overrides,
+  };
+}

--- a/tests/builders/graphql.ts
+++ b/tests/builders/graphql.ts
@@ -1,0 +1,36 @@
+import { buildClientMutationId, buildUserId } from './auth';
+import { buildEmail, buildFullName } from './user';
+
+export interface CreateUserInputData {
+  email: string;
+  initials: string;
+  clientMutationId: string;
+}
+
+export interface GraphqlUserData {
+  id: string;
+  confirmed: boolean;
+  email: string;
+  initials: string;
+}
+
+export function buildCreateUserInput(
+  overrides: Partial<CreateUserInputData> = {}
+): CreateUserInputData {
+  return {
+    email: buildEmail(),
+    initials: buildFullName(),
+    clientMutationId: buildClientMutationId(),
+    ...overrides,
+  };
+}
+
+export function buildGraphqlUser(overrides: Partial<GraphqlUserData> = {}): GraphqlUserData {
+  return {
+    id: buildUserId(),
+    confirmed: true,
+    email: buildEmail(),
+    initials: buildFullName(),
+    ...overrides,
+  };
+}

--- a/tests/builders/index.ts
+++ b/tests/builders/index.ts
@@ -1,0 +1,5 @@
+export * from './seed';
+export * from './user';
+export * from './credentials';
+export * from './auth';
+export * from './graphql';

--- a/tests/builders/seed.ts
+++ b/tests/builders/seed.ts
@@ -1,0 +1,18 @@
+import { faker } from '@faker-js/faker';
+
+export const DEFAULT_FAKER_SEED = 20260624;
+
+export function resolveFakerSeed(): number {
+  const raw = process.env.FAKER_SEED;
+  const parsed = raw === undefined || raw.trim() === '' ? Number.NaN : Number(raw);
+  return Number.isInteger(parsed) ? parsed : DEFAULT_FAKER_SEED;
+}
+
+export function seedFaker(seed: number = resolveFakerSeed()): number {
+  faker.seed(seed);
+  if (!process.env.FAKER_SEED_REPORTED) {
+    process.env.FAKER_SEED_REPORTED = '1';
+    console.warn(`[faker] deterministic seed=${seed} (override with FAKER_SEED=<integer>)`);
+  }
+  return seed;
+}

--- a/tests/builders/user.ts
+++ b/tests/builders/user.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker';
+
+import type { RegisterUserDto } from '@/modules/user/features/auth/types/credentials';
+
+const NAME_PART = /[A-Za-z]{3,10}/;
+
+export function buildNamePart(): string {
+  return faker.helpers.fromRegExp(NAME_PART);
+}
+
+export function buildFullName(): string {
+  return `${buildNamePart()} ${buildNamePart()}`;
+}
+
+export function buildEmail(): string {
+  return faker.internet.email({ allowSpecialCharacters: false }).toLowerCase();
+}
+
+export function buildPassword(): string {
+  const upper = faker.string.alpha({ length: 1, casing: 'upper' });
+  const lower = faker.string.alpha({ length: 1, casing: 'lower' });
+  const digit = faker.string.numeric({ length: 1 });
+  const rest = faker.string.alphanumeric({ length: 13 });
+  return faker.helpers.shuffle(`${upper}${lower}${digit}${rest}`.split('')).join('');
+}
+
+export function buildUser(overrides: Partial<RegisterUserDto> = {}): RegisterUserDto {
+  return {
+    fullName: buildFullName(),
+    email: buildEmail(),
+    password: buildPassword(),
+    ...overrides,
+  };
+}

--- a/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/constants/constants.ts
+++ b/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/constants/constants.ts
@@ -1,7 +1,11 @@
 import { faker } from '@faker-js/faker';
 
+import { buildUser, seedFaker } from '@tests/builders';
+
 import { t } from '../../../../../../../../utils/initialize-localization';
 import { ExpectationEmail, ExpectationsPassword, User } from '../types';
+
+seedFaker();
 
 export const REGISTRATION_URL = '/authentication';
 export const REGISTRATION_API_URL = '**/graphql'; // Apollo GraphQL createUser endpoint
@@ -15,15 +19,7 @@ export const requiredNameError: string = t('sign_up.form.name_input.required');
 export const successNotificationTitle: string = t('notifications.success.title');
 
 export function generateUserData(): User {
-  const firstName: string = faker.helpers.fromRegExp(/[A-Za-zА-Яа-яІіЇїЄєҐґ]{3,10}/);
-  const lastName: string = faker.helpers.fromRegExp(/[A-Za-zА-Яа-яІіЇїЄєҐґ]{3,10}/);
-  const domain = faker.internet.domainName();
-  const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@${domain}`;
-  return {
-    fullName: `${firstName} ${lastName}`,
-    email,
-    password: faker.internet.password({ length: 16, prefix: 'Q9' }),
-  };
+  return buildUser();
 }
 
 export const userData: User = generateUserData();

--- a/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/login-form.spec.ts
+++ b/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/login-form.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, type Page, type Route } from '@playwright/test';
 
+import { buildCredentials } from '@tests/builders';
+
 import fillInput from '../../../../../../../utils/fill-input';
 import { t } from '../../../../../../../utils/initialize-localization';
 
@@ -11,7 +13,7 @@ const emailPlaceholder: string = t('sign_in.form.email_input.placeholder');
 const passwordPlaceholder: string = t('sign_in.form.password_input.placeholder');
 const submitLabel: string = t('sign_in.form.submit_button');
 
-const validCredentials = { email: 'user@example.com', password: 'Q9validPassword1' };
+const validCredentials = buildCredentials();
 
 async function gotoLogin(page: Page): Promise<void> {
   await page.goto(AUTH_URL);

--- a/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/utils/responses.ts
+++ b/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/utils/responses.ts
@@ -5,6 +5,10 @@ import { buildClientMutationId, buildGraphqlUser } from '@tests/builders';
 import { userData } from '../constants/constants';
 
 export async function successResponse(route: Route): Promise<void> {
+  const requestBody = route.request().postDataJSON() as {
+    variables?: { input?: { clientMutationId?: string } };
+  } | null;
+  const sentMutationId = requestBody?.variables?.input?.clientMutationId;
   await route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -16,7 +20,7 @@ export async function successResponse(route: Route): Promise<void> {
             initials: userData.fullName,
             confirmed: true,
           }),
-          clientMutationId: buildClientMutationId(),
+          clientMutationId: sentMutationId ?? buildClientMutationId(),
         },
       },
     }),

--- a/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/utils/responses.ts
+++ b/tests/e2e/modules/user/features/auth/components/form-section/auth-forms/utils/responses.ts
@@ -1,5 +1,7 @@
 import { Route } from '@playwright/test';
 
+import { buildClientMutationId, buildGraphqlUser } from '@tests/builders';
+
 import { userData } from '../constants/constants';
 
 export async function successResponse(route: Route): Promise<void> {
@@ -9,13 +11,12 @@ export async function successResponse(route: Route): Promise<void> {
     body: JSON.stringify({
       data: {
         createUser: {
-          user: {
+          user: buildGraphqlUser({
             email: userData.email,
             initials: userData.fullName,
-            id: '12345',
             confirmed: true,
-          },
-          clientMutationId: '186',
+          }),
+          clientMutationId: buildClientMutationId(),
         },
       },
     }),

--- a/tests/integration/mocks/server.ts
+++ b/tests/integration/mocks/server.ts
@@ -3,17 +3,17 @@ import { setupServer } from 'msw/node';
 
 import API_ENDPOINTS from '@/config/api-config';
 import GraphQLUrl from '@/utils/get-graphql-url';
+import { buildClientMutationId, buildGraphqlUser, buildLoginResponse } from '@tests/builders';
 
 export const GRAPHQL_URL = new GraphQLUrl().resolve();
 
+export const defaultLoginResponse = buildLoginResponse();
+export const defaultGraphqlUser = buildGraphqlUser();
+export const defaultClientMutationId = buildClientMutationId();
+
 const handlers = [
   rest.post(API_ENDPOINTS.LOGIN, (_req, res, ctx) =>
-    res(
-      ctx.status(200),
-      ctx.json({
-        token: 'default-token-123',
-      })
-    )
+    res(ctx.status(200), ctx.json(defaultLoginResponse))
   ),
   rest.post(GRAPHQL_URL, (_req, res, ctx) =>
     res(
@@ -21,13 +21,8 @@ const handlers = [
       ctx.json({
         data: {
           createUser: {
-            user: {
-              id: 'default-user-id',
-              confirmed: true,
-              email: 'test@example.com',
-              initials: 'Test User',
-            },
-            clientMutationId: 'default-client-mutation-id',
+            user: defaultGraphqlUser,
+            clientMutationId: defaultClientMutationId,
           },
         },
       })

--- a/tests/integration/modules/user/features/auth/login-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/login-api.integration.test.ts
@@ -6,6 +6,7 @@ import container from '@/config/dependency-injection-config';
 import TOKENS from '@/config/tokens';
 import LoginAPI from '@/modules/user/features/auth/repositories/login-api';
 import { AuthenticationError } from '@/modules/user/lib/api-errors';
+import { buildCredentials, buildLoginResponse } from '@tests/builders';
 
 import server from '../../../../mocks/server';
 
@@ -23,9 +24,7 @@ describe('LoginAPI Integration', () => {
 
   describe('successful login', () => {
     it('should successfully login with valid credentials', async () => {
-      const mockResponse = {
-        token: 'abc123-token',
-      };
+      const mockResponse = buildLoginResponse();
 
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
@@ -33,33 +32,25 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      const result = await loginAPI.login({
-        email: 'test@example.com',
-        password: 'password123',
-      });
+      const result = await loginAPI.login(buildCredentials());
 
       expect(result).toEqual(mockResponse);
     });
 
     it('should send correct request body', async () => {
       let requestBody: Record<string, string> | null = null;
+      const credentials = buildCredentials();
 
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, async (req, res, ctx) => {
           requestBody = await req.json();
-          return res(ctx.status(200), ctx.json({ token: 'abc' }));
+          return res(ctx.status(200), ctx.json(buildLoginResponse()));
         })
       );
 
-      await loginAPI.login({
-        email: 'user@test.com',
-        password: 'mypassword',
-      });
+      await loginAPI.login(credentials);
 
-      expect(requestBody).toEqual({
-        email: 'user@test.com',
-        password: 'mypassword',
-      });
+      expect(requestBody).toEqual(credentials);
     });
   });
 
@@ -71,9 +62,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(
-        loginAPI.login({ email: 'wrong@test.com', password: 'wrongpass' })
-      ).rejects.toThrow(AuthenticationError);
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(AuthenticationError);
     });
 
     it('should throw ApiError with correct message for 400 status', async () => {
@@ -83,9 +72,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'invalid', password: '123' })).rejects.toThrow(
-        'Invalid login data'
-      );
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow('Invalid login data');
     });
 
     it('should throw ApiError for 403 status', async () => {
@@ -95,9 +82,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
-        'Forbidden'
-      );
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow('Forbidden');
     });
 
     it('should throw ApiError for 404 status', async () => {
@@ -107,9 +92,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
-        'Login not found'
-      );
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow('Login not found');
     });
 
     it('should map 408 to a timeout ApiError', async () => {
@@ -119,7 +102,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Request timed out. Please try again.'
       );
     });
@@ -131,7 +114,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Too many requests. Please slow down.'
       );
     });
@@ -143,7 +126,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Server error. Please try again later.'
       );
     });
@@ -155,7 +138,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Service unavailable. Please try again later.'
       );
     });
@@ -167,7 +150,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Service unavailable. Please try again later.'
       );
     });
@@ -179,7 +162,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Service unavailable. Please try again later.'
       );
     });
@@ -187,7 +170,7 @@ describe('LoginAPI Integration', () => {
     it('should handle network errors', async () => {
       server.use(rest.post(API_ENDPOINTS.LOGIN, (_, res) => res.networkError('Failed to fetch')));
 
-      await expect(loginAPI.login({ email: 'test@test.com', password: 'pass' })).rejects.toThrow(
+      await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Network error. Please check your connection.'
       );
     });
@@ -201,13 +184,13 @@ describe('LoginAPI Integration', () => {
       controller.abort();
 
       await expect(
-        loginAPI.login({ email: 'test@test.com', password: 'pass' }, { signal: controller.signal })
+        loginAPI.login(buildCredentials(), { signal: controller.signal })
       ).rejects.toThrow();
     });
 
     it('should not throw if request completes before cancellation', async () => {
       const controller = new AbortController();
-      const mockResponse = { token: 'abc' };
+      const mockResponse = buildLoginResponse();
 
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
@@ -215,10 +198,7 @@ describe('LoginAPI Integration', () => {
         )
       );
 
-      const result = await loginAPI.login(
-        { email: 'test@test.com', password: 'pass' },
-        { signal: controller.signal }
-      );
+      const result = await loginAPI.login(buildCredentials(), { signal: controller.signal });
 
       controller.abort();
 

--- a/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
@@ -9,6 +9,7 @@ import { ApiError, ConflictError } from '@/modules/user/lib/api-errors';
 import HttpErrorGuard from '@/services/https-client/http-error-guard';
 import ApiErrorFactory from '@auth/repositories/api-error-factory';
 import ApiStatusErrorFactory from '@auth/repositories/api-status-error-factory';
+import { buildClientMutationId, buildUser, buildUserId } from '@tests/builders';
 
 import server, { GRAPHQL_URL } from '../../../../mocks/server';
 
@@ -16,17 +17,14 @@ type ApolloClientLike = import('@apollo/client').ApolloClient<
   import('@apollo/client').NormalizedCacheObject
 >;
 
-const credentials = {
-  email: 'newuser@example.com',
-  password: 'securepass123',
-  fullName: 'New User',
-};
+const credentials = buildUser();
+const { email, fullName, password } = credentials;
 
 const createUserSuccessBody = {
   data: {
     createUser: {
-      user: { id: 'user-123', confirmed: true, email: 'newuser@example.com', initials: 'New User' },
-      clientMutationId: 'client-mutation-id',
+      user: { id: buildUserId(), confirmed: true, email, initials: fullName },
+      clientMutationId: buildClientMutationId(),
     },
   },
 };
@@ -56,11 +54,11 @@ describe('RegistrationAPI Integration', () => {
 
       const result = await registrationAPI.register(credentials);
 
-      expect(result).toEqual({ email: 'newuser@example.com', fullName: 'New User' });
+      expect(result).toEqual({ email, fullName });
       expect(capturedInput).toEqual({
-        email: 'newuser@example.com',
-        initials: 'New User',
-        password: 'securepass123',
+        email,
+        initials: fullName,
+        password,
         clientMutationId: expect.any(String),
       });
     });
@@ -76,9 +74,9 @@ describe('RegistrationAPI Integration', () => {
         })
       );
 
-      await registrationAPI.register({ ...credentials, fullName: '  New User  ' });
+      await registrationAPI.register({ ...credentials, fullName: `  ${fullName}  ` });
 
-      expect(capturedInput?.initials).toBe('New User');
+      expect(capturedInput?.initials).toBe(fullName);
     });
   });
 

--- a/tests/integration/modules/user/features/auth/stores/auth-store-composition.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/auth-store-composition.integration.test.ts
@@ -3,8 +3,9 @@ import '../../../../../setup';
 import { renderHook } from '@testing-library/react';
 
 import { AuthStateVar, authActions, useAuthState, useAuthToken } from '@auth/stores';
+import { buildCredentials, buildUser } from '@tests/builders';
 
-import server from '../../../../../mocks/server';
+import server, { defaultLoginResponse } from '../../../../../mocks/server';
 
 describe('auth stores composition root integration', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -15,10 +16,10 @@ describe('auth stores composition root integration', () => {
   afterAll(() => server.close());
 
   it('drives login and registration through the real repository and clears state', async () => {
-    await authActions.loginUser({ email: 'a@b.c', password: 'password' });
-    expect(AuthStateVar.get().token).toBe('default-token-123');
+    await authActions.loginUser(buildCredentials());
+    expect(AuthStateVar.get().token).toBe(defaultLoginResponse.token);
 
-    await authActions.registerUser({ fullName: 'A B', email: 'a@b.c', password: 'password' });
+    await authActions.registerUser(buildUser());
     expect(AuthStateVar.get().registerError).toBeNull();
 
     authActions.resetRegistration();

--- a/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
@@ -7,20 +7,25 @@ import TOKENS from '@/config/tokens';
 import type LoginAPI from '@auth/repositories/login-api';
 import type RegistrationAPI from '@auth/repositories/registration-api';
 import { AuthStateVar, AuthStoreSelectors, authActions } from '@auth/stores';
+import {
+  buildClientMutationId,
+  buildCredentials,
+  buildGraphqlUser,
+  buildLoginResponse,
+  buildRegistrationResponse,
+  buildToken,
+  buildUser,
+} from '@tests/builders';
 
 import server, { GRAPHQL_URL } from '../../../../../mocks/server';
 
-const registrationCredentials = {
-  email: 'test@example.com',
-  password: 'password123',
-  fullName: 'Test User',
-};
+const registrationCredentials = buildUser();
 
 const createUserSuccessBody = {
   data: {
     createUser: {
-      user: { id: 'u1', confirmed: true, email: 'test@example.com', initials: 'Test User' },
-      clientMutationId: 'c1',
+      user: buildGraphqlUser(),
+      clientMutationId: buildClientMutationId(),
     },
   },
 };
@@ -59,11 +64,11 @@ describe('Auth Store Integration', () => {
     it('should update state to pending when login starts', async () => {
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.delay(50), ctx.status(200), ctx.json({ token: 'token123' }))
+          res(ctx.delay(50), ctx.status(200), ctx.json(buildLoginResponse()))
         )
       );
 
-      const promise = authActions.loginUser({ email: 'user@test.com', password: 'pass' });
+      const promise = authActions.loginUser(buildCredentials());
       expect(AuthStateVar.get().loginLoading).toBe(true);
 
       await promise;
@@ -71,26 +76,26 @@ describe('Auth Store Integration', () => {
     });
 
     it('should update state on successful login', async () => {
+      const credentials = buildCredentials();
+      const { token } = buildLoginResponse();
       server.use(
-        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'token123' }))
-        )
+        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) => res(ctx.status(200), ctx.json({ token })))
       );
 
-      await authActions.loginUser({ email: 'user@example.com', password: 'pass123' });
+      await authActions.loginUser(credentials);
 
       const state = AuthStateVar.get();
 
       expect(state.loginLoading).toBe(false);
-      expect(state.email).toBe('user@example.com');
-      expect(state.token).toBe('token123');
+      expect(state.email).toBe(credentials.email);
+      expect(state.token).toBe(token);
       expect(state.loginError).toBeNull();
     });
 
     it('should normalize email to lowercase', async () => {
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'token-abc' }))
+          res(ctx.status(200), ctx.json(buildLoginResponse()))
         )
       );
 
@@ -101,26 +106,30 @@ describe('Auth Store Integration', () => {
     });
 
     it('should handle multiple successful logins', async () => {
+      const firstCredentials = buildCredentials();
+      const firstToken = buildToken();
+      const secondCredentials = buildCredentials();
+      const secondToken = buildToken();
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'first-token' }))
+          res(ctx.status(200), ctx.json({ token: firstToken }))
         )
       );
 
-      await authActions.loginUser({ email: 'first@test.com', password: 'pass' });
-      expect(AuthStateVar.get().token).toBe('first-token');
+      await authActions.loginUser(firstCredentials);
+      expect(AuthStateVar.get().token).toBe(firstToken);
 
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'second-token' }))
+          res(ctx.status(200), ctx.json({ token: secondToken }))
         )
       );
 
-      await authActions.loginUser({ email: 'second@test.com', password: 'pass' });
+      await authActions.loginUser(secondCredentials);
 
       const state = AuthStateVar.get();
-      expect(state.token).toBe('second-token');
-      expect(state.email).toBe('second@test.com');
+      expect(state.token).toBe(secondToken);
+      expect(state.email).toBe(secondCredentials.email);
     });
   });
 
@@ -132,7 +141,7 @@ describe('Auth Store Integration', () => {
         )
       );
 
-      await authActions.loginUser({ email: 'bad@test.com', password: 'badpass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -143,7 +152,7 @@ describe('Auth Store Integration', () => {
     it('should set error state on network failure', async () => {
       server.use(rest.post(API_ENDPOINTS.LOGIN, (_, res) => res.networkError('Failed to fetch')));
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -172,20 +181,21 @@ describe('Auth Store Integration', () => {
         )
       );
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
       expect(AuthStateVar.get().loginError).toBeTruthy();
 
+      const newToken = buildToken();
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'new-token' }))
+          res(ctx.status(200), ctx.json({ token: newToken }))
         )
       );
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'correctpass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginError).toBeNull();
-      expect(state.token).toBe('new-token');
+      expect(state.token).toBe(newToken);
     });
 
     it('should handle 500 server error', async () => {
@@ -195,7 +205,7 @@ describe('Auth Store Integration', () => {
         )
       );
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -213,7 +223,7 @@ describe('Auth Store Integration', () => {
           )
         );
 
-        await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+        await authActions.loginUser(buildCredentials());
 
         const state = AuthStateVar.get();
         expect(state.loginLoading).toBe(false);
@@ -224,15 +234,15 @@ describe('Auth Store Integration', () => {
 
   describe('logout action', () => {
     it('should clear all auth state on logout', async () => {
+      const credentials = buildCredentials();
+      const { token } = buildLoginResponse();
       server.use(
-        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'token123' }))
-        )
+        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) => res(ctx.status(200), ctx.json({ token })))
       );
 
-      await authActions.loginUser({ email: 'user@test.com', password: 'pass' });
-      expect(AuthStateVar.get().token).toBe('token123');
-      expect(AuthStateVar.get().email).toBe('user@test.com');
+      await authActions.loginUser(credentials);
+      expect(AuthStateVar.get().token).toBe(token);
+      expect(AuthStateVar.get().email).toBe(credentials.email);
 
       authActions.logout();
 
@@ -251,15 +261,12 @@ describe('Auth Store Integration', () => {
       server.use(
         rest.post(API_ENDPOINTS.LOGIN, async (_, res, ctx) => {
           await createDelayedPromise(100);
-          return res(ctx.status(200), ctx.json({ token: 'token' }));
+          return res(ctx.status(200), ctx.json(buildLoginResponse()));
         })
       );
 
       const abortController = new AbortController();
-      const promise = authActions.loginUser(
-        { email: 'test@test.com', password: 'pass' },
-        abortController.signal
-      );
+      const promise = authActions.loginUser(buildCredentials(), abortController.signal);
 
       abortController.abort();
       await promise;
@@ -278,7 +285,7 @@ describe('Auth Store Integration', () => {
         )
       );
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -413,10 +420,7 @@ describe('Auth Store Integration', () => {
       const abortController = new AbortController();
       abortController.abort();
 
-      await authActions.loginUser(
-        { email: 'test@test.com', password: 'pass' },
-        abortController.signal
-      );
+      await authActions.loginUser(buildCredentials(), abortController.signal);
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -429,7 +433,7 @@ describe('Auth Store Integration', () => {
         .spyOn(loginAPI, 'login')
         .mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'));
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -442,7 +446,7 @@ describe('Auth Store Integration', () => {
       abortError.name = 'AbortError';
       jest.spyOn(loginAPI, 'login').mockRejectedValue(abortError);
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -453,7 +457,7 @@ describe('Auth Store Integration', () => {
       const loginAPI = container.resolve<LoginAPI>(TOKENS.LoginAPI);
       jest.spyOn(loginAPI, 'login').mockRejectedValue(new Error('Request was aborted by user'));
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -464,7 +468,7 @@ describe('Auth Store Integration', () => {
       const loginAPI = container.resolve<LoginAPI>(TOKENS.LoginAPI);
       jest.spyOn(loginAPI, 'login').mockRejectedValue(new Error('Network failure'));
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -475,7 +479,7 @@ describe('Auth Store Integration', () => {
       const loginAPI = container.resolve<LoginAPI>(TOKENS.LoginAPI);
       jest.spyOn(loginAPI, 'login').mockRejectedValue('string error');
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -486,7 +490,7 @@ describe('Auth Store Integration', () => {
       const loginAPI = container.resolve<LoginAPI>(TOKENS.LoginAPI);
       jest.spyOn(loginAPI, 'login').mockRejectedValue(null);
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -499,7 +503,7 @@ describe('Auth Store Integration', () => {
       error.message = undefined as unknown as string;
       jest.spyOn(loginAPI, 'login').mockRejectedValue(error);
 
-      await authActions.loginUser({ email: 'test@test.com', password: 'pass' });
+      await authActions.loginUser(buildCredentials());
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -509,17 +513,17 @@ describe('Auth Store Integration', () => {
 
   describe('selectors', () => {
     it('should select state values correctly', async () => {
+      const credentials = buildCredentials();
+      const { token } = buildLoginResponse();
       server.use(
-        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'sel-token' }))
-        )
+        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) => res(ctx.status(200), ctx.json({ token })))
       );
 
-      await authActions.loginUser({ email: 'sel@test.com', password: 'pass' });
+      await authActions.loginUser(credentials);
 
       const state = AuthStateVar.get();
-      expect(AuthStoreSelectors.email(state)).toBe('sel@test.com');
-      expect(AuthStoreSelectors.token(state)).toBe('sel-token');
+      expect(AuthStoreSelectors.email(state)).toBe(credentials.email);
+      expect(AuthStoreSelectors.token(state)).toBe(token);
       expect(AuthStoreSelectors.loginLoading(state)).toBe(false);
       expect(AuthStoreSelectors.loginError(state)).toBeNull();
       expect(AuthStoreSelectors.registerLoading(state)).toBe(false);
@@ -532,7 +536,7 @@ describe('Auth Store Integration', () => {
     });
 
     it('should select registerUser from state', async () => {
-      const user = { fullName: 'Jane Doe', email: 'jane@test.com' };
+      const user = buildRegistrationResponse();
       AuthStateVar.set({ user });
 
       const state = AuthStateVar.get();
@@ -548,17 +552,17 @@ describe('Auth Store Integration', () => {
       const loginAPI = container.resolve<LoginAPI>(TOKENS.LoginAPI);
       expect(loginAPI).toBeDefined();
 
+      const credentials = buildCredentials();
+      const { token } = buildLoginResponse();
       server.use(
-        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ token: 'di-token' }))
-        )
+        rest.post(API_ENDPOINTS.LOGIN, (_, res, ctx) => res(ctx.status(200), ctx.json({ token })))
       );
 
-      await authActions.loginUser({ email: 'di@test.com', password: 'pass' });
+      await authActions.loginUser(credentials);
 
       const state = AuthStateVar.get();
-      expect(state.token).toBe('di-token');
-      expect(state.email).toBe('di@test.com');
+      expect(state.token).toBe(token);
+      expect(state.email).toBe(credentials.email);
     });
 
     it('should use real RegistrationAPI from DI container', async () => {

--- a/tests/integration/modules/user/features/auth/stores/deferred-auth-actions.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/deferred-auth-actions.integration.test.ts
@@ -2,8 +2,9 @@ import '../../../../../setup';
 
 import container from '@/config/dependency-injection-config';
 import { AuthStateVar, authActions } from '@auth/stores';
+import { buildCredentials, buildUser } from '@tests/builders';
 
-import server from '../../../../../mocks/server';
+import server, { defaultLoginResponse } from '../../../../../mocks/server';
 
 describe('deferred auth actions integration', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -14,17 +15,19 @@ describe('deferred auth actions integration', () => {
   afterAll(() => server.close());
 
   it('surfaces a retryable error when the DI graph fails to load, then recovers', async () => {
+    const credentials = buildCredentials();
+    const registration = buildUser();
     const resolveSpy = jest.spyOn(container, 'resolve').mockImplementation(() => {
       throw new Error('chunk load failed');
     });
 
-    await authActions.loginUser({ email: 'a@b.c', password: 'password' });
+    await authActions.loginUser(credentials);
     expect(AuthStateVar.get()).toMatchObject({
       loginLoading: false,
       loginError: { kind: 'network', retryable: true },
     });
 
-    await authActions.registerUser({ fullName: 'A B', email: 'a@b.c', password: 'password' });
+    await authActions.registerUser(registration);
     expect(AuthStateVar.get()).toMatchObject({
       registerLoading: false,
       registerError: { kind: 'network', retryable: true },
@@ -32,7 +35,7 @@ describe('deferred auth actions integration', () => {
 
     resolveSpy.mockRestore();
 
-    await authActions.loginUser({ email: 'a@b.c', password: 'password' });
-    expect(AuthStateVar.get().token).toBe('default-token-123');
+    await authActions.loginUser(credentials);
+    expect(AuthStateVar.get().token).toBe(defaultLoginResponse.token);
   });
 });

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,5 +1,9 @@
 import 'reflect-metadata';
 
+import { seedFaker } from '@tests/builders/seed';
+
+seedFaker();
+
 const mockoonPort = process.env.MOCKOON_PORT || '8080';
 process.env.REACT_APP_MOCKOON_URL = `http://localhost:${mockoonPort}`;
 

--- a/tests/unit/components/ui-form-input-field.controller.test.tsx
+++ b/tests/unit/components/ui-form-input-field.controller.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren, ReactNode } from 'react';
 import type { Control, FieldValues } from 'react-hook-form';
 
 import UIFormInputField from '@/components/ui-form-input-field';
+import { buildEmail } from '@tests/builders';
 
 type ControllerRenderParams = {
   field: {
@@ -129,11 +130,13 @@ describe('UIFormInputField controller branches', () => {
   });
 
   it('forwards defaultValue to Controller when provided', () => {
+    const defaultValue = buildEmail();
+
     render(
       <UIFormInputField
         autoComplete="email"
         control={{} as Control<FieldValues>}
-        defaultValue="seed@example.com"
+        defaultValue={defaultValue}
         name="email"
         placeholder="Email"
         rules={{}}
@@ -145,7 +148,7 @@ describe('UIFormInputField controller branches', () => {
 
     expect(controllerProps).toEqual(
       expect.objectContaining({
-        defaultValue: 'seed@example.com',
+        defaultValue,
         name: 'email',
       })
     );

--- a/tests/unit/modules/user/features/auth/components/form-section/auth-forms/login-form.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section/auth-forms/login-form.test.tsx
@@ -4,9 +4,12 @@ import type { ReactElement } from 'react';
 import LoginForm, {
   LoginErrorMessageNormalizer,
 } from '@auth/components/form-section/auth-forms/login-form';
+import { buildCredentials } from '@tests/builders';
 
 const normalizeLoginErrorMessage = (error: unknown): string =>
   new LoginErrorMessageNormalizer().normalize(error);
+
+const submitCredentials = buildCredentials();
 
 const mockLoginUser = jest.fn();
 const mockFormField = jest.fn();
@@ -16,7 +19,7 @@ function makeSubmitHandler(
   onSubmit: (data: { email: string; password: string }) => Promise<void>
 ): () => void {
   return (): void => {
-    void onSubmit({ email: 'user@example.com', password: 'secret123' });
+    void onSubmit({ ...submitCredentials });
   };
 }
 
@@ -144,13 +147,7 @@ describe('LoginForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'submit' }));
 
     await waitFor(() => {
-      expect(mockLoginUser).toHaveBeenCalledWith(
-        {
-          email: 'user@example.com',
-          password: 'secret123',
-        },
-        expect.any(AbortSignal)
-      );
+      expect(mockLoginUser).toHaveBeenCalledWith(submitCredentials, expect.any(AbortSignal));
     });
   });
 

--- a/tests/unit/modules/user/features/auth/components/form-section/auth-forms/use-login-submitter.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section/auth-forms/use-login-submitter.test.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 
 import useLoginSubmitter from '@auth/components/form-section/auth-forms/use-login-submitter';
 import { AuthStateVar, authActions } from '@auth/stores';
+import { buildCredentials } from '@tests/builders';
 
 const t: TFunction = ((key: string, options?: Record<string, unknown>): string => {
   if (options?.reason !== undefined) return `${key}|${String(options.reason)}`;
@@ -71,17 +72,15 @@ describe('useLoginSubmitter', () => {
 
   it('invokes the loginUser action when handleLogin is called', async () => {
     const loginUser = jest.spyOn(authActions, 'loginUser').mockResolvedValue(undefined);
+    const credentials = buildCredentials();
 
     const { result } = renderHook(() => useLoginSubmitter(t));
 
     await act(async () => {
-      await result.current.handleLogin({ email: 'a@b.com', password: 'pw' });
+      await result.current.handleLogin(credentials);
     });
 
-    expect(loginUser).toHaveBeenCalledWith(
-      { email: 'a@b.com', password: 'pw' },
-      expect.any(AbortSignal)
-    );
+    expect(loginUser).toHaveBeenCalledWith(credentials, expect.any(AbortSignal));
   });
 
   it('does not restore a late login error after unmount', async () => {
@@ -107,7 +106,7 @@ describe('useLoginSubmitter', () => {
     let pendingLogin!: Promise<void>;
 
     await act(async () => {
-      pendingLogin = result.current.handleLogin({ email: 'a@b.com', password: 'pw' });
+      pendingLogin = result.current.handleLogin(buildCredentials());
     });
 
     unmount();

--- a/tests/unit/modules/user/features/auth/hooks/use-registration-form.test.tsx
+++ b/tests/unit/modules/user/features/auth/hooks/use-registration-form.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import useRegistrationForm from '@auth/hooks/use-registration-form';
 import { AuthStateVar } from '@auth/stores';
+import { buildRegistrationResponse } from '@tests/builders';
 
 describe('useRegistrationForm', () => {
   beforeEach(() => {
@@ -47,7 +48,7 @@ describe('useRegistrationForm', () => {
   it('keeps showSubmitLoader on after success until the result is cleared', () => {
     AuthStateVar.set({
       registerLoading: false,
-      user: { email: 'user@example.com', fullName: 'User Example' },
+      user: buildRegistrationResponse(),
     });
 
     const { result } = renderHook(() => useRegistrationForm());

--- a/tests/unit/modules/user/features/auth/hooks/use-registration-handlers.test.tsx
+++ b/tests/unit/modules/user/features/auth/hooks/use-registration-handlers.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react';
 
 import useRegistrationHandlers from '@auth/hooks/use-registration-handlers';
 import type { RegisterUserDto } from '@auth/types/credentials';
+import { buildUser } from '@tests/builders';
 
 const registerUser = jest.fn<Promise<void>, [RegisterUserDto]>(() => Promise.resolve());
 const resetRegistration = jest.fn();
@@ -75,7 +76,7 @@ describe('useRegistrationHandlers', () => {
 
   it('handleRetry resets and re-registers the last submitted data when available', () => {
     const { current, lastSubmittedDataRef } = buildHook();
-    const last: RegisterUserDto = { email: 'a@b.com', password: 'pw', fullName: 'Alice' };
+    const last: RegisterUserDto = buildUser();
     lastSubmittedDataRef.current = last;
 
     act(() => current().handleRetry());

--- a/tests/unit/modules/user/features/auth/repositories/auth-repository-impl.test.ts
+++ b/tests/unit/modules/user/features/auth/repositories/auth-repository-impl.test.ts
@@ -1,5 +1,6 @@
 import AuthRepositoryImpl from '@auth/repositories/auth-repository-impl';
 import type { AuthRepositoryDeps } from '@auth/types/auth-repository-deps';
+import { buildEmail, buildFullName, buildPassword, buildToken, buildUserId } from '@tests/builders';
 
 const ok = <T>(value: T): { ok: true; value: T } => ({ ok: true as const, value });
 
@@ -19,13 +20,15 @@ const makeDeps = (): AuthRepositoryDeps =>
 describe('AuthRepositoryImpl', () => {
   it('returns an AuthSession on successful login', async () => {
     const deps = makeDeps();
-    (deps.loginAPI.login as jest.Mock).mockResolvedValue({ token: 't' });
-    (deps.loginResponseMapper.map as jest.Mock).mockReturnValue(ok({ token: 't', email: 'a@b.c' }));
+    const email = buildEmail();
+    const token = buildToken();
+    (deps.loginAPI.login as jest.Mock).mockResolvedValue({ token });
+    (deps.loginResponseMapper.map as jest.Mock).mockReturnValue(ok({ token, email }));
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.login({ email: 'A@B.C', password: 'p' });
+    const result = await repo.login({ email: buildEmail(), password: buildPassword() });
 
-    expect(result).toEqual({ ok: true, value: { email: 'a@b.c', token: 't' } });
+    expect(result).toEqual({ ok: true, value: { email, token } });
   });
 
   it('maps transport errors to a structured AuthError', async () => {
@@ -37,7 +40,7 @@ describe('AuthRepositoryImpl', () => {
     });
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.login({ email: 'a@b.c', password: 'p' });
+    const result = await repo.login({ email: buildEmail(), password: buildPassword() });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -51,7 +54,7 @@ describe('AuthRepositoryImpl', () => {
     (deps.abortDetector.isAbortError as jest.Mock).mockReturnValue(true);
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.login({ email: 'a@b.c', password: 'p' });
+    const result = await repo.login({ email: buildEmail(), password: buildPassword() });
 
     expect(result).toEqual({
       ok: false,
@@ -69,7 +72,7 @@ describe('AuthRepositoryImpl', () => {
     });
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.login({ email: 'a@b.c', password: 'p' });
+    const result = await repo.login({ email: buildEmail(), password: buildPassword() });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -79,12 +82,16 @@ describe('AuthRepositoryImpl', () => {
 
   it('returns a SafeUserInfo on successful register', async () => {
     const deps = makeDeps();
-    const safeUser = { id: '1', email: 'a@b.c', fullName: 'A B' };
+    const safeUser = { id: buildUserId(), email: buildEmail(), fullName: buildFullName() };
     (deps.registrationAPI.register as jest.Mock).mockResolvedValue({});
     (deps.registrationResponseMapper.map as jest.Mock).mockReturnValue(ok(safeUser));
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.register({ email: 'a@b.c', password: 'p', fullName: 'A B' });
+    const result = await repo.register({
+      email: buildEmail(),
+      password: buildPassword(),
+      fullName: buildFullName(),
+    });
 
     expect(result).toEqual({ ok: true, value: safeUser });
   });
@@ -98,7 +105,11 @@ describe('AuthRepositoryImpl', () => {
     });
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.register({ email: 'a@b.c', password: 'p', fullName: 'A B' });
+    const result = await repo.register({
+      email: buildEmail(),
+      password: buildPassword(),
+      fullName: buildFullName(),
+    });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -115,7 +126,11 @@ describe('AuthRepositoryImpl', () => {
     });
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.register({ email: 'a@b.c', password: 'p', fullName: 'A B' });
+    const result = await repo.register({
+      email: buildEmail(),
+      password: buildPassword(),
+      fullName: buildFullName(),
+    });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/tests/unit/modules/user/features/auth/repositories/auth-repository-impl.test.ts
+++ b/tests/unit/modules/user/features/auth/repositories/auth-repository-impl.test.ts
@@ -20,15 +20,20 @@ const makeDeps = (): AuthRepositoryDeps =>
 describe('AuthRepositoryImpl', () => {
   it('returns an AuthSession on successful login', async () => {
     const deps = makeDeps();
-    const email = buildEmail();
+    const credentials = { email: buildEmail(), password: buildPassword() };
     const token = buildToken();
-    (deps.loginAPI.login as jest.Mock).mockResolvedValue({ token });
-    (deps.loginResponseMapper.map as jest.Mock).mockReturnValue(ok({ token, email }));
+    const apiResponse = { token };
+    (deps.loginAPI.login as jest.Mock).mockResolvedValue(apiResponse);
+    (deps.loginResponseMapper.map as jest.Mock).mockReturnValue(
+      ok({ token, email: credentials.email })
+    );
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.login({ email: buildEmail(), password: buildPassword() });
+    const result = await repo.login(credentials);
 
-    expect(result).toEqual({ ok: true, value: { email, token } });
+    expect(deps.loginAPI.login).toHaveBeenCalledWith(credentials, { signal: undefined });
+    expect(deps.loginResponseMapper.map).toHaveBeenCalledWith(apiResponse, credentials.email);
+    expect(result).toEqual({ ok: true, value: { email: credentials.email, token } });
   });
 
   it('maps transport errors to a structured AuthError', async () => {
@@ -82,17 +87,23 @@ describe('AuthRepositoryImpl', () => {
 
   it('returns a SafeUserInfo on successful register', async () => {
     const deps = makeDeps();
-    const safeUser = { id: buildUserId(), email: buildEmail(), fullName: buildFullName() };
+    const credentials = {
+      email: buildEmail(),
+      password: buildPassword(),
+      fullName: buildFullName(),
+    };
+    const safeUser = {
+      id: buildUserId(),
+      email: credentials.email,
+      fullName: credentials.fullName,
+    };
     (deps.registrationAPI.register as jest.Mock).mockResolvedValue({});
     (deps.registrationResponseMapper.map as jest.Mock).mockReturnValue(ok(safeUser));
     const repo = new AuthRepositoryImpl(deps);
 
-    const result = await repo.register({
-      email: buildEmail(),
-      password: buildPassword(),
-      fullName: buildFullName(),
-    });
+    const result = await repo.register(credentials);
 
+    expect(deps.registrationAPI.register).toHaveBeenCalledWith(credentials, { signal: undefined });
     expect(result).toEqual({ ok: true, value: safeUser });
   });
 

--- a/tests/unit/modules/user/features/auth/repositories/login-api.test.ts
+++ b/tests/unit/modules/user/features/auth/repositories/login-api.test.ts
@@ -2,20 +2,22 @@
 
 import { ApiError } from '@/modules/user/lib/api-errors';
 import LoginAPI from '@auth/repositories/login-api';
+import { buildCredentials, buildLoginResponse } from '@tests/builders';
 
 type HttpsClient = import('@/services/types/https-client/https-client').HttpsClient;
 
 describe('LoginAPI', () => {
-  const credentials = { email: 'user@example.com', password: 'secret' };
+  const credentials = buildCredentials();
 
   it('returns the underlying client response on success', async () => {
+    const loginResponse = buildLoginResponse();
     const httpsClient = {
-      post: jest.fn().mockResolvedValue({ token: 'abc123' }),
+      post: jest.fn().mockResolvedValue(loginResponse),
     } as unknown as HttpsClient;
 
     const api = new LoginAPI(httpsClient, { convert: jest.fn() } as never);
 
-    await expect(api.login(credentials)).resolves.toEqual({ token: 'abc123' });
+    await expect(api.login(credentials)).resolves.toEqual(loginResponse);
     expect(httpsClient.post).toHaveBeenCalledWith(expect.any(String), credentials, undefined);
   });
 

--- a/tests/unit/modules/user/features/auth/repositories/registration-api.test.ts
+++ b/tests/unit/modules/user/features/auth/repositories/registration-api.test.ts
@@ -6,6 +6,7 @@ import ApiErrorFactory from '@auth/repositories/api-error-factory';
 import ApiStatusErrorFactory from '@auth/repositories/api-status-error-factory';
 import CREATE_USER from '@auth/repositories/create-user-mutation';
 import RegistrationAPI from '@auth/repositories/registration-api';
+import { buildClientMutationId, buildGraphqlUser, buildUser } from '@tests/builders';
 
 type ApolloClient = import('@apollo/client').ApolloClient<
   import('@apollo/client').NormalizedCacheObject
@@ -14,22 +15,16 @@ type ApolloClient = import('@apollo/client').ApolloClient<
 const mockApollo = (mutate: jest.Mock): ApolloClient => ({ mutate }) as unknown as ApolloClient;
 
 describe('RegistrationAPI', () => {
-  const credentials = {
-    email: 'user@example.com',
-    password: 'secret',
-    fullName: 'Test User',
-  };
+  const credentials = buildUser();
 
-  const userPayload = {
-    id: 'user-1',
-    confirmed: true,
+  const userPayload = buildGraphqlUser({
     email: credentials.email,
     initials: credentials.fullName,
-  };
+  });
 
   it('creates the user through the GraphQL mutation and maps the payload', async () => {
     const mutate = jest.fn().mockResolvedValue({
-      data: { createUser: { user: userPayload, clientMutationId: 'cid' } },
+      data: { createUser: { user: userPayload, clientMutationId: buildClientMutationId() } },
     });
     const api = new RegistrationAPI(mockApollo(mutate), { convert: jest.fn() } as never);
 

--- a/tests/unit/modules/user/features/auth/stores/auth-store-actions.test.ts
+++ b/tests/unit/modules/user/features/auth/stores/auth-store-actions.test.ts
@@ -4,6 +4,12 @@ import type { AuthError } from '@auth/types/auth-error';
 import type { AuthRepository } from '@auth/types/auth-repository';
 import type AuthErrorHandler from '@auth/utils/auth-error-handler';
 import AuthRequestErrors from '@auth/utils/auth-request-errors';
+import { buildEmail, buildFullName, buildPassword, buildToken } from '@tests/builders';
+
+const email = buildEmail();
+const token = buildToken();
+const password = buildPassword();
+const fullName = buildFullName();
 
 const authRequestErrors = new AuthRequestErrors({
   handle: (e: unknown) => ({ displayMessage: String(e), retryable: false }),
@@ -11,19 +17,19 @@ const authRequestErrors = new AuthRequestErrors({
 
 const makeRepo = (over: Partial<AuthRepository> = {}): AuthRepository =>
   ({
-    login: jest.fn().mockResolvedValue({ ok: true, value: { email: 'a@b.c', token: 't' } }),
-    register: jest.fn().mockResolvedValue({ ok: true, value: { email: 'a@b.c' } }),
+    login: jest.fn().mockResolvedValue({ ok: true, value: { email, token } }),
+    register: jest.fn().mockResolvedValue({ ok: true, value: { email } }),
     ...over,
   }) as AuthRepository;
 
 const loginWith = (over: Partial<AuthRepository>): Promise<void> =>
-  new AuthStoreActions(makeRepo(over), authRequestErrors).login({ email: 'a@b.c', password: 'p' });
+  new AuthStoreActions(makeRepo(over), authRequestErrors).login({ email, password });
 
 const registerWith = (over: Partial<AuthRepository>): Promise<void> =>
   new AuthStoreActions(makeRepo(over), authRequestErrors).register({
-    fullName: 'A',
-    email: 'a@b.c',
-    password: 'p',
+    fullName,
+    email,
+    password,
   });
 
 const abortError = {
@@ -40,8 +46,8 @@ describe('AuthStoreActions', () => {
     await loginWith({});
     expect(AuthStateVar.get()).toMatchObject({
       loginLoading: false,
-      email: 'a@b.c',
-      token: 't',
+      email,
+      token,
       loginError: null,
     });
   });
@@ -65,7 +71,7 @@ describe('AuthStoreActions', () => {
     await registerWith({});
     expect(AuthStateVar.get()).toMatchObject({
       registerLoading: false,
-      user: { email: 'a@b.c' },
+      user: { email },
       registerError: null,
     });
   });

--- a/tests/unit/modules/user/features/auth/stores/auth-var.test.ts
+++ b/tests/unit/modules/user/features/auth/stores/auth-var.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import AuthStateVar from '@auth/stores/auth-var';
 import useAuthState from '@auth/stores/use-auth-state';
+import { buildEmail } from '@tests/builders';
 
 const ENV_KEY = 'REACT_APP_LHCI_PRELOADED_AUTH_TOKEN';
 const CLEARED = {
@@ -30,11 +31,12 @@ describe('auth-var state helpers', () => {
   });
 
   it('re-renders consumers of useAuthState when the reactive var changes', () => {
+    const email = buildEmail();
     const { result } = renderHook(() => useAuthState());
     expect(result.current.email).toBe('');
 
-    act(() => AuthStateVar.set({ email: 'live@update.com' }));
-    expect(result.current.email).toBe('live@update.com');
+    act(() => AuthStateVar.set({ email }));
+    expect(result.current.email).toBe(email);
   });
 });
 

--- a/tests/unit/modules/user/features/auth/stores/use-auth-token.test.ts
+++ b/tests/unit/modules/user/features/auth/stores/use-auth-token.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import AuthStateVar from '@auth/stores/auth-var';
 import useAuthToken from '@auth/stores/use-auth-token';
+import { buildToken } from '@tests/builders';
 
 // Wraps every unsubscriber handed out by `onNextChange` so tests can assert which
 // registrations the hook actually cancels on cleanup.
@@ -38,24 +39,27 @@ describe('useAuthToken', () => {
     });
     expect(result.current).toBeNull();
 
-    act(() => AuthStateVar.set({ token: 'tok-1' }));
-    expect(result.current).toBe('tok-1');
+    const firstToken = buildToken();
+    act(() => AuthStateVar.set({ token: firstToken }));
+    expect(result.current).toBe(firstToken);
 
     const callsAfterToken = hookCalls;
     act(() => AuthStateVar.set({ loginLoading: true }));
     expect(hookCalls).toBe(callsAfterToken);
 
-    act(() => AuthStateVar.set({ token: 'tok-2' }));
-    expect(result.current).toBe('tok-2');
+    const secondToken = buildToken();
+    act(() => AuthStateVar.set({ token: secondToken }));
+    expect(result.current).toBe(secondToken);
   });
 
   it('stops notifying after unmount', () => {
     const { result, unmount } = renderHook(() => useAuthToken());
     expect(result.current).toBeNull();
 
+    const afterUnmountToken = buildToken();
     unmount();
-    act(() => AuthStateVar.set({ token: 'after-unmount' }));
-    expect(AuthStateVar.get().token).toBe('after-unmount');
+    act(() => AuthStateVar.set({ token: afterUnmountToken }));
+    expect(AuthStateVar.get().token).toBe(afterUnmountToken);
   });
 
   it('unregisters the armed listener on unmount', () => {
@@ -74,7 +78,7 @@ describe('useAuthToken', () => {
     tracker.install();
 
     const { unmount } = renderHook(() => useAuthToken());
-    act(() => AuthStateVar.set({ token: 'tok-rearm' }));
+    act(() => AuthStateVar.set({ token: buildToken() }));
     expect(tracker.cancelled).toEqual([false, false]);
 
     unmount();
@@ -93,8 +97,8 @@ describe('useAuthToken', () => {
     });
 
     const { unmount } = renderHook(() => useAuthToken());
-    act(() => AuthStateVar.set({ token: 'tok-1' }));
-    act(() => AuthStateVar.set({ token: 'tok-2' }));
+    act(() => AuthStateVar.set({ token: buildToken() }));
+    act(() => AuthStateVar.set({ token: buildToken() }));
 
     expect(registered).toHaveLength(3);
     expect(new Set(registered).size).toBe(1);
@@ -112,7 +116,7 @@ describe('useAuthToken', () => {
     unmountHook = unmount;
     const relistenSpy = jest.spyOn(reactiveVar, 'onNextChange');
 
-    act(() => AuthStateVar.set({ token: 'race' }));
+    act(() => AuthStateVar.set({ token: buildToken() }));
     expect(relistenSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/modules/user/features/auth/utils/registration-handlers-factory.test.ts
+++ b/tests/unit/modules/user/features/auth/utils/registration-handlers-factory.test.ts
@@ -2,6 +2,7 @@ import { createRef } from 'react';
 
 import type { RegisterUserDto } from '@auth/types/credentials';
 import RegistrationHandlersFactory from '@auth/utils/registration-handlers-factory';
+import { buildUser } from '@tests/builders';
 
 const createDeps = (
   ref: { current: RegisterUserDto | null } = createRef<RegisterUserDto | null>() as {
@@ -94,7 +95,7 @@ describe('RegistrationHandlersFactory', () => {
   });
 
   it('handleRetry resets and re-submits with the last submitted data', () => {
-    const last: RegisterUserDto = { email: 'a@b.com', password: 'pw', fullName: 'Last User' };
+    const last: RegisterUserDto = buildUser();
     const ref = { current: last };
     const { deps } = createDeps(ref);
     const { actions, registerUser, resetRegistration } = createActions();

--- a/tests/unit/modules/user/store/login-response-mapper.test.ts
+++ b/tests/unit/modules/user/store/login-response-mapper.test.ts
@@ -1,22 +1,24 @@
 import 'reflect-metadata';
 
 import LoginResponseMapper from '@/modules/user/store/login-response-mapper';
+import { buildEmail, buildToken } from '@tests/builders';
 
 describe('LoginResponseMapper', () => {
   const mapper = new LoginResponseMapper();
 
   it('returns ok with normalized email and token on a valid response', () => {
-    const result = mapper.map({ token: 'abc123' }, 'USER@EXAMPLE.COM');
+    const token = buildToken();
+    const result = mapper.map({ token }, 'USER@EXAMPLE.COM');
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.token).toBe('abc123');
+      expect(result.value.token).toBe(token);
       expect(result.value.email).toBe('user@example.com');
     }
   });
 
   it('returns error when the response is missing the token field', () => {
-    const result = mapper.map({ invalidField: 'value' }, 'user@example.com');
+    const result = mapper.map({ invalidField: 'value' }, buildEmail());
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -26,7 +28,7 @@ describe('LoginResponseMapper', () => {
   });
 
   it('returns error when the response is null', () => {
-    const result = mapper.map(null, 'user@example.com');
+    const result = mapper.map(null, buildEmail());
 
     expect(result.ok).toBe(false);
   });

--- a/tests/unit/modules/user/store/registration-response-mapper.test.ts
+++ b/tests/unit/modules/user/store/registration-response-mapper.test.ts
@@ -1,17 +1,19 @@
 import 'reflect-metadata';
 
 import RegistrationResponseMapper from '@/modules/user/store/registration-response-mapper';
+import { buildRegistrationResponse } from '@tests/builders';
 
 describe('RegistrationResponseMapper', () => {
   const mapper = new RegistrationResponseMapper();
 
   it('returns ok with user info on a valid response', () => {
-    const result = mapper.map({ fullName: 'Test User', email: 'test@example.com' });
+    const response = buildRegistrationResponse();
+    const result = mapper.map(response);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.fullName).toBe('Test User');
-      expect(result.value.email).toBe('test@example.com');
+      expect(result.value.fullName).toBe(response.fullName);
+      expect(result.value.email).toBe(response.email);
     }
   });
 

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -4,7 +4,8 @@
     "paths": {
       "@/*": ["src/*"],
       "@": ["src"],
-      "@auth/*": ["src/modules/user/features/auth/*"]
+      "@auth/*": ["src/modules/user/features/auth/*"],
+      "@tests/*": ["tests/*"]
     }
   }
 }


### PR DESCRIPTION
## What & why

Adopts [`@faker-js/faker`](https://fakerjs.dev/) as the standard way to generate test data across all test types, replacing hardcoded magic-value fixtures (emails, names, passwords, ids, tokens) with generated, intention-revealing data. Implements issue #101.

## How

- **Shared builders** in `tests/builders/` (`buildUser`, `buildCredentials`, `buildEmail`, `buildFullName`, `buildPassword`, `buildToken`, `buildUserId`, `buildLoginResponse`, `buildRegistrationResponse`, `buildCreateUserInput`, `buildGraphqlUser`), imported via a new `@tests/*` path alias. Every builder returns **domain-valid data by construction** (passes the app's email / password / name validators) and accepts an `overrides` object.
- **Deterministic seeding** — `seedFaker()` wired into every runner's setup (`jest.setup.ts`, `tests/integration/setup.ts`, new `tests/apollo-server/setup.ts`, and the Playwright e2e/visual shared constants). Default `DEFAULT_FAKER_SEED`, override with `FAKER_SEED=<integer>`; the active seed is reported once per worker so failures are reproducible.
- **Converted fixtures** across unit, integration, Apollo-server, and e2e/visual tests to use the builders. The integration mock server now exposes its generated defaults (`defaultLoginResponse`, `defaultGraphqlUser`, `defaultClientMutationId`) so tests assert against those instead of literals.
- **Faker ESM** transpiled for Jest (faker v10 is ESM-only) via a scoped `babel-jest` + `@babel/preset-env` transform and a `transformIgnorePatterns` exception.
- **Docs** — full convention + review guideline in `agents.md`; pattern reference in `CLAUDE.md`.

## Scope decisions

- Intentional edge-case / invalid literals (malformed emails, boundary passwords), golden text, config values, URLs, error codes, i18n strings, and mock sentinels are **kept** — they are the test case or a fixed contract, not arbitrary fixtures.
- Visual snapshots are unaffected: the success/error notification overlays the form (only i18n strings are in-frame), and deterministic seeding keeps generated data stable.
- The "discourage new hardcoded fixtures" item is a **documented review guideline**, not an ESLint rule — "arbitrary fixture vs intentional literal" is a semantic distinction a static rule can't reliably make (same reasoning as the #89 class-only gate).

## Verification

- `make test-unit-client`, `make test-unit-server`, `make test-integration` — green.
- `make format`, `make lint` — clean.

Closes #101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes test data generation with `@faker-js/faker` builders and deterministic seeding across unit, integration, Apollo-server, and e2e tests to make tests clearer and reproducible. Adds an e2e mock pass-through for `clientMutationId` and tightens threading assertions. Implements issue #101.

- **Refactors**
  - Added shared Faker-backed builders in `tests/builders` (user/auth/GraphQL); domain-valid by construction, `overrides` supported; import via `@tests/*`.
  - Deterministic seeding in all runners (`jest.setup.ts`, `tests/integration/setup.ts`, `tests/apollo-server/setup.ts`, Playwright); default `DEFAULT_FAKER_SEED`, override with `FAKER_SEED`; seed logged once per worker. Enabled ESM-only Faker in Jest via `babel-jest` + `@babel/preset-env` and a `transformIgnorePatterns` exception.
  - Converted tests to builders; integration mock server now exports `defaultLoginResponse`, `defaultGraphqlUser`, `defaultClientMutationId`.
  - E2E success mock now echoes the request `clientMutationId` to match the real API.
  - Strengthened `AuthRepositoryImpl` happy-path tests to assert credentials flow to `loginAPI`/`registrationAPI` and the response mappers.
  - Kept intentional literals (invalid inputs, golden text, config, URLs, error codes, i18n, sentinels); visual snapshots unchanged; docs added in `agents.md` and `CLAUDE.md`.

- **Migration**
  - Use `@tests/builders` in new tests; bind a generated value to a const and reuse it in assertions.
  - To reproduce failures, run with `FAKER_SEED=<integer>` (defaults to `DEFAULT_FAKER_SEED`).

<sup>Written for commit 94f499227203c0abe49e7e46c3c94b7d9d059d21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

