### PR TITLE
ci(#120): shard mutation testing and add concurrency to cut PR runtime

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/bats-testing.yml
+++ b/.github/workflows/bats-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-cruiser.yml
+++ b/.github/workflows/dependency-cruiser.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-cruiser:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint-suppressions.yml
+++ b/.github/workflows/eslint-suppressions.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: eslint-suppressions-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   load-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   memory-leak-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -7,8 +7,60 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  mutation-testing:
+  shard:
+    name: shard ${{ matrix.index }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # To change the shard count, keep this list and the merge job's
+        # MUTATION_SHARD_TOTAL in lock-step: index must be [0 .. TOTAL-1]. A
+        # mismatch fails closed at the merge gate's shard-count/index check.
+        index: [0, 1, 2, 3]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+
+      - name: Start dev container
+        run: make start-dev
+
+      - name: Run mutation shard
+        run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=4
+
+      - name: Upload shard report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mutation-shard-${{ matrix.index }}
+          path: reports/mutation/mutation-shard-${{ matrix.index }}.json
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down
+
+  merge:
+    name: merge and enforce gate
+    needs: shard
+    # Run even when a shard failed so the gate fails CLOSED. Without this the job
+    # would be SKIPPED on shard failure, and branch protection treats a skipped
+    # required check as passing — silently bypassing the mutation gate.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,8 +76,27 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      - name: Start container
-        run: make start
+      - name: Fail if any mutation shard did not succeed
+        if: needs.shard.result != 'success'
+        env:
+          SHARD_RESULT: ${{ needs.shard.result }}
+        run: |
+          echo "::error::Mutation shards did not all succeed (result=$SHARD_RESULT); failing the gate."
+          exit 1
 
-      - name: Run mutation testing
-        run: make test-mutation
+      - name: Download shard reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: mutation-shard-*
+          path: reports/mutation
+          merge-multiple: true
+
+      - name: Start dev container
+        run: make start-dev
+
+      - name: Merge reports and enforce mutation-score gate
+        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -7,11 +7,20 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   performance:
+    name: lighthouse ${{ matrix.formFactor }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        formFactor: [desktop, mobile]
 
     steps:
       - name: Checkout code
@@ -30,8 +39,5 @@ jobs:
       - name: Start container
         run: INSTALL_CHROMIUM=true make start
 
-      - name: Run desktop performance test
-        run: make lighthouse-desktop
-
-      - name: Run mobile performance test
-        run: make lighthouse-mobile
+      - name: Run ${{ matrix.formFactor }} performance test
+        run: make lighthouse-${{ matrix.formFactor }}

--- a/.github/workflows/rust-code-analysis.yml
+++ b/.github/workflows/rust-code-analysis.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: rca-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sandbox-creating.yml
+++ b/.github/workflows/sandbox-creating.yml
@@ -12,6 +12,10 @@ env:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/sandbox-deleting.yml
+++ b/.github/workflows/sandbox-deleting.yml
@@ -13,6 +13,10 @@ env:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   trigger-sandbox-deletion-pipeline:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml-formater.yml
+++ b/.github/workflows/yaml-formater.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yamlfmt:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,18 @@ Load test scenarios (configurable in `./test/load/config.json.dist`):
 
 - smoke, average, stress, spike
 
+### CI parallelization
+
+`make test-mutation` runs the full, gated Stryker suite locally. In CI it is **sharded** across a
+4-way matrix (`make test-mutation-shard`, lean `make start-dev` container) and a final
+`merge and enforce gate` job merges the per-shard JSON reports and re-enforces the same `break`
+threshold read from `stryker.config.mjs` (`make merge-mutation-reports`) — identical gate, much
+faster (~1h → fits the PR budget). Lighthouse desktop/mobile run as a parallel matrix
+(`performance-testing.yml`). Every workflow declares `concurrency` with `cancel-in-progress: true`
+(release/sandbox workflows use `false`) so a new push cancels the previous run. No gate is weakened
+and no threshold changes. See "CI speed and the mutation-testing gate" in `CONTRIBUTING.md` for the
+full flow and the branch-protection required-checks update.
+
 ## Code Quality
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,61 @@ or a per-image `docker-perf-exception:<name>` PR label that waives only that
 image. The decision logic is covered by `tests/bats/docker_perf.bats`
 (run with `make test-bats`).
 
+### CI speed and the mutation-testing gate
+
+GitHub runs the pull-request workflows in parallel, so PR feedback is gated by the slowest single
+job. Two things keep that fast without dropping or weakening any check — every gate still runs on
+every PR, and no threshold (Stryker, metrics, jscpd, dependency-cruiser, Lighthouse) is relaxed.
+
+**Cancel superseded runs.** Every workflow declares a `concurrency` group keyed on the workflow and
+the PR (or ref) with `cancel-in-progress: true`, so pushing a new commit aborts the previous run for
+that PR instead of letting it finish. The release and sandbox-lifecycle workflows
+(`autorelease`, `sandbox-creating`, `sandbox-deleting`) use `cancel-in-progress: false` so an
+in-flight release or sandbox trigger is never aborted.
+
+**Mutation testing is sharded, not slowed.** Stryker over the whole component surface
+(`src/components/**/*.tsx`) took close to an hour as one job. `mutation-testing.yml` now fans
+`make test-mutation-shard` across a 4-way matrix; each shard mutates a deterministic, disjoint slice
+of the same file set (`stryker.shard.config.mjs`) and uploads a per-shard JSON report. A final
+`merge and enforce gate` job runs `make merge-mutation-reports`, which unions the shard reports and
+re-enforces the **unchanged** Stryker `break` threshold (read live from `stryker.config.mjs`) over
+the whole set, computing the mutation score exactly as an unsharded run would. Sharding by file is
+score-preserving: each mutant runs against the full suite regardless of which shard owns it. A
+missing shard report makes the merge fail closed (it never passes the gate vacuously). The merge math
+is unit-tested in `tests/unit/mutation-report.test.ts`. Shards run against a lean dev-only container
+(`make start-dev`) because mutation tests mock all backends and need neither Mockoon nor Apollo.
+
+Run it locally either way:
+
+```bash
+make test-mutation                                   # full, gated, single-process run
+# or reproduce the sharded CI flow against a running dev service:
+make start-dev
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4   # repeat for 1..3
+make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+```
+
+To change the shard count, keep the `index` matrix in `mutation-testing.yml` and the merge job's
+`MUTATION_SHARD_TOTAL` in lock-step (`index` must be `[0 .. TOTAL-1]`); a mismatch fails closed at
+the merge gate rather than passing silently.
+
+**Lighthouse runs as a matrix.** `performance-testing.yml` runs the desktop and mobile audits as two
+parallel matrix cells (`lighthouse desktop` / `lighthouse mobile`) instead of sequentially in one
+job.
+
+**Required status checks (maintainer action).** Because the single `mutation testing` and
+`performance testing` checks no longer exist as one job each, a maintainer must update
+**Settings → Branches → Branch protection rules** to require these jobs in place of the old single
+checks:
+
+- `mutation testing / merge and enforce gate`
+- `performance testing / lighthouse desktop`
+- `performance testing / lighthouse mobile`
+
+The merge job runs `if: ${{ !cancelled() }}` and fails closed if any shard did not succeed (a skipped
+required check would otherwise count as a pass), so requiring the merge job alone is sufficient — a
+crashed shard turns the gate red rather than bypassing it.
+
 ### Pull Request
 
 When you're finished with the changes, create a pull request, also known as a PR.

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ STRYKER_CMD                 = make start && $(BUNX) stryker run
 STRYKER_CMD_DIND            = $(BUNX_DIND) stryker run
 UNIT_TESTS                  = $(MAKE) ensure-dev && $(EXEC_DEV_TTYLESS) env
 
+MUTATION_SHARD_TOTAL        ?= 1
+MUTATION_SHARD_INDEX        ?= 0
+MUTATION_REPORTS_DIR         = reports/mutation
+
 STORYBOOK_BUILD             = $(BUNX) storybook build
 STORYBOOK_START             = $(STORYBOOK_CMD) --host 0.0.0.0 --no-open
 
@@ -176,6 +180,9 @@ help:
 
 start: create-network ## Start the frontend dev server and Mockoon API mock
 	$(DEV_CMD)
+
+start-dev: create-network ## Build and start only the dev service (no mockoon/apollo, no readiness wait) for container-exec jobs like mutation sharding
+	$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up -d --build dev
 
 ci-setup: create-network ## Prepare the shared dev environment for CI-oriented checks
 	$(CI_SETUP_CMD)
@@ -525,6 +532,12 @@ test-memory-leak: start-prod ## This command executes memory leaks tests using M
 
 test-mutation: ## Run mutation tests using Stryker after building the app
 	$(STRYKER_CMD)
+
+test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL in the running dev container
+	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) dev bun x stryker run stryker.shard.config.mjs
+
+merge-mutation-reports: ## Merge mutation shard reports and re-enforce the Stryker break gate in the running dev container
+	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) dev bun scripts/ci/merge-mutation-reports.ts
 
 wait-for-prod-health: ## Wait for the prod container to reach a healthy state.
 	@echo "Waiting for prod container to become healthy (timeout: 60s)..."

--- a/agents.md
+++ b/agents.md
@@ -793,6 +793,12 @@ Add a specialized suite when the change touches its concern: `make test-mutation
 strength), `make test-memory-leak` (leaks / OOM), `make test-load` (traffic, K6), and
 `make lighthouse-desktop` / `make lighthouse-mobile` (performance, a11y, best practices).
 
+`make test-mutation` runs the full, gated Stryker suite locally. In CI it is sharded across a 4-way
+matrix (`make test-mutation-shard`) and a final job merges the per-shard reports and re-enforces the
+same `break` threshold (`make merge-mutation-reports`) — same gate, much faster. Lighthouse runs as a
+desktop/mobile matrix, and every workflow cancels superseded runs via `concurrency`. See
+CONTRIBUTING.md ("CI speed and the mutation-testing gate") for the full flow.
+
 ### Step 2 — Cover Every Applicable Scenario Class
 
 For each layer you touch, cover all three scenario classes that apply to the change.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,7 @@ export default [
       'build/**',
       'coverage/**',
       'stryker.config.mjs',
+      'stryker.shard.config.mjs',
       '.stryker-tmp/**',
       '.storybook/**',
       'storybook-static/**',

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -4,8 +4,11 @@ import { join, resolve } from 'node:path';
 import { type MutationReport, scoreReports } from './mutation-report';
 
 const SHARD_FILE = /^mutation-shard-\d+\.json$/;
+
+/** Fixed shard-report directory; never taken from argv so it stays path-injection safe. */
 const REPORTS_DIR = resolve(process.cwd(), 'reports', 'mutation');
 
+/** Read and parse every `mutation-shard-*.json` report in `dir`, sorted by name. */
 function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
   let entries: string[];
   try {
@@ -27,6 +30,7 @@ function loadShardReports(dir: string): { name: string; report: MutationReport }
     });
 }
 
+/** Read the canonical `thresholds.break` from the real Stryker config so it can never drift. */
 async function resolveBreakThreshold(): Promise<number> {
   const { default: base } = (await import('../../stryker.config.mjs')) as {
     default: { thresholds?: { break?: number | null } };
@@ -40,6 +44,7 @@ async function resolveBreakThreshold(): Promise<number> {
   return breakThreshold;
 }
 
+/** Merge the shard reports, recompute the score, and exit non-zero if it is below the break gate. */
 async function main(): Promise<void> {
   const dir = REPORTS_DIR;
 

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -44,7 +44,7 @@ async function resolveBreakThreshold(): Promise<number> {
   return breakThreshold;
 }
 
-/** Merge the shard reports, recompute the score, and exit non-zero if it is below the break gate. */
+/** Merge shard reports, recompute the score, and exit non-zero if below the break gate. */
 async function main(): Promise<void> {
   const dir = REPORTS_DIR;
 

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -1,0 +1,108 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { type MutationReport, scoreReports } from './mutation-report';
+
+const SHARD_FILE = /^mutation-shard-\d+\.json$/;
+const REPORTS_DIR = resolve(process.cwd(), 'reports', 'mutation');
+
+function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (error) {
+    throw new Error(`Could not read mutation report directory "${dir}": ${String(error)}`);
+  }
+
+  return entries
+    .filter((name) => SHARD_FILE.test(name))
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => {
+      const raw = readFileSync(join(dir, name), 'utf8');
+      try {
+        return { name, report: JSON.parse(raw) as MutationReport };
+      } catch (error) {
+        throw new Error(`Mutation report "${name}" is not valid JSON: ${String(error)}`);
+      }
+    });
+}
+
+async function resolveBreakThreshold(): Promise<number> {
+  const { default: base } = (await import('../../stryker.config.mjs')) as {
+    default: { thresholds?: { break?: number | null } };
+  };
+  const breakThreshold = base.thresholds?.break;
+  if (typeof breakThreshold !== 'number') {
+    throw new TypeError(
+      'stryker.config.mjs has no numeric thresholds.break; refusing to gate without a threshold.'
+    );
+  }
+  return breakThreshold;
+}
+
+async function main(): Promise<void> {
+  const dir = REPORTS_DIR;
+
+  const expectedShards = Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '', 10);
+  if (!Number.isInteger(expectedShards) || expectedShards <= 0) {
+    throw new Error(
+      'MUTATION_SHARD_TOTAL must be a positive integer so the gate can verify every shard.'
+    );
+  }
+
+  const shards = loadShardReports(dir);
+  if (shards.length !== expectedShards) {
+    throw new Error(
+      `Expected ${expectedShards} shard reports but found ${shards.length} (${
+        shards.map((s) => s.name).join(', ') || 'none'
+      }). A missing shard must not pass the gate vacuously.`
+    );
+  }
+
+  const seen = new Set(shards.map((s) => Number.parseInt(/\d+/.exec(s.name)?.[0] ?? '-1', 10)));
+  for (let i = 0; i < expectedShards; i += 1) {
+    if (!seen.has(i)) {
+      throw new Error(`Mutation shard ${i} of ${expectedShards} is missing from "${dir}".`);
+    }
+  }
+
+  const breakThreshold = await resolveBreakThreshold();
+  const { tally, fileCount, mutationScore } = scoreReports(shards.map((s) => s.report));
+
+  if (!Number.isFinite(mutationScore) || tally.valid === 0) {
+    throw new Error(
+      `No valid mutants found across ${shards.length} shard(s) over ${fileCount} file(s); ` +
+        'the mutation run is misconfigured.'
+    );
+  }
+
+  const score = mutationScore.toFixed(2);
+  process.stdout.write(
+    [
+      `Merged ${shards.length} mutation shard(s) over ${fileCount} source file(s):`,
+      `  killed=${tally.killed} timeout=${tally.timeout} ` +
+        `survived=${tally.survived} noCoverage=${tally.noCoverage}`,
+      `  compileError=${tally.compileError} runtimeError=${tally.runtimeError} ` +
+        `ignored=${tally.ignored}`,
+      `  detected=${tally.detected} valid=${tally.valid} mutationScore=${score}%`,
+      '',
+    ].join('\n')
+  );
+
+  if (mutationScore < breakThreshold) {
+    process.stderr.write(
+      `Mutation score ${score}% is below the break threshold ${breakThreshold}%. Gate failed.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `Mutation score ${score}% meets the break threshold ${breakThreshold}%. Gate passed.\n`
+  );
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -1,15 +1,19 @@
+/** A single mutant entry in a `mutation-testing-elements` JSON report. */
 export interface ReportMutant {
   status?: string;
 }
 
