### PR TITLE
ci(#187): make Codecov upload fail-closed with pinned lcov path

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,3 +38,5 @@ jobs:
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
## What

Makes the Codecov upload in `.github/workflows/codecov.yml` fail-closed and
pins the coverage report path.

## Why

The upload step passed only `token`, so `fail_ci_if_error` stayed at its v4
default of `false`: an expired/rotated `CODECOV_TOKEN`, a Codecov outage, or a
moved report left the job **green** while the coverage telemetry channel
silently died.

## Change

```yaml
files: ./coverage/lcov.info
fail_ci_if_error: true
```

- Report path verified against `jest.config.ts` (`coverageDirectory:
  'coverage'`, default `lcov` reporter → `./coverage/lcov.info`).
- Both inputs verified against `codecov-action@v4` `action.yml` at the pinned
  SHA (`b9fd7d1…`).

Closes #187


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Codecov step fail-closed and pin the coverage report path in `.github/workflows/codecov.yml`. Sets `fail_ci_if_error: true` and `files: ./coverage/lcov.info` (matches Jest output) so the job fails on upload errors and doesn’t silently drop coverage, addressing #187.

<sup>Written for commit 326f15e0ee650568fe61ec7252c5490a51b9dbcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

