### PR TITLE
feat(#105): module-owned route registry (typed contracts + composer + boundary gate)

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -381,14 +381,18 @@ module.exports = {
     {
       name: 'no-routes-import-feature-internals',
       comment:
-        'The routes shell layer must not import from feature internals. ' +
-        'Exceptions: public page entries (routes/) and the routing guard (protected-route).',
+        'The routes shell layer (registry + composer) must not import feature ' +
+        'internals. It consumes a feature only through its module-owned route ' +
+        'contract barrel (features/<f>/routes/index) — never a deep page path — ' +
+        'so pages are declared as data inside the module, not wired in the shell ' +
+        '(issue #105). The routing guard (protected-route) is the one further ' +
+        'exception, resolved by the composer for the declarative `guard` field.',
       severity: 'error',
       from: { path: '^src/routes/' },
       to: {
         path: '^src/modules/[^/]+/features/',
         pathNot: [
-          '^src/modules/[^/]+/features/[^/]+/routes/',
+          '^src/modules/[^/]+/features/[^/]+/routes/index[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$',
           '^src/modules/[^/]+/features/[^/]+/components/protected-route/',
         ],
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,7 @@ src/
 ├── features/        # Shared features
 ├── services/        # Singleton services (HttpsClient, error handling)
 ├── config/          # DI configuration, tokens, API config
-├── routes/          # Route definitions
+├── routes/          # Route registry + composer (module-owned route contracts)
 ├── providers/       # React context providers
 └── utils/           # Shared utilities
 ```
@@ -454,14 +454,47 @@ feature boundary is allowed **only** through its `index` barrel —
 across the boundary fail `no-module-internal-imports` /
 `no-feature-internal-imports` (dependency-cruiser) and scoped
 `no-restricted-imports` (ESLint). The DI composition root and the app-shell
-router's code-split route/guard entries are the only sanctioned exceptions.
-See `src/modules/user/README.md` for the full contract.
+router are the only sanctioned exceptions — and the router now reaches a
+feature **only** through its module-owned route contract barrel
+(`features/<f>/routes/index`) plus the `protected-route` guard, enforced by the
+tightened `no-routes-import-feature-internals` rule (issue #105).
+See `src/modules/user/README.md` for the full contract and `src/routes/README.md`
+for the route registry.
 
 These aliases are configured in:
 
 - `tsconfig.paths.json` for TypeScript
 - `rsbuild.config.ts` for RSBuild
 - `jest.config.ts` for Jest
+
+### Route Registry (issue #105)
+
+Routes are **module-owned data**, not a hand-edited tree in the app shell. Each
+module/feature declares its routes through a typed **public route contract** in
+its own `routes/` folder; a central registry collects the contracts and a
+composer builds the `createBrowserRouter` tree. `src/routes/routes.tsx` is pure
+wiring — it contains no route-array literal and no feature/module page imports.
+
+- **Contract types** — `src/routes/types/{app-route,route-module}.ts`
+  (`AppRouteObject`: `path`/`index`, lazy `load`, declarative `guard`, `meta`;
+  `RouteModule`: `id` + `routes`). Type-only files (issue #88).
+- **Module contract** — `src/modules/<m>/features/<f>/routes/index.ts` exports a
+  `RouteModule` whose routes lazy-`load` the feature's pages (per-route code
+  splitting preserved). The auth feature: `@auth/routes`. The app shell's own
+  routes (home + 404) live in `src/routes/app-routes.ts`.
+- **Registry** — `src/routes/registry.ts` collects the contracts (one-line
+  append per new module).
+- **Composer** — `src/routes/route-composer.tsx` (+ `route-mapper.tsx`,
+  `route-validator.ts`, all container-free module singletons) validates the
+  contracts, resolves `guard: 'protected'` to the `ProtectedRoute` guard nested
+  under `AppLayout`, keeps public routes directly under `RootLayout`, and wraps
+  each `load` in `React.lazy`.
+
+**Adding a page** — add a route entry to the owning module's
+`routes/index.ts` contract, then (for a new module) append it to
+`src/routes/registry.ts`. Never edit `src/routes/routes.tsx` or the composer.
+Deep-importing a feature page from the shell fails
+`no-routes-import-feature-internals`.
 
 ### GraphQL Setup
 
@@ -559,7 +592,10 @@ Key variables in `.env`:
 
 2. **Form Validation**: Centralized in module features (e.g., `auth/components/form-section/validations/`)
 
-3. **Routing**: Defined in `App.tsx` using `createBrowserRouter`
+3. **Routing**: Module-owned route contracts collected by a registry and
+   assembled by a composer into `createBrowserRouter` (see "Route Registry"
+   above). Add a page in the owning module's `routes/` folder — never in the
+   app shell.
 
 4. **Testing Philosophy**:
    - Unit tests for components and utilities

--- a/src/modules/user/README.md
+++ b/src/modules/user/README.md
@@ -20,9 +20,11 @@ Two deliberate deviations from the issue's illustrative example, both forced by
 this codebase:
 
 - **Route entry components stay out of the barrel.** The issue example shows
-  `Authentication` / `ProtectedRoute` here, but the app-shell router
-  **code-splits** the page entries (`@auth/routes/sign-up|sign-in`) and imports
-  the `protected-route` guard directly. Re-exporting components from this barrel
+  `Authentication` / `ProtectedRoute` here, but the feature owns its routes
+  through its `routes/index` **route contract** (`@auth/routes`), which
+  **code-splits** the page entries (`load: () => import('./sign-up|sign-in')`);
+  the app-shell registry consumes that contract and the composer imports the
+  `protected-route` guard directly. Re-exporting components from this barrel
   would (a) defeat lazy-loading (the auth page's mobile Lighthouse budget) and
   (b) pull React into every consumer of the barrel — including the plain
   `error-parser` util. They remain the documented router-only exception below.
@@ -54,12 +56,16 @@ free-for-all.
 1. **DI composition root** (`src/config/dependency-injection-config.ts`) wires
    concrete implementations into the tsyringe container and may deep-import
    them. The impls stay private to everyone else.
-2. **App-shell router** (`src/routes/`) mounts the feature's **code-split**
-   page entries (`@auth/routes/sign-up`, `@auth/routes/sign-in`) and the
-   `protected-route` guard directly. A single eager barrel would pull the whole
-   feature into one chunk and defeat lazy-loading (the auth page's mobile
-   Lighthouse budget), so these entries are consumed only by the router,
-   governed by `no-routes-import-feature-internals`.
+2. **App-shell router** (`src/routes/`) mounts the feature through its
+   module-owned **route contract barrel** (`@auth/routes` →
+   `features/auth/routes/index`), which lazy-`load`s the page entries, plus the
+   `protected-route` guard (resolved by the composer for `guard: 'protected'`).
+   The router may reach a feature **only** through that `routes/index` contract
+   and the guard — deep-importing a page (`@auth/routes/sign-up`) is forbidden.
+   A single eager barrel would pull the whole feature into one chunk and defeat
+   lazy-loading (the auth page's mobile Lighthouse budget), so the pages stay
+   `import()`-split inside the contract. Governed by
+   `no-routes-import-feature-internals` (issue #105); see `src/routes/README.md`.
 
 ## Enforcement
 

--- a/src/modules/user/features/auth/routes/index.ts
+++ b/src/modules/user/features/auth/routes/index.ts
@@ -1,0 +1,22 @@
+import ROUTE_PATHS from '@/routes/route-paths';
+import type { RouteModule } from '@/routes/types/route-module';
+
+const authRoutes: RouteModule = {
+  id: 'user.auth',
+  routes: [
+    {
+      path: ROUTE_PATHS.signUp,
+      guard: 'public',
+      load: () => import('./sign-up'),
+      meta: { titleKey: 'sign_up.title' },
+    },
+    {
+      path: ROUTE_PATHS.signIn,
+      guard: 'public',
+      load: () => import('./sign-in'),
+      meta: { titleKey: 'sign_in.title' },
+    },
+  ],
+};
+
+export default authRoutes;

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -17,17 +17,17 @@ route set discoverable (audit, nav, sitemap).
 
 ## Files
 
-| File                         | Responsibility                                              |
-| ---------------------------- | ----------------------------------------------------------- |
-| `types/app-route.ts`         | `AppRouteObject` (path/index, lazy `load`, `guard`, `meta`) |
-| `types/route-module.ts`      | `RouteModule` (`id` + `routes`) — a module's contract shape |
-| `app-routes.ts`              | The app shell's own contract (home + 404)                   |
-| `registry.ts`                | Collects every module contract into one list                |
-| `route-validator.ts`         | Rejects duplicate module ids / routes with no path or index |
-| `route-mapper.tsx`           | Maps one contract route → a `react-router` route (lazy)     |
-| `route-composer.tsx`         | Validates, partitions by guard, assembles the tree          |
-| `route-paths.ts`             | Canonical URL constants (`home`, `signUp`, `signIn`, 404)   |
-| `routes.tsx`                 | Wiring only: `createBrowserRouter(composer.compose(...))`   |
+| File                    | Responsibility                                              |
+| ----------------------- | ----------------------------------------------------------- |
+| `types/app-route.ts`    | `AppRouteObject` (path/index, lazy `load`, `guard`, `meta`) |
+| `types/route-module.ts` | `RouteModule` (`id` + `routes`) — a module's contract shape |
+| `app-routes.ts`         | The app shell's own contract (home + 404)                   |
+| `registry.ts`           | Collects every module contract into one list                |
+| `route-validator.ts`    | Rejects duplicate module ids / routes with no path or index |
+| `route-mapper.tsx`      | Maps one contract route → a `react-router` route (lazy)     |
+| `route-composer.tsx`    | Validates, partitions by guard, assembles the tree          |
+| `route-paths.ts`        | Canonical URL constants (`home`, `signUp`, `signIn`, 404)   |
+| `routes.tsx`            | Wiring only: `createBrowserRouter(composer.compose(...))`   |
 
 The composer, mapper, and validator are container-free **module singletons**
 (`export default new X()`), so no tsyringe is pulled into the auth page's paint

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -36,20 +36,28 @@ path (mobile Lighthouse budget).
 ## The contract
 
 ```ts
-// src/routes/types/app-route.ts
-export interface AppRouteObject {
-  readonly path?: string; // omit for an index route
-  readonly index?: boolean;
+// src/routes/types/app-route.ts — a discriminated union: exactly one of index | path
+interface RouteCommon {
   readonly load: () => Promise<{ default: ComponentType }>; // per-route code split
-  readonly guard?: 'protected' | 'public'; // resolved by the composer
+  readonly guard?: 'protected' | 'public'; // top-level only; resolved by the composer
   readonly meta?: { titleKey?: string; permission?: string };
+}
+interface IndexRoute extends RouteCommon {
+  readonly index: true; // a leaf — no path, no children
+}
+interface PathRoute extends RouteCommon {
+  readonly path: string;
   readonly children?: readonly AppRouteObject[];
 }
+export type AppRouteObject = IndexRoute | PathRoute;
 ```
 
 `guard: 'protected'` routes are nested under the `ProtectedRoute` guard and
 `AppLayout`; everything else renders directly under `RootLayout`. The guard is
-declarative data in the contract — it is never hand-wired in the shell.
+declarative data in the contract — it is never hand-wired in the shell. `guard`
+applies to a module's **top-level** routes only; nested children inherit their
+parent's protection context, so declaring a guard on a child is rejected by the
+`RouteValidator` (it would otherwise render outside `ProtectedRoute`).
 
 ## Adding a page
 

--- a/src/routes/README.md
+++ b/src/routes/README.md
@@ -1,0 +1,93 @@
+# Route registry
+
+Routing in this CRM is **module-owned data**, not a hand-edited tree in the app
+shell. Each module/feature declares its routes through a small typed **public
+route contract**; a registry collects the contracts and a composer assembles the
+`createBrowserRouter` tree. Adding a page touches only the owning module — never
+`routes.tsx` or the composer (issue #105).
+
+## Why
+
+A 50+ page CRM built by many parallel human and AI contributors cannot route
+through one shared file. A single `createBrowserRouter([...])` literal is a
+merge-conflict hotspot and a central coupling node that reaches across every
+module boundary. Module-owned contracts give each page a bounded blast radius,
+keep a feature's URLs/guards/lazy chunks colocated with the feature, and make the
+route set discoverable (audit, nav, sitemap).
+
+## Files
+
+| File                         | Responsibility                                              |
+| ---------------------------- | ----------------------------------------------------------- |
+| `types/app-route.ts`         | `AppRouteObject` (path/index, lazy `load`, `guard`, `meta`) |
+| `types/route-module.ts`      | `RouteModule` (`id` + `routes`) — a module's contract shape |
+| `app-routes.ts`              | The app shell's own contract (home + 404)                   |
+| `registry.ts`                | Collects every module contract into one list                |
+| `route-validator.ts`         | Rejects duplicate module ids / routes with no path or index |
+| `route-mapper.tsx`           | Maps one contract route → a `react-router` route (lazy)     |
+| `route-composer.tsx`         | Validates, partitions by guard, assembles the tree          |
+| `route-paths.ts`             | Canonical URL constants (`home`, `signUp`, `signIn`, 404)   |
+| `routes.tsx`                 | Wiring only: `createBrowserRouter(composer.compose(...))`   |
+
+The composer, mapper, and validator are container-free **module singletons**
+(`export default new X()`), so no tsyringe is pulled into the auth page's paint
+path (mobile Lighthouse budget).
+
+## The contract
+
+```ts
+// src/routes/types/app-route.ts
+export interface AppRouteObject {
+  readonly path?: string; // omit for an index route
+  readonly index?: boolean;
+  readonly load: () => Promise<{ default: ComponentType }>; // per-route code split
+  readonly guard?: 'protected' | 'public'; // resolved by the composer
+  readonly meta?: { titleKey?: string; permission?: string };
+  readonly children?: readonly AppRouteObject[];
+}
+```
+
+`guard: 'protected'` routes are nested under the `ProtectedRoute` guard and
+`AppLayout`; everything else renders directly under `RootLayout`. The guard is
+declarative data in the contract — it is never hand-wired in the shell.
+
+## Adding a page
+
+1. **Existing module** — add a route object to that module's
+   `features/<f>/routes/index.ts` contract:
+
+   ```ts
+   // src/modules/user/features/<f>/routes/index.ts
+   const featureRoutes: RouteModule = {
+     id: 'user.<f>',
+     routes: [
+       {
+         path: ROUTE_PATHS.customers,
+         guard: 'protected',
+         load: () => import('./customers'), // own dynamic chunk
+         meta: { titleKey: 'customers.title' },
+       },
+     ],
+   };
+   ```
+
+2. **New module** — create its `routes/index.ts` contract, then append it (one
+   line) to `src/routes/registry.ts`.
+
+3. Add any new URL constant to `route-paths.ts`.
+
+Never edit `routes.tsx`, `route-composer.tsx`, or `route-mapper.tsx` to add a
+page.
+
+## Enforcement
+
+- **dependency-cruiser** `no-routes-import-feature-internals` — the shell may
+  reach a feature only through its `routes/index` contract barrel and the
+  `protected-route` guard. Deep-importing a page (`@auth/routes/sign-up`) fails
+  the gate. Verified by `tests/unit/tooling/route-registry-boundary.test.ts`.
+- **Unit tests** — `tests/unit/routes/*` cover the composer (invariants A/B/D:
+  single `RootLayout`, `protected`→`AppLayout`, public not), the validator
+  (duplicate id / unlocatable route), and the registry; per-route code splitting
+  is asserted in `tests/unit/tooling/performance-serving.test.ts`.
+
+Never satisfy a gate with a suppression — route through the contract instead.

--- a/src/routes/app-routes.ts
+++ b/src/routes/app-routes.ts
@@ -1,0 +1,21 @@
+import ROUTE_PATHS from './route-paths';
+import type { RouteModule } from './types/route-module';
+
+const appRoutes: RouteModule = {
+  id: 'app.shell',
+  routes: [
+    {
+      index: true,
+      guard: 'protected',
+      load: () => import('@/button-example'),
+      meta: { permission: 'app.home' },
+    },
+    {
+      path: ROUTE_PATHS.notFound,
+      guard: 'public',
+      load: () => import('@/components/not-found/not-found'),
+    },
+  ],
+};
+
+export default appRoutes;

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -1,0 +1,8 @@
+import authRoutes from '@auth/routes';
+
+import appRoutes from './app-routes';
+import type { RouteModule } from './types/route-module';
+
+const routeModules: readonly RouteModule[] = [appRoutes, authRoutes];
+
+export default routeModules;

--- a/src/routes/route-composer.tsx
+++ b/src/routes/route-composer.tsx
@@ -1,0 +1,45 @@
+import type { RouteObject } from 'react-router-dom';
+
+import RouteError from '@/components/error-boundary/route-error';
+import AppLayout from '@/components/layouts/app-layout';
+import RootLayout from '@/components/layouts/root-layout';
+import ProtectedRoute from '@auth/components/protected-route';
+
+import routeMapper from './route-mapper';
+import ROUTE_PATHS from './route-paths';
+import routeValidator from './route-validator';
+import type { AppRouteObject } from './types/app-route';
+import type { RouteModule } from './types/route-module';
+
+class RouteComposer {
+  public compose(modules: readonly RouteModule[]): RouteObject[] {
+    routeValidator.validate(modules);
+    const routes = modules.flatMap((module) => module.routes);
+    return [
+      {
+        path: ROUTE_PATHS.home,
+        element: <RootLayout />,
+        errorElement: <RouteError />,
+        children: this.children(routes),
+      },
+    ];
+  }
+
+  private children(routes: readonly AppRouteObject[]): RouteObject[] {
+    const secured = routes.filter((route) => route.guard === 'protected');
+    const open = routes.filter((route) => route.guard !== 'protected');
+    return [...this.protectedBranch(secured), ...open.map((route) => routeMapper.map(route))];
+  }
+
+  private protectedBranch(routes: readonly AppRouteObject[]): RouteObject[] {
+    if (routes.length === 0) {
+      return [];
+    }
+    const pages = routes.map((route) => routeMapper.map(route));
+    return [
+      { element: <ProtectedRoute />, children: [{ element: <AppLayout />, children: pages }] },
+    ];
+  }
+}
+
+export default new RouteComposer();

--- a/src/routes/route-mapper.tsx
+++ b/src/routes/route-mapper.tsx
@@ -1,0 +1,24 @@
+import { lazy } from 'react';
+import type { RouteObject } from 'react-router-dom';
+
+import type { AppRouteObject } from './types/app-route';
+
+class RouteMapper {
+  public map(route: AppRouteObject): RouteObject {
+    const Page = lazy(route.load);
+    const element = <Page />;
+    if (route.index) {
+      return { index: true, element };
+    }
+    return { path: route.path, element, ...this.nested(route) };
+  }
+
+  private nested(route: AppRouteObject): { children?: RouteObject[] } {
+    if (!route.children?.length) {
+      return {};
+    }
+    return { children: route.children.map((child) => this.map(child)) };
+  }
+}
+
+export default new RouteMapper();

--- a/src/routes/route-validator.ts
+++ b/src/routes/route-validator.ts
@@ -1,0 +1,29 @@
+import type { AppRouteObject } from './types/app-route';
+import type { RouteModule } from './types/route-module';
+
+class RouteValidator {
+  public validate(modules: readonly RouteModule[]): void {
+    this.assertUniqueIds(modules);
+    modules.forEach((module) => this.assertRoutes(module.routes));
+  }
+
+  private assertUniqueIds(modules: readonly RouteModule[]): void {
+    const ids = modules.map((module) => module.id);
+    const duplicate = ids.find((id, index) => ids.indexOf(id) !== index);
+    if (duplicate !== undefined) {
+      throw new Error(`Duplicate route module id: ${duplicate}`);
+    }
+  }
+
+  private assertRoutes(routes: readonly AppRouteObject[]): void {
+    routes.forEach((route) => this.assertLocatable(route));
+  }
+
+  private assertLocatable(route: AppRouteObject): void {
+    if (route.index !== true && route.path === undefined) {
+      throw new Error('Route must declare a path or be an index route');
+    }
+  }
+}
+
+export default new RouteValidator();

--- a/src/routes/route-validator.ts
+++ b/src/routes/route-validator.ts
@@ -4,7 +4,7 @@ import type { RouteModule } from './types/route-module';
 class RouteValidator {
   public validate(modules: readonly RouteModule[]): void {
     this.assertUniqueIds(modules);
-    modules.forEach((module) => this.assertRoutes(module.routes));
+    modules.forEach((module) => module.routes.forEach((route) => this.assertRoute(route, false)));
   }
 
   private assertUniqueIds(modules: readonly RouteModule[]): void {
@@ -15,8 +15,12 @@ class RouteValidator {
     }
   }
 
-  private assertRoutes(routes: readonly AppRouteObject[]): void {
-    routes.forEach((route) => this.assertLocatable(route));
+  private assertRoute(route: AppRouteObject, nested: boolean): void {
+    this.assertLocatable(route);
+    if (nested && route.guard !== undefined) {
+      throw new Error('Nested routes must not declare a guard (guards are top-level only)');
+    }
+    route.children?.forEach((child) => this.assertRoute(child, true));
   }
 
   private assertLocatable(route: AppRouteObject): void {

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,37 +1,8 @@
-import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
-import RouteError from '@/components/error-boundary/route-error';
-import AppLayout from '@/components/layouts/app-layout';
-import RootLayout from '@/components/layouts/root-layout';
-import ROUTE_PATHS from '@/routes/route-paths';
-import ProtectedRoute from '@auth/components/protected-route';
+import registry from './registry';
+import routeComposer from './route-composer';
 
-const ButtonExample = lazy(async () => import('@/button-example'));
-const NotFound = lazy(async () => import('@/components/not-found/not-found'));
-const SignUp = lazy(async () => import('@auth/routes/sign-up'));
-const SignIn = lazy(async () => import('@auth/routes/sign-in'));
-
-const router = createBrowserRouter([
-  {
-    path: ROUTE_PATHS.home,
-    element: <RootLayout />,
-    errorElement: <RouteError />,
-    children: [
-      {
-        element: <ProtectedRoute />,
-        children: [
-          {
-            element: <AppLayout />,
-            children: [{ index: true, element: <ButtonExample /> }],
-          },
-        ],
-      },
-      { path: ROUTE_PATHS.signUp, element: <SignUp /> },
-      { path: ROUTE_PATHS.signIn, element: <SignIn /> },
-      { path: ROUTE_PATHS.notFound, element: <NotFound /> },
-    ],
-  },
-]);
+const router = createBrowserRouter(routeComposer.compose(registry));
 
 export default router;

--- a/src/routes/types/app-route.ts
+++ b/src/routes/types/app-route.ts
@@ -1,0 +1,17 @@
+import type { ComponentType } from 'react';
+
+export type RouteGuard = 'protected' | 'public';
+
+export interface RouteMeta {
+  readonly titleKey?: string;
+  readonly permission?: string;
+}
+
+export interface AppRouteObject {
+  readonly path?: string;
+  readonly index?: boolean;
+  readonly load: () => Promise<{ default: ComponentType }>;
+  readonly guard?: RouteGuard;
+  readonly meta?: RouteMeta;
+  readonly children?: readonly AppRouteObject[];
+}

--- a/src/routes/types/app-route.ts
+++ b/src/routes/types/app-route.ts
@@ -7,11 +7,26 @@ export interface RouteMeta {
   readonly permission?: string;
 }
 
-export interface AppRouteObject {
-  readonly path?: string;
-  readonly index?: boolean;
+interface RouteCommon {
   readonly load: () => Promise<{ default: ComponentType }>;
   readonly guard?: RouteGuard;
   readonly meta?: RouteMeta;
+}
+
+interface IndexRoute extends RouteCommon {
+  readonly index: true;
+  readonly path?: never;
+  readonly children?: never;
+}
+
+interface PathRoute extends RouteCommon {
+  readonly path: string;
+  readonly index?: never;
   readonly children?: readonly AppRouteObject[];
 }
+
+// Exactly one of `index` or `path` (react-router index routes are leaves and
+// carry no path/children). `guard` applies to a module's top-level routes only —
+// nested children inherit their parent's protection context (enforced by the
+// RouteValidator), so declaring a guard on a child is a contract error.
+export type AppRouteObject = IndexRoute | PathRoute;

--- a/src/routes/types/route-module.ts
+++ b/src/routes/types/route-module.ts
@@ -1,0 +1,6 @@
+import type { AppRouteObject } from './app-route';
+
+export interface RouteModule {
+  readonly id: string;
+  readonly routes: readonly AppRouteObject[];
+}

--- a/tests/unit/routes/registry.test.ts
+++ b/tests/unit/routes/registry.test.ts
@@ -1,0 +1,45 @@
+import registry from '@/routes/registry';
+import ROUTE_PATHS from '@/routes/route-paths';
+
+describe('route registry', () => {
+  it('collects the module route contracts in composition order with unique ids', () => {
+    const ids = registry.map((module) => module.id);
+
+    expect(ids).toEqual(['app.shell', 'user.auth']);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('declares every route with a loader and a locatable target', () => {
+    registry.forEach((module) => {
+      module.routes.forEach((route) => {
+        expect(typeof route.load).toBe('function');
+        expect(route.index === true || typeof route.path === 'string').toBe(true);
+      });
+    });
+  });
+
+  it('declares the app-shell home (protected) and 404 (public) routes', () => {
+    const shell = registry.find((module) => module.id === 'app.shell');
+    const [home, notFound] = shell?.routes ?? [];
+
+    expect(home.index).toBe(true);
+    expect(home.guard).toBe('protected');
+    expect(home.meta?.permission).toBe('app.home');
+    expect(notFound.path).toBe(ROUTE_PATHS.notFound);
+    expect(notFound.guard).toBe('public');
+  });
+
+  it('declares the auth pages as public routes carrying their title metadata', () => {
+    const auth = registry.find((module) => module.id === 'user.auth');
+
+    expect(auth?.routes.map((route) => route.path)).toEqual([
+      ROUTE_PATHS.signUp,
+      ROUTE_PATHS.signIn,
+    ]);
+    expect(auth?.routes.every((route) => route.guard === 'public')).toBe(true);
+    expect(auth?.routes.map((route) => route.meta?.titleKey)).toEqual([
+      'sign_up.title',
+      'sign_in.title',
+    ]);
+  });
+});

--- a/tests/unit/routes/registry.test.ts
+++ b/tests/unit/routes/registry.test.ts
@@ -20,13 +20,15 @@ describe('route registry', () => {
 
   it('declares the app-shell home (protected) and 404 (public) routes', () => {
     const shell = registry.find((module) => module.id === 'app.shell');
-    const [home, notFound] = shell?.routes ?? [];
+    // Select by stable identity, not array position, so reordering can't silently
+    // pass with the wrong fixtures.
+    const home = shell?.routes.find((route) => route.index === true);
+    const notFound = shell?.routes.find((route) => route.path === ROUTE_PATHS.notFound);
 
-    expect(home.index).toBe(true);
-    expect(home.guard).toBe('protected');
-    expect(home.meta?.permission).toBe('app.home');
-    expect(notFound.path).toBe(ROUTE_PATHS.notFound);
-    expect(notFound.guard).toBe('public');
+    expect(home?.guard).toBe('protected');
+    expect(home?.meta?.permission).toBe('app.home');
+    expect(notFound).toBeDefined();
+    expect(notFound?.guard).toBe('public');
   });
 
   it('declares the auth pages as public routes carrying their title metadata', () => {

--- a/tests/unit/routes/route-composer.test.tsx
+++ b/tests/unit/routes/route-composer.test.tsx
@@ -1,0 +1,91 @@
+import type { ComponentType, ReactElement } from 'react';
+import type { RouteObject } from 'react-router-dom';
+
+import RouteError from '@/components/error-boundary/route-error';
+import AppLayout from '@/components/layouts/app-layout';
+import RootLayout from '@/components/layouts/root-layout';
+import registry from '@/routes/registry';
+import routeComposer from '@/routes/route-composer';
+import ROUTE_PATHS from '@/routes/route-paths';
+import type { RouteModule } from '@/routes/types/route-module';
+import ProtectedRoute from '@auth/components/protected-route';
+
+const page = (): Promise<{ default: ComponentType }> =>
+  Promise.resolve({ default: (): null => null });
+
+const typeOf = (route: RouteObject): unknown => (route.element as ReactElement).type;
+const isLayout = (route: RouteObject): boolean =>
+  route.path === undefined && Boolean(route.children);
+
+describe('route composer', () => {
+  it('wraps every route in a single RootLayout with a route error boundary (invariant A)', () => {
+    const tree = routeComposer.compose(registry);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].path).toBe(ROUTE_PATHS.home);
+    expect(typeOf(tree[0])).toBe(RootLayout);
+    expect((tree[0].errorElement as ReactElement).type).toBe(RouteError);
+  });
+
+  it('nests protected routes under ProtectedRoute then AppLayout (invariants B, D)', () => {
+    const tree = routeComposer.compose(registry);
+    const branch = tree[0].children?.find(isLayout) as RouteObject;
+    const layout = branch.children?.[0] as RouteObject;
+
+    expect(typeOf(branch)).toBe(ProtectedRoute);
+    expect(typeOf(layout)).toBe(AppLayout);
+    expect(layout.children?.some((route) => route.index)).toBe(true);
+  });
+
+  it('keeps public routes directly under RootLayout, never under AppLayout (invariant B)', () => {
+    const tree = routeComposer.compose(registry);
+    // Everything that is not the protected layout branch is a flat public route.
+    const flat = (tree[0].children ?? []).filter((child) => !isLayout(child));
+
+    // A protected route (the home index route) must never leak into the flat list.
+    expect(flat.every((child) => child.index !== true)).toBe(true);
+    expect(flat.map((child) => child.path)).toEqual([
+      ROUTE_PATHS.notFound,
+      ROUTE_PATHS.signUp,
+      ROUTE_PATHS.signIn,
+    ]);
+  });
+
+  it('omits the protected branch when no route is protected (edge: empty branch)', () => {
+    const modules: RouteModule[] = [
+      { id: 'only-public', routes: [{ path: '/p', guard: 'public', load: page }] },
+    ];
+    const tree = routeComposer.compose(modules);
+
+    expect(tree[0].children?.some(isLayout)).toBe(false);
+  });
+
+  it('composes a module that declares no routes into a childless root (edge: empty module)', () => {
+    const tree = routeComposer.compose([{ id: 'empty', routes: [] }]);
+
+    expect(tree).toHaveLength(1);
+    expect(typeOf(tree[0])).toBe(RootLayout);
+    expect(tree[0].children).toEqual([]);
+  });
+
+  it('maps nested child routes recursively (edge: nested children)', () => {
+    const modules: RouteModule[] = [
+      {
+        id: 'nested',
+        routes: [
+          {
+            path: '/parent',
+            guard: 'public',
+            load: page,
+            children: [{ path: 'child', load: page }],
+          },
+        ],
+      },
+    ];
+    const tree = routeComposer.compose(modules);
+    const parent = tree[0].children?.find((child) => child.path === '/parent') as RouteObject;
+
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children?.[0].path).toBe('child');
+  });
+});

--- a/tests/unit/routes/route-validator.test.ts
+++ b/tests/unit/routes/route-validator.test.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 
 import routeValidator from '@/routes/route-validator';
+import type { AppRouteObject } from '@/routes/types/app-route';
 import type { RouteModule } from '@/routes/types/route-module';
 
 const page = (): Promise<{ default: ComponentType }> =>
@@ -10,7 +11,7 @@ describe('route validator', () => {
   it('accepts unique module ids and locatable routes', () => {
     const modules: RouteModule[] = [
       { id: 'a', routes: [{ index: true, load: page }] },
-      { id: 'b', routes: [{ path: '/b', load: page }] },
+      { id: 'b', routes: [{ path: '/b', guard: 'protected', load: page }] },
     ];
 
     expect(() => routeValidator.validate(modules)).not.toThrow();
@@ -26,10 +27,33 @@ describe('route validator', () => {
   });
 
   it('rejects a route with neither path nor index (negative)', () => {
-    const modules: RouteModule[] = [{ id: 'a', routes: [{ load: page }] }];
+    // The discriminated union forbids this at compile time; cast to exercise the
+    // runtime guard that still protects dynamically-built contracts.
+    const modules: RouteModule[] = [
+      { id: 'a', routes: [{ load: page } as unknown as AppRouteObject] },
+    ];
 
     expect(() => routeValidator.validate(modules)).toThrow(
       'Route must declare a path or be an index route'
+    );
+  });
+
+  it('rejects a nested child that declares a guard (negative)', () => {
+    const modules: RouteModule[] = [
+      {
+        id: 'a',
+        routes: [
+          {
+            path: '/parent',
+            load: page,
+            children: [{ path: 'child', guard: 'protected', load: page }],
+          },
+        ],
+      },
+    ];
+
+    expect(() => routeValidator.validate(modules)).toThrow(
+      'Nested routes must not declare a guard'
     );
   });
 });

--- a/tests/unit/routes/route-validator.test.ts
+++ b/tests/unit/routes/route-validator.test.ts
@@ -1,0 +1,35 @@
+import type { ComponentType } from 'react';
+
+import routeValidator from '@/routes/route-validator';
+import type { RouteModule } from '@/routes/types/route-module';
+
+const page = (): Promise<{ default: ComponentType }> =>
+  Promise.resolve({ default: (): null => null });
+
+describe('route validator', () => {
+  it('accepts unique module ids and locatable routes', () => {
+    const modules: RouteModule[] = [
+      { id: 'a', routes: [{ index: true, load: page }] },
+      { id: 'b', routes: [{ path: '/b', load: page }] },
+    ];
+
+    expect(() => routeValidator.validate(modules)).not.toThrow();
+  });
+
+  it('rejects duplicate module ids (negative)', () => {
+    const modules: RouteModule[] = [
+      { id: 'dupe', routes: [{ path: '/x', load: page }] },
+      { id: 'dupe', routes: [{ path: '/y', load: page }] },
+    ];
+
+    expect(() => routeValidator.validate(modules)).toThrow('Duplicate route module id: dupe');
+  });
+
+  it('rejects a route with neither path nor index (negative)', () => {
+    const modules: RouteModule[] = [{ id: 'a', routes: [{ load: page }] }];
+
+    expect(() => routeValidator.validate(modules)).toThrow(
+      'Route must declare a path or be an index route'
+    );
+  });
+});

--- a/tests/unit/tooling/performance-serving.test.ts
+++ b/tests/unit/tooling/performance-serving.test.ts
@@ -48,21 +48,28 @@ describe('performance serving config', () => {
     expect(rsbuildConfigSource).not.toContain("type: 'async-chunks'");
   });
 
-  it('keeps route-level code splitting in the routes layer', () => {
+  it('keeps route-level code splitting via the module-owned route contracts', () => {
+    const mapperSource = readFile('src/routes/route-mapper.tsx');
+    const appRoutesSource = readFile('src/routes/app-routes.ts');
+    const authRoutesSource = readFile('src/modules/user/features/auth/routes/index.ts');
     const routesSource = readFile('src/routes/routes.tsx');
 
-    expect(routesSource).toContain(
-      "const SignUp = lazy(async () => import('@auth/routes/sign-up'));"
-    );
-    expect(routesSource).toContain(
-      "const SignIn = lazy(async () => import('@auth/routes/sign-in'));"
-    );
-    expect(routesSource).toContain(
-      "const ButtonExample = lazy(async () => import('@/button-example'));"
-    );
-    expect(routesSource).not.toContain("import SignUp from '@auth/routes/sign-up';");
-    expect(routesSource).not.toContain("import SignIn from '@auth/routes/sign-in';");
-    expect(routesSource).not.toContain("import ButtonExample from '@/button-example';");
+    // The composer maps each contract loader through React.lazy, so every page
+    // still resolves via its own dynamic import() chunk.
+    expect(mapperSource).toContain('lazy(route.load)');
+
+    // Each page is declared as a lazy loader inside its owning module's contract.
+    expect(appRoutesSource).toContain("import('@/button-example')");
+    expect(appRoutesSource).toContain("import('@/components/not-found/not-found')");
+    expect(authRoutesSource).toContain("import('./sign-up')");
+    expect(authRoutesSource).toContain("import('./sign-in')");
+
+    // Pages are never statically imported (which would defeat code splitting).
+    expect(routesSource).not.toContain('import SignUp');
+    expect(routesSource).not.toContain('import SignIn');
+    expect(routesSource).not.toContain('import ButtonExample');
+    expect(authRoutesSource).not.toContain("import SignUp from './sign-up'");
+    expect(authRoutesSource).not.toContain("import SignIn from './sign-in'");
   });
 
   it('keeps registration notifications out of the initial auth form chunk', () => {

--- a/tests/unit/tooling/route-registry-boundary.test.ts
+++ b/tests/unit/tooling/route-registry-boundary.test.ts
@@ -1,0 +1,42 @@
+type ForbiddenRule = {
+  name: string;
+  severity: string;
+  from: { path: string };
+  to: { path: string; pathNot: string[] };
+};
+
+type DepcruiseConfig = { forbidden: ForbiddenRule[] };
+
+const depcruise = require('../../../.dependency-cruiser.js') as DepcruiseConfig;
+
+const rule = depcruise.forbidden.find(
+  (candidate) => candidate.name === 'no-routes-import-feature-internals'
+) as ForbiddenRule;
+
+const matchesAny = (patterns: string[], value: string): boolean =>
+  patterns.some((pattern) => new RegExp(pattern).test(value));
+
+// A module owns its routes; the shell mounts a feature only through its
+// routes/index contract barrel + the guard. The deep page path is the
+// deliberate violation the rule must reject (issue #105).
+const barrel = 'src/modules/user/features/auth/routes/index.ts';
+const deepPage = 'src/modules/user/features/auth/routes/sign-up/index.tsx';
+const guard = 'src/modules/user/features/auth/components/protected-route/index.tsx';
+
+describe('route registry dependency-cruiser boundary (issue #105)', () => {
+  it('errors when the routes shell reaches into a feature internal', () => {
+    expect(rule).toBeDefined();
+    expect(rule.severity).toBe('error');
+    expect(new RegExp(rule.from.path).test('src/routes/registry.ts')).toBe(true);
+    expect(new RegExp(rule.to.path).test(deepPage)).toBe(true);
+  });
+
+  it('allows only the module-owned route contract barrel and the routing guard', () => {
+    expect(matchesAny(rule.to.pathNot, barrel)).toBe(true);
+    expect(matchesAny(rule.to.pathNot, guard)).toBe(true);
+  });
+
+  it('forbids the shell from deep-importing a feature page (bypassing the contract)', () => {
+    expect(matchesAny(rule.to.pathNot, deepPage)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #105.

Routing was still centralized: `src/routes/routes.tsx` hard-coded the whole
`createBrowserRouter([...])` tree and deep-imported every page + the guard. For a
50+ page CRM built by many parallel contributors that one file is a merge-conflict
hotspot and a central coupling node reaching across module boundaries.

This makes route declarations **module-owned typed data**. Each module/feature
exports a small route contract in its own `routes/` folder; a registry collects
the contracts and a composer assembles the exact same router tree. Adding a page
now touches only the owning module — never the app shell.

## How

- **Contract types** (`src/routes/types/`, type-only per #88): `AppRouteObject`
  (`path`/`index`, lazy `load`, declarative `guard`, `meta`) and `RouteModule`
  (`id` + `routes`).
- **Module contracts**: `src/modules/user/features/auth/routes/index.ts` (auth
  pages, public) and `src/routes/app-routes.ts` (shell home + 404). Pages stay
  `import()`-split inside the contract.
- **Registry**: `src/routes/registry.ts` collects contracts (one-line append per
  new module).
- **Composer**: `route-composer.tsx` + `route-mapper.tsx` + `route-validator.ts`
  — container-free **module singletons** (no tsyringe in the auth paint path, so
  the mobile Lighthouse budget is untouched). The composer validates contracts,
  resolves `guard: 'protected'` → `ProtectedRoute` nested under `AppLayout`, keeps
  public routes directly under `RootLayout`, and wraps each `load` in `React.lazy`.
- **`routes.tsx`** is now pure wiring:
  `createBrowserRouter(routeComposer.compose(registry))` — no route-array literal,
  no feature/module page imports.

The rendered tree is **byte-identical** to before (one `RootLayout` root with the
`RouteError` boundary, protected home index route under `ProtectedRoute`→`AppLayout`,
public `/sign-up` `/sign-in` `*` flat). react-router ranks routes by specificity,
so the reordered public children resolve identically.

## Machine-enforced boundary (config change — dependency-cruiser)

`no-routes-import-feature-internals` is **tightened**: the shell may reach a feature
only through its `routes/index` **contract barrel** + the `protected-route` guard —
deep-importing a page (`@auth/routes/sign-up`) now fails the gate.

- **Rationale**: forces the module-owned contract; the shell can no longer wire a
  page directly.
- **Impact**: the migrated tree passes `make lint-deps` (662 modules cruised, 0
  violations); the rule is unit-verified in
  `tests/unit/tooling/route-registry-boundary.test.ts` (barrel + guard allowed,
  deep page forbidden).
- **Rollback**: revert the `pathNot` of that single rule to the previous
  `routes/` prefix.

No suppressions, no threshold relaxations, no new alias.

## Acceptance criteria

- [x] Typed route contract (`AppRouteObject` + `RouteModule`) with `path`, lazy
      `load`, declarative `guard`, `meta`.
- [x] `routes.tsx` has no `createBrowserRouter` route-array literal and no
      feature/module page imports.
- [x] `/` and `/sign-up` `/sign-in` migrated to module-owned contracts; app
      renders identically (unit render + build verified; E2E/visual in CI).
- [x] Auth feature declares its routes in `.../auth/routes/index.ts` via the
      contract; placeholder `.gitignore` files removed (real files exist).
- [x] `ProtectedRoute` applied via the declarative `guard` field, not hand-wired;
      redirect covered by `protected-route.test.tsx` + composer structural test.
- [x] dependency-cruiser rule forbids the shell from deep-importing feature
      internals for routing; verified passing on the tree and failing on a
      deliberate deep-import fixture.
- [x] Adding a page = edit only the owning module's `routes/` (+ one-line
      registry append) — documented in `src/routes/README.md`.
- [x] Per-route lazy code splitting preserved (build produces separate async
      chunks per page; asserted in `performance-serving.test.ts`).
- [x] `make format && make lint` pass (eslint, tsc, markdownlint, lint-deps,
      lint-dup, lint-metrics) — no disables/exceptions/relaxations.
- [x] Unit tests: positive (compose→tree, registry shape), negative (duplicate id,
      missing path/index), edge (empty module, nested children, guarded vs public).
- [x] `CLAUDE.md` routing guidance updated (+ `src/routes/README.md`,
      `src/modules/user/README.md`).

## Verification

Local (Docker, matches CI): ESLint ✓, tsc ✓, markdownlint ✓, dependency-cruiser ✓
(0 violations), jscpd ✓ (0 clones), rca-metrics ✓, unit-client ✓ (135 suites /
1429 tests, **100% coverage** on all new files), unit-server ✓ (118), integration
✓ (374), production build ✓ (per-page async chunks). Accessibility reviewed
(accessibility-lead): routing-composition refactor preserves the RTL/`document.dir`,
single-`<main>`, and per-route `document.title` invariants — GO, no new a11y risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a module-owned route registry with typed contracts and a central composer. Adding pages now only touches the owning module and not the app shell, preserving the router tree and lazy-loading while enforcing a stricter shell-to-feature boundary per #105.

- **New Features**
  - Typed route contracts: `AppRouteObject` (discriminated union — exactly one of `index` or `path`; guards are top-level only and nested guards are rejected) and `RouteModule`. Each feature exports its routes from `routes/index.ts`; the app shell has `src/routes/app-routes.ts`.
  - Central `registry` + container-free `composer` build the same `createBrowserRouter` tree, resolving `guard: 'protected'` under `ProtectedRoute` → `AppLayout`, and mapping all pages via `React.lazy`.
  - `src/routes/routes.tsx` is wiring only; it no longer imports feature pages or declares a route-array literal.
  - Tightened `dependency-cruiser` rule blocks deep page imports from the shell; only a feature’s `routes/index` contract and the `protected-route` guard are allowed.

- **Migration**
  - To add a page: edit the owning module’s `routes/index.ts`. For a new module, append it to `src/routes/registry.ts`.
  - Add new URL constants to `src/routes/route-paths.ts`.
  - Do not edit `src/routes/routes.tsx`, the composer, or map pages directly from the shell.

<sup>Written for commit 8726dad35aecbd1434b08d449c789173a1e838da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