+/** A source file entry (the system under test) in a mutation report. */
 export interface ReportFile {
   mutants?: ReportMutant[];
 }
 
+/** The subset of the `mutation-testing-elements` schema this gate reads. */
 export interface MutationReport {
   files?: Record<string, ReportFile>;
 }
 
+/** Per-status mutant counts plus the derived detected/undetected/valid totals. */
 export interface StatusTally {
   killed: number;
   timeout: number;
@@ -24,12 +28,14 @@ export interface StatusTally {
   valid: number;
 }
 
+/** The merged score over a set of shard reports. */
 export interface ScoreResult {
   tally: StatusTally;
   fileCount: number;
   mutationScore: number;
 }
 
+/** Union the `files` maps of every shard report, keyed by source path (first occurrence wins). */
 export function mergeReportFiles(reports: readonly MutationReport[]): Map<string, ReportMutant[]> {
   const byFile = new Map<string, ReportMutant[]>();
   for (const report of reports) {
@@ -42,6 +48,7 @@ export function mergeReportFiles(reports: readonly MutationReport[]): Map<string
   return byFile;
 }
 
+/** Map each Stryker mutant status to its tally counter. */
 const STATUS_TALLY_KEYS = new Map<string, keyof StatusTally>([
   ['Killed', 'killed'],
   ['Timeout', 'timeout'],
@@ -52,6 +59,7 @@ const STATUS_TALLY_KEYS = new Map<string, keyof StatusTally>([
   ['Ignored', 'ignored'],
 ]);
 
+/** Tally mutant statuses across the merged source files and derive detected/undetected/valid. */
 export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>): StatusTally {
   const tally: StatusTally = {
     killed: 0,
@@ -84,10 +92,12 @@ export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>)
   return tally;
 }
 
+/** The overall mutation score (`detected / valid * 100`), or `NaN` when there are no valid mutants. */
 export function mutationScore(tally: StatusTally): number {
   return tally.valid > 0 ? (tally.detected / tally.valid) * 100 : Number.NaN;
 }
 
+/** Merge shard reports and compute the overall mutation score. */
 export function scoreReports(reports: readonly MutationReport[]): ScoreResult {
   const byFile = mergeReportFiles(reports);
   const tally = tallyMutants(byFile);

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -1,0 +1,95 @@
+export interface ReportMutant {
+  status?: string;
+}
+
+export interface ReportFile {
+  mutants?: ReportMutant[];
+}
+
+export interface MutationReport {
+  files?: Record<string, ReportFile>;
+}
+
+export interface StatusTally {
+  killed: number;
+  timeout: number;
+  survived: number;
+  noCoverage: number;
+  compileError: number;
+  runtimeError: number;
+  ignored: number;
+  pending: number;
+  detected: number;
+  undetected: number;
+  valid: number;
+}
+
+export interface ScoreResult {
+  tally: StatusTally;
+  fileCount: number;
+  mutationScore: number;
+}
+
+export function mergeReportFiles(reports: readonly MutationReport[]): Map<string, ReportMutant[]> {
+  const byFile = new Map<string, ReportMutant[]>();
+  for (const report of reports) {
+    for (const [path, file] of Object.entries(report.files ?? {})) {
+      if (!byFile.has(path)) {
+        byFile.set(path, file?.mutants ?? []);
+      }
+    }
+  }
+  return byFile;
+}
+
+const STATUS_TALLY_KEYS = new Map<string, keyof StatusTally>([
+  ['Killed', 'killed'],
+  ['Timeout', 'timeout'],
+  ['Survived', 'survived'],
+  ['NoCoverage', 'noCoverage'],
+  ['CompileError', 'compileError'],
+  ['RuntimeError', 'runtimeError'],
+  ['Ignored', 'ignored'],
+]);
+
+export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>): StatusTally {
+  const tally: StatusTally = {
+    killed: 0,
+    timeout: 0,
+    survived: 0,
+    noCoverage: 0,
+    compileError: 0,
+    runtimeError: 0,
+    ignored: 0,
+    pending: 0,
+    detected: 0,
+    undetected: 0,
+    valid: 0,
+  };
+
+  for (const mutants of mutantsByFile.values()) {
+    for (const mutant of mutants) {
+      const key = mutant.status === undefined ? undefined : STATUS_TALLY_KEYS.get(mutant.status);
+      if (key === undefined) {
+        tally.pending += 1;
+      } else {
+        tally[key] += 1;
+      }
+    }
+  }
+
+  tally.detected = tally.killed + tally.timeout;
+  tally.undetected = tally.survived + tally.noCoverage;
+  tally.valid = tally.detected + tally.undetected;
+  return tally;
+}
+
+export function mutationScore(tally: StatusTally): number {
+  return tally.valid > 0 ? (tally.detected / tally.valid) * 100 : Number.NaN;
+}
+
+export function scoreReports(reports: readonly MutationReport[]): ScoreResult {
+  const byFile = mergeReportFiles(reports);
+  const tally = tallyMutants(byFile);
+  return { tally, fileCount: byFile.size, mutationScore: mutationScore(tally) };
+}

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -92,7 +92,7 @@ export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>)
   return tally;
 }
 
-/** The overall mutation score (`detected / valid * 100`), or `NaN` when there are no valid mutants. */
+/** Mutation score (`detected / valid * 100`), or `NaN` when there are no valid mutants. */
 export function mutationScore(tally: StatusTally): number {
   return tally.valid > 0 ? (tally.detected / tally.valid) * 100 : Number.NaN;
 }

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -6,8 +6,9 @@ import base from './stryker.config.mjs';
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
 
+/** Recursively collect mutatable `.tsx` files (excluding stories) under `dir`. */
 function collectTsxFiles(dir) {
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) return collectTsxFiles(full);
     if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.stories.tsx')) return [full];

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -6,7 +6,7 @@ import base from './stryker.config.mjs';
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
 
-/** Recursively collect mutatable `.tsx` files (excluding stories) under `dir`. */
+/** Recursively collect the `.tsx` files Stryker mutates (excluding stories) under `dir`. */
 function collectTsxFiles(dir) {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = path.join(dir, entry.name);

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import base from './stryker.config.mjs';
+
+const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
+const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
+
+function collectTsxFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectTsxFiles(full);
+    if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.stories.tsx')) return [full];
+    return [];
+  });
+}
+
+const sliced = collectTsxFiles('src/components')
+  .sort()
+  .filter((_, i) => i % total === index % total);
+
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  ...base,
+  mutate: sliced,
+  reporters: ['json', 'clear-text', 'progress'],
+  jsonReporter: { fileName: `reports/mutation/mutation-shard-${index}.json` },
+  thresholds: { ...base.thresholds, break: null },
+};
+
+export default config;

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -101,3 +101,6 @@ run-load-tests-dind	bats	tests/bats/makefile_targets.bats	Validated as the DIND 
 test-bats	ci	.github/workflows/bats-testing.yml	Executed directly by the dedicated Bats PR workflow.
 ensure-playwright-browsers	bats	tests/bats/makefile_targets.bats	Validated as the idempotent dev-container Chromium installer (system apk build).
 require-playwright-browsers	bats	tests/bats/makefile_targets.bats	Validated as the fail-fast browser preflight that gates the dev-mode targets.
