### PR TITLE
ci(#47): add Dependabot for bun deps and GitHub Actions (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'bun'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'javascript'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      bun-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,3 +207,24 @@ contracts in the same change:
 Congratulations :tada::tada: The our team thanks you :sparkles:.
 
 Now that you are part of the php service template community.
+
+## Dependency updates
+
+Dependencies are kept current by [Dependabot](.github/dependabot.yml), which opens pull
+requests on a weekly schedule for two ecosystems:
+
+- `bun` — the `package.json` JavaScript dependencies. The Bun ecosystem updates the manifest
+  and `bun.lock` together in one pull request, so the `bun install --frozen-lockfile` step
+  used across the Docker images and CI stays green.
+- `github-actions` — the SHA-pinned actions in `.github/workflows/`.
+
+To keep pull request volume low, minor and patch updates are grouped into a single request
+per ecosystem while major bumps arrive individually, and `open-pull-requests-limit` is capped
+at 5.
+
+Dependabot commit headers use the conventional `chore(deps):` prefix (`chore(github-actions):`
+for the actions entry). Our commitlint `check-task-number-rule` expects a `(#N)` scope, which
+Dependabot cannot emit; that rule runs only in the local Husky `commit-msg` hook (there is no
+commitlint CI gate), so Dependabot pull requests are not blocked. Because the repository is
+squash-merge-only, add the task number to the squash commit title at merge time to keep
+`main`'s history conformant.


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` enabling weekly Dependabot updates for two
ecosystems, and documents the policy in `CONTRIBUTING.md`.

## Ecosystems

- **`bun`** — `package.json` JavaScript dependencies. Updates the manifest
  **and** `bun.lock` in one PR, keeping `bun install --frozen-lockfile`
  (Dockerfile, Apollo/Playwright images, Makefile recipes) green.
- **`github-actions`** — the SHA-pinned actions in `.github/workflows/`.

## Deviation from the issue notes (npm → bun)

Issue #47's *Notes* suggest the `npm` ecosystem. Verified against current
Dependabot docs: the `npm` ecosystem does **not** update `bun.lock` (Bun is a
separate ecosystem, GA 2025-02-13, requires Bun ≥ 1.1.39 — this repo is
1.3.5). Using `npm` would bump `package.json` while leaving `bun.lock` stale,
so every Dependabot PR would fail the `--frozen-lockfile` install used across
the Docker images and Makefile. The `bun` ecosystem avoids that drift and
satisfies the acceptance criterion ("opens PRs from `package.json` /
`bun.lock`").

## Config choices

- Minor + patch updates grouped per ecosystem to cap PR volume; major bumps
  open individually.
- `open-pull-requests-limit: 5`.
- Dependabot cannot emit the repo's `(#N)` commit scope; set it in the
  squash-merge title (documented in `CONTRIBUTING.md`).

Closes #47


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up Dependabot to update `bun` dependencies and GitHub Actions weekly, grouping minor/patch changes and keeping `bun.lock` in sync. Documented the policy in CONTRIBUTING.

- **Dependencies**
  - Use the `bun` ecosystem (not `npm`) so `package.json` and `bun.lock` update together; keeps `bun install --frozen-lockfile` green and satisfies #47.
  - Weekly on Monday; group minor/patch per ecosystem, majors separate; limit 5 open PRs.
  - Commit titles use `chore(scope):`; add the task number in the squash title at merge time (documented in CONTRIBUTING).

<sup>Written for commit 7e8893a8f2aaff93fc6307c28e4715712ff6da07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