+start-dev	bats	tests/bats/makefile_targets.bats	Validated as the lean dev-only Docker Compose start target for container-exec jobs.
+test-mutation-shard	bats	tests/bats/makefile_targets.bats	Validated as the per-shard Stryker run dispatched to the running dev container.
+merge-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated as the shard-report merge and break-gate command in the running dev container.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -272,3 +272,24 @@ EOF
   [ "$status" -eq 0 ]
   assert_log_contains 'compose exec dev env PLAYWRIGHT_DEV_MODE=1 PLAYWRIGHT_TRACE_PORT=9323 bun x playwright test tests/e2e/modules/back-to-main.spec.ts --debug'
 }
+
+@test "start-dev builds and starts only the dev service" {
+  reset_command_log
+  run_make_target start-dev
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose -f docker-compose.yml up -d --build dev'
+}
+
+@test "test-mutation-shard runs the shard config in the dev container with shard env vars" {
+  reset_command_log
+  run_make_target test-mutation-shard MUTATION_SHARD_INDEX=2 MUTATION_SHARD_TOTAL=4
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_INDEX=2 -e MUTATION_SHARD_TOTAL=4 dev bun x stryker run stryker.shard.config.mjs'
+}
+
+@test "merge-mutation-reports merges shard reports and enforces the gate in the dev container" {
+  reset_command_log
+  run_make_target merge-mutation-reports MUTATION_SHARD_TOTAL=4
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_TOTAL=4 dev bun scripts/ci/merge-mutation-reports.ts'
+}

--- a/tests/unit/mutation-report.test.ts
+++ b/tests/unit/mutation-report.test.ts
@@ -1,0 +1,105 @@
+import {
+  type MutationReport,
+  mergeReportFiles,
+  mutationScore,
+  scoreReports,
+  tallyMutants,
+} from '../../scripts/ci/mutation-report';
+
+function report(files: Record<string, string[]>): MutationReport {
+  return {
+    files: Object.fromEntries(
+      Object.entries(files).map(([path, statuses]) => [
+        path,
+        { mutants: statuses.map((status) => ({ status })) },
+      ])
+    ),
+  };
+}
+
+describe('mutation-report merge gate', () => {
+  describe('mutationScore mirrors Stryker (detected / valid * 100)', () => {
+    it('counts killed and timeout as detected', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.tsx': ['Killed', 'Timeout'] })]));
+      expect(tally.detected).toBe(2);
+      expect(tally.valid).toBe(2);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('counts survived and noCoverage against the score (undetected, still valid)', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.tsx': ['Killed', 'Killed', 'Survived', 'NoCoverage'] })])
+      );
+      expect(tally.detected).toBe(2);
+      expect(tally.undetected).toBe(2);
+      expect(tally.valid).toBe(4);
+      expect(mutationScore(tally)).toBe(50);
+    });
+
+    it('excludes compile/runtime errors and ignored mutants from valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([
+          report({ 'a.tsx': ['Killed', 'CompileError', 'RuntimeError', 'Ignored'] }),
+        ])
+      );
+      expect(tally.compileError).toBe(1);
+      expect(tally.runtimeError).toBe(1);
+      expect(tally.ignored).toBe(1);
+      expect(tally.valid).toBe(1);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('treats Pending and unknown statuses as non-valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.tsx': ['Killed', 'Pending', 'Weird'] })])
+      );
+      expect(tally.pending).toBe(2);
+      expect(tally.valid).toBe(1);
+    });
+
+    it('returns NaN when there are no valid mutants', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.tsx': ['Ignored'] })]));
+      expect(tally.valid).toBe(0);
+      expect(Number.isNaN(mutationScore(tally))).toBe(true);
+    });
+  });
+
+  describe('the break boundary is exact', () => {
+    it('scores 80% when 8 of 10 valid mutants are detected', () => {
+      const statuses = [...Array(8).fill('Killed'), 'Survived', 'NoCoverage'];
+      expect(scoreReports([report({ 'a.tsx': statuses })]).mutationScore).toBe(80);
+    });
+
+    it('scores below 80% when only 7 of 10 are detected', () => {
+      const statuses = [...Array(7).fill('Killed'), ...Array(3).fill('Survived')];
+      expect(scoreReports([report({ 'a.tsx': statuses })]).mutationScore).toBeCloseTo(70, 10);
+    });
+  });
+
+  describe('merging shard reports', () => {
+    it('unions disjoint files and sums their mutants', () => {
+      const result = scoreReports([
+        report({ 'a.tsx': ['Killed', 'Killed'] }),
+        report({ 'b.tsx': ['Killed', 'Survived'] }),
+      ]);
+      expect(result.fileCount).toBe(2);
+      expect(result.tally.detected).toBe(3);
+      expect(result.tally.valid).toBe(4);
+      expect(result.mutationScore).toBe(75);
+    });
+
+    it('does not double-count a file that appears in two shards', () => {
+      const duplicate = report({ 'a.tsx': ['Killed', 'Survived'] });
+      const result = scoreReports([duplicate, duplicate]);
+      expect(result.fileCount).toBe(1);
+      expect(result.tally.valid).toBe(2);
+      expect(result.mutationScore).toBe(50);
+    });
+
+    it('tolerates reports with no files', () => {
+      const result = scoreReports([{}, report({ 'a.tsx': ['Killed'] })]);
+      expect(result.fileCount).toBe(1);
+      expect(result.mutationScore).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #120.

Makes CI fast by **parallelizing in place** — every gate still runs on every PR, and **no
threshold is weakened or removed**. GitHub already runs the workflows in parallel, so PR wall-clock
is the single slowest job, which was **mutation testing (~1h)**.

This mirrors the proven [`ui-toolkit#65`](https://github.com/VilnaCRM-Org/ui-toolkit/pull/65)
(`ci(#64)`) approach for crm's Stryker setup, and matches the `user-service` convention of running
mutation (Infection) on every PR with no nightly tier.

### Scope note (vs. the issue text)

Issue #120 proposed a three-tier model (fast PR gate + **nightly** heavy gate + release gate). Per
the request, **this PR deliberately does not add a nightly tier or a release gate** — all gates stay
on the PR and are simply made fast. If the tiered model is wanted later, it can build on this.

## Changes

- **Mutation testing → 4-way shard matrix + fail-closed merge gate.** Each shard
  (`make test-mutation-shard`) mutates a deterministic, disjoint slice of the same
  `src/components/**/*.tsx` set (`stryker.shard.config.mjs`) and uploads a per-shard JSON report. A
  final **`merge and enforce gate`** job (`make merge-mutation-reports`) unions them and re-enforces
  the **unchanged** Stryker `break` threshold read live from `stryker.config.mjs`
  (`scripts/ci/merge-mutation-reports.ts`). Sharding by file is score-preserving — each mutant runs
  against the full suite regardless of which shard owns it.
- **Lean dev-only startup for mutation.** Shards/merge use a new `make start-dev` (just the `dev`
  service, no readiness waits) instead of `make start`; mutation tests mock all backends (MSW), so
  Mockoon/Apollo aren't needed.
- **Lighthouse desktop/mobile → parallel matrix** in `performance-testing.yml` (was sequential in
  one job).
- **`concurrency: cancel-in-progress: true` on every workflow** so a new push aborts the previous
  run. `autorelease`, `sandbox-creating`, and `sandbox-deleting` use `cancel-in-progress: false` so
  a release or sandbox lifecycle trigger is never aborted. (`rust-code-analysis` / `eslint-suppressions`
  groups normalized to the standard format.)

## Gate safety (no weakening)

- The merge job runs `if: ${{ !cancelled() }}` and **fails closed** when any shard did not succeed —
  a *skipped* required check would otherwise count as a pass and silently bypass the gate.
- The merge verifies it found exactly `MUTATION_SHARD_TOTAL` reports with indices `{0..N-1}`, so a
  dropped/missing shard fails closed instead of passing vacuously.
- Merge score math mirrors Stryker exactly (`detected/valid*100`; `Survived`/`NoCoverage` count
  against; compile/runtime errors and ignored excluded; `testFiles` excluded) — unit-tested in
  `tests/unit/mutation-report.test.ts`.
- `stryker.config.mjs` `thresholds.break` is unchanged; `config/metrics-policy.json`, `.jscpd.json`,
  and `.dependency-cruiser.js` are untouched. The shard config only sets `break: null` per-shard and
  re-enforces the real threshold once over the union.

## Verification (run locally in the dev container)

- `tsc` ✅ · ESLint (test file) ✅ · markdownlint (changed docs) ✅
- dependency-cruiser ✅ (617 modules, 0 violations) · **actionlint on all 21 workflows** ✅
- **Full client unit suite: 119 suites / 1355 tests / 100% coverage** ✅ (new test doesn't perturb
  the coverage gate — `scripts/ci` is outside `collectCoverageFrom`)
- **Bats: 16/16**, incl. the make-target-coverage contract and the 3 new target tests
- Merge CLI end-to-end: happy path (exit 0) + 3 fail-closed paths (missing shard / below-threshold /
  no valid mutants, all exit 1)
- A **real Stryker shard** confirms `stryker.shard.config.mjs` slices files, emits a valid JSON
  report, and that the report schema matches the merge helper's interface

## Maintainer action required — branch protection

The single `mutation testing` and `performance testing` checks no longer exist as one job each.
Update **Settings → Branches → Branch protection rules** to require these jobs instead:

- `mutation testing / merge and enforce gate`
- `performance testing / lighthouse desktop`
- `performance testing / lighthouse mobile`

The merge job fails closed, so requiring it alone is sufficient for the mutation gate.

To change the shard count, keep the `index` matrix in `mutation-testing.yml` and the merge job's
`MUTATION_SHARD_TOTAL` in lock-step (`index` must be `[0 .. TOTAL-1]`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up PR CI by sharding mutation testing and running Lighthouse as a matrix, without weakening any gates or thresholds. Addresses #120 by keeping all checks on PRs; no nightly tier.

- **New Features**
  - Mutation testing: 4-way shard matrix plus a merge gate that re-enforces the unchanged Stryker break threshold; fails closed on shard failure or missing reports.
  - Lean `make start-dev` for shards (tests mock backends; no Mockoon/Apollo).
  - Lighthouse desktop/mobile split into a parallel matrix.
  - Concurrency groups on all workflows to cancel superseded runs; release/sandbox workflows opt out.
  - New targets and scripts with tests: `start-dev`, `test-mutation-shard`, `merge-mutation-reports`, `scripts/ci/mutation-report.ts`, `scripts/ci/merge-mutation-reports.ts`.
  - Formatting/JSDoc and max-line-length fixes in `scripts/ci/*` and prettified `stryker.shard.config.mjs`; typo fix; no behavior change.

- **Migration**
  - Update required checks to:
    - mutation testing / merge and enforce gate
    - performance testing / lighthouse desktop
    - performance testing / lighthouse mobile
  - The merge job fails closed; requiring it alone is sufficient for the mutation gate.

<sup>Written for commit d0b2e3719ad02d5b28ec698fab3b7e9bc853f5ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

