### PR TITLE
ci(#121): strengthen mutation testing scope, wiring, and thresholds

### DIFF
--- a/.claude/skills/mutation-testing/SKILL.md
+++ b/.claude/skills/mutation-testing/SKILL.md
@@ -15,9 +15,9 @@ mutation-testing gate" and CLAUDE.md → "Mutation testing scope and baseline".
 
 ```bash
 make test-mutation  # full local run (heavy — prefer CI)
-make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4  # one shard
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=8  # one shard
 # add MUTATION_INCREMENTAL=1 for PR/incremental mode
-make merge-mutation-reports MUTATION_SHARD_TOTAL=4  # merge shards + enforce gate
+make merge-mutation-reports MUTATION_SHARD_TOTAL=8  # merge shards + enforce gate
 ```
 
 ## Run unit AND integration in one pass

--- a/.claude/skills/mutation-testing/SKILL.md
+++ b/.claude/skills/mutation-testing/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: mutation-testing
+description: Use when configuring, running, sharding, or setting the threshold for Stryker mutation testing over a logic layer exercised by both the unit and integration Jest suites.
+---
+
+# Mutation Testing
+
+Stryker config lives in `stryker.config.mjs` (base), `stryker.shard.config.mjs` (per-shard),
+`jest.mutation.config.ts` (the Jest config Stryker runs), and `scripts/ci/mutation-scope.mjs` (the
+mutated file list). CI: `.github/workflows/mutation-testing.yml` (PR, incremental) and
+`mutation-testing-full.yml` (scheduled, authoritative). See CONTRIBUTING.md → "CI speed and the
+mutation-testing gate" and CLAUDE.md → "Mutation testing scope and baseline".
+
+## Run it
+
+```bash
+make test-mutation  # full local run (heavy — prefer CI)
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4  # one shard
+# add MUTATION_INCREMENTAL=1 for PR/incremental mode
+make merge-mutation-reports MUTATION_SHARD_TOTAL=4  # merge shards + enforce gate
+```
+
+## Run unit AND integration in one pass
+
+Stryker's `@stryker-mutator/jest-runner` (v9) does **not** support Jest `projects` with
+`coverageAnalysis: 'perTest'` — it wraps a single top-level `testEnvironment` and reads a single
+top-level `roots` (see the runner's `jest-plugins/with-coverage-analysis.js`). So union the suites
+into one flat config (`jest.mutation.config.ts`), do not use `projects`:
+
+- `roots: ['./tests/unit', './tests/integration']`, `testMatch` unioning both patterns, one
+  `testEnvironment: 'jsdom'`.
+- `collectCoverage: false` and drop `coverageThreshold` — a 100% coverage gate would abort the
+  mutation dry run.
+
+When the two suites have conflicting global setup (e.g. a unit `fetch` stub vs. integration MSW
+`server.listen({ onUnhandledRequest: 'error' })`), keep them in one flat config and branch **per
+file** on the test path — `expect.getState().testPath` is populated at `setupFilesAfterEnv`
+module-eval time in jest-circus. The integration branch just `require()`s the existing integration
+setup so nothing is duplicated (`tests/mutation/setup.ts`).
+
+## Never measure the baseline locally
+
+A widened mutation run over ts-jest is far too heavy for a dev machine: Stryker's default concurrency
+is `cores - 1` and will overload/lock up the laptop; even `--concurrency 4` in the background does.
+Per-mutant cost is dominated by ts-jest (sandbox copy + transform), so a single file can exceed nine
+minutes. **Measure the baseline in CI (sharded runners), never locally.**
+
+Set the enforced `break` from that CI measurement with a two-push flow:
+
+1. Push with a bootstrap `break` low enough to pass (clearly above any old no-op value).
+2. Read the real score from the merge gate — `make merge-mutation-reports` prints `mutationScore`
+   even when it fails the gate.
+3. Ratchet `break` to just below the measured score; fill the per-area table in CLAUDE.md.
+
+Ratchet policy: raise `break` over time, never lower it to make CI pass, never narrow the mutated
+scope to dodge a survived mutant, and never add `stryker disable` / `istanbul ignore` suppressions —
+fix survived mutants with real assertions.
+
+## Keep scope and shards in lockstep
+
+`scripts/ci/mutation-scope.mjs` is the single source of truth for the mutated file list (its
+exclusions mirror `jest.config.ts` `collectCoverageFrom`). The base config sets `mutate` to that
+list; the shard config slices the same list round-robin
+(`collectMutateFiles().filter((_, i) => i % total === index % total)`) so the union of all shards
+equals the full set exactly. Never hand-maintain a second file list.
+
+## Sharded incremental CI
+
+Reconcile sharding (feasible cold runs) with Stryker `--incremental` (fast warm PRs): each shard
+keeps its **own** `incrementalFile` (`reports/stryker-incremental-<index>.json`) restored from a
+rolling `actions/cache` key (unique run-id key + prefix `restore-keys`). A `push: main` trigger keeps
+the base warm; the scheduled workflow runs cold and from scratch as the authoritative baseline and to
+refresh the caches. The merge gate always scores the full set, so incremental never weakens it.
+
+## Accessibility scope
+
+Mutation-testing config/CI work touches no UI/HTML/JSX/CSS, so the accessibility-lead review is Not
+Applicable — record the skip reason rather than running it.

--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -514,12 +514,12 @@ module.exports = {
       name: 'tests-top-level-allowed-folders',
       comment:
         'Tests root may only contain allowed folders: apollo-server, builders, ' +
-        'e2e, integration, load, memory-leak, unit, utils, visual.',
+        'e2e, integration, load, memory-leak, mutation, unit, utils, visual.',
       severity: 'error',
       from: {
         path:
           '^tests/(?!(?:apollo-server|builders|e2e|integration|' +
-          'load|memory-leak|unit|utils|visual)/)[^/]+/',
+          'load|memory-leak|mutation|unit|utils|visual)/)[^/]+/',
       },
       to: {},
     },

--- a/.github/workflows/mutation-testing-full.yml
+++ b/.github/workflows/mutation-testing-full.yml
@@ -1,33 +1,29 @@
-name: mutation testing
+name: mutation testing (scheduled full)
 
 on:
-  pull_request:
-    branches:
-      - main
-  # Refresh each shard's incremental cache from main so pull requests branch off an accurate,
-  # warm base and only re-run mutants their diff actually touches.
-  push:
-    branches:
-      - main
+  # Weekly authoritative pass: a full, from-scratch mutation run over the whole widened scope. It
+  # re-establishes the true baseline (catching any incremental-cache drift) and refreshes each
+  # shard's incremental cache so pull-request runs stay fast and accurate. Tune the cadence here
+  # (e.g. nightly '0 3 * * *') against CI cost.
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   shard:
-    name: shard ${{ matrix.index }}
+    name: full shard ${{ matrix.index }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        # To change the shard count, keep this list and the merge job's
-        # MUTATION_SHARD_TOTAL in lock-step: index must be [0 .. TOTAL-1]. A
-        # mismatch fails closed at the merge gate's shard-count/index check.
         index: [0, 1, 2, 3]
 
     steps:
@@ -41,23 +37,19 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      # Rolling cache: the unique run-id key never hits on restore, so the newest
-      # `mutation-incremental-shard-<index>-*` cache is restored via restore-keys and a fresh one is
-      # saved at job end. Pull requests restore main's cache (base branch); the first run ever is a
-      # cold, full sharded pass that seeds it.
-      - name: Restore mutation incremental cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: reports/stryker-incremental-${{ matrix.index }}.json
-          key: mutation-incremental-shard-${{ matrix.index }}-${{ github.run_id }}
-          restore-keys: |
-            mutation-incremental-shard-${{ matrix.index }}-
-
       - name: Start dev container
         run: make start-dev
 
-      - name: Run mutation shard (incremental)
+      # No cache restore: this pass runs cold and from scratch so the score cannot inherit stale
+      # reused results. MUTATION_INCREMENTAL=1 still makes Stryker write a fresh incremental file.
+      - name: Run full mutation shard
         run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1
+
+      - name: Save refreshed mutation incremental cache
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: reports/stryker-incremental-${{ matrix.index }}.json
+          key: mutation-incremental-shard-${{ matrix.index }}-${{ github.run_id }}
 
       - name: Upload shard report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -74,9 +66,6 @@ jobs:
   merge:
     name: merge and enforce gate
     needs: shard
-    # Run even when a shard failed so the gate fails CLOSED. Without this the job
-    # would be SKIPPED on shard failure, and branch protection treats a skipped
-    # required check as passing — silently bypassing the mutation gate.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/mutation-testing-full.yml
+++ b/.github/workflows/mutation-testing-full.yml
@@ -1,10 +1,8 @@
 name: mutation testing (scheduled full)
 
 on:
-  # Weekly authoritative pass: a full, from-scratch mutation run over the whole widened scope. It
-  # re-establishes the true baseline (catching any incremental-cache drift) and refreshes each
-  # shard's incremental cache so pull-request runs stay fast and accurate. Tune the cadence here
-  # (e.g. nightly '0 3 * * *') against CI cost.
+  # Weekly authoritative pass: full, from-scratch run over the whole scope. Tune
+  # the cadence (e.g. nightly '0 3 * * *') against CI cost.
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:
@@ -24,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        index: [0, 1, 2, 3]
+        index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     steps:
       - name: Checkout code
@@ -40,10 +38,10 @@ jobs:
       - name: Start dev container
         run: make start-dev
 
-      # No cache restore: this pass runs cold and from scratch so the score cannot inherit stale
-      # reused results. MUTATION_INCREMENTAL=1 still makes Stryker write a fresh incremental file.
+      # No cache restore: this pass runs cold and from scratch so the score cannot
+      # inherit stale reused results. --incremental still writes a fresh cache.
       - name: Run full mutation shard
-        run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1
+        run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=8 MUTATION_INCREMENTAL=1
 
       - name: Save refreshed mutation incremental cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -101,7 +99,7 @@ jobs:
         run: make start-dev
 
       - name: Merge reports and enforce mutation-score gate
-        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=8
 
       - name: Stop docker test environment
         if: always()

--- a/.github/workflows/mutation-testing-full.yml
+++ b/.github/workflows/mutation-testing-full.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   shard:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  # Refresh each shard's incremental cache from main so pull requests branch off an accurate,
-  # warm base and only re-run mutants their diff actually touches.
   push:
     branches:
       - main
@@ -25,10 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # To change the shard count, keep this list and the merge job's
-        # MUTATION_SHARD_TOTAL in lock-step: index must be [0 .. TOTAL-1]. A
-        # mismatch fails closed at the merge gate's shard-count/index check.
-        index: [0, 1, 2, 3]
+        # Keep this list and the merge job's MUTATION_SHARD_TOTAL in lock-step:
+        # index must be [0 .. TOTAL-1]. A mismatch fails closed at the merge gate.
+        index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     steps:
       - name: Checkout code
@@ -41,10 +38,6 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      # Rolling cache: the unique run-id key never hits on restore, so the newest
-      # `mutation-incremental-shard-<index>-*` cache is restored via restore-keys and a fresh one is
-      # saved at job end. Pull requests restore main's cache (base branch); the first run ever is a
-      # cold, full sharded pass that seeds it.
       - name: Restore mutation incremental cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -57,7 +50,7 @@ jobs:
         run: make start-dev
 
       - name: Run mutation shard (incremental)
-        run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1
+        run: make test-mutation-shard MUTATION_SHARD_INDEX=${{ matrix.index }} MUTATION_SHARD_TOTAL=8 MUTATION_INCREMENTAL=1
 
       - name: Upload shard report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -74,9 +67,8 @@ jobs:
   merge:
     name: merge and enforce gate
     needs: shard
-    # Run even when a shard failed so the gate fails CLOSED. Without this the job
-    # would be SKIPPED on shard failure, and branch protection treats a skipped
-    # required check as passing — silently bypassing the mutation gate.
+    # Run even when a shard failed so the gate fails CLOSED. A skipped required
+    # check would otherwise count as a pass and bypass the mutation gate.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
@@ -112,7 +104,7 @@ jobs:
         run: make start-dev
 
       - name: Merge reports and enforce mutation-score gate
-        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=8
 
       - name: Stop docker test environment
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,15 +157,15 @@ Measured baseline (widened scope, unit + integration; 8-way sharded full run):
 | `…/auth/repositories/**`     | 7     | 100%           |
 | `…/auth/stores/**`           | 8     | 100%           |
 | `…/form-section/validations` | 4     | 100%           |
-| Overall (`break` = 88)       | 134   | 92.5%          |
+| Overall (`break` = 90)       | 134   | 92.5%          |
 
 The mutate scope is 154 files; 134 produced mutants in the report (the other ~20 are pure re-export
 barrels or files whose only mutants are static and skipped by `ignoreStatic`). The logic layer is
 fully detected; the overall gap is `noCoverage` mutants in non-logic files (UI/providers/routes
 exercised by e2e/visual rather than unit/integration). Detections in the async logic layer land as
 Stryker `Timeout` (a mutant that breaks a promise chain hangs its covering test), which counts as
-detected. `break` starts at 88 — below the 92.5% baseline for margin — and ratchets toward 90+ as the
-scheduled full runs confirm stability.
+detected. `break` is set to 90 — below the 92.5% baseline for margin — and ratchets toward the
+`high` = 100 target as the scheduled full runs confirm stability.
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,8 @@ Load test scenarios (configurable in `./test/load/config.json.dist`):
 
 ### CI parallelization
 
-`make test-mutation` runs the full, gated Stryker suite locally. In CI it is **sharded** across a
-4-way matrix (`make test-mutation-shard`, lean `make start-dev` container) and a final
+`make test-mutation` runs the full, gated Stryker suite locally. In CI it is **sharded** across an
+8-way matrix (`make test-mutation-shard`, lean `make start-dev` container) and a final
 `merge and enforce gate` job merges the per-shard JSON reports and re-enforces the same `break`
 threshold read from `stryker.config.mjs` (`make merge-mutation-reports`). On pull requests the shards
 run **incrementally** (`MUTATION_INCREMENTAL=1`, per-shard `actions/cache`), so only mutants the diff
@@ -137,7 +137,11 @@ source of truth in `scripts/ci/mutation-scope.mjs`, whose exclusions mirror `jes
 `collectCoverageFrom` (types, styles, stories, generated code, DI-free i18n). Stryker runs unit **and**
 integration tests via `jest.mutation.config.ts` — a flat union of both suites, since Stryker's
 jest-runner cannot use Jest `projects` with `perTest` coverage — so repository/service/store mutants
-are killed by the integration tests that assert on them.
+are killed by the integration tests that assert on them. The mutation config excludes the
+`tests/unit/{tooling,scripts,performance,load}` meta-tests (they read source as text and break under
+instrumentation) and uses ts-jest `isolatedModules`; `stryker.config.mjs` sets `ignoreStatic: true`.
+These keep the run affordable — CI runners are 2-core, so parallelism comes from the 8-way shard
+count, not Stryker's in-process concurrency.
 
 `thresholds` in `stryker.config.mjs` is a coherent band `{ high, low, break }`. `break` is the
 enforced floor, set at/just below the measured baseline. **Ratchet policy:** raise `break` toward

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,12 +119,40 @@ Load test scenarios (configurable in `./test/load/config.json.dist`):
 `make test-mutation` runs the full, gated Stryker suite locally. In CI it is **sharded** across a
 4-way matrix (`make test-mutation-shard`, lean `make start-dev` container) and a final
 `merge and enforce gate` job merges the per-shard JSON reports and re-enforces the same `break`
-threshold read from `stryker.config.mjs` (`make merge-mutation-reports`) — identical gate, much
-faster (~1h → fits the PR budget). Lighthouse desktop/mobile run as a parallel matrix
-(`performance-testing.yml`). Every workflow declares `concurrency` with `cancel-in-progress: true`
-(release/sandbox workflows use `false`) so a new push cancels the previous run. No gate is weakened
-and no threshold changes. See "CI speed and the mutation-testing gate" in `CONTRIBUTING.md` for the
+threshold read from `stryker.config.mjs` (`make merge-mutation-reports`). On pull requests the shards
+run **incrementally** (`MUTATION_INCREMENTAL=1`, per-shard `actions/cache`), so only mutants the diff
+touches re-run while the gate still scores the whole set; `mutation-testing-full.yml` runs the same
+matrix weekly, cold and from scratch, as the authoritative baseline. Lighthouse desktop/mobile run as
+a parallel matrix (`performance-testing.yml`). Every workflow declares `concurrency` with
+`cancel-in-progress: true` (release/sandbox workflows use `false`) so a new push cancels the previous
+run. No gate is weakened. See "CI speed and the mutation-testing gate" in `CONTRIBUTING.md` for the
 full flow and the branch-protection required-checks update.
+
+### Mutation testing scope and baseline
+
+Stryker mutates the **logic layer across all modules**, not just `src/components/`: repositories
+(`src/modules/user/features/auth/repositories/**`), application services (`src/services/**`), auth
+stores/state, validation policies, and the module `.tsx` surface. The mutated file list is the single
+source of truth in `scripts/ci/mutation-scope.mjs`, whose exclusions mirror `jest.config.ts`
+`collectCoverageFrom` (types, styles, stories, generated code, DI-free i18n). Stryker runs unit **and**
+integration tests via `jest.mutation.config.ts` — a flat union of both suites, since Stryker's
+jest-runner cannot use Jest `projects` with `perTest` coverage — so repository/service/store mutants
+are killed by the integration tests that assert on them.
+
+`thresholds` in `stryker.config.mjs` is a coherent band `{ high, low, break }`. `break` is the
+enforced floor, set at/just below the measured baseline. **Ratchet policy:** raise `break` toward
+`high` as suites improve; never lower it to make CI pass, never narrow the mutated scope to dodge a
+survived mutant, and never add a mutation/coverage suppression — fix survived mutants with real
+assertions.
+
+Measured baseline (widened scope, unit + integration; established by the introducing full run):
+
+| Area                     | Files | Mutation score              |
+| ------------------------ | ----- | --------------------------- |
+| `src/services/**`        | —     | _pending first full CI run_ |
+| `…/auth/repositories/**` | —     | _pending first full CI run_ |
+| `…/auth/stores/**`       | —     | _pending first full CI run_ |
+| Overall (`break` floor)  | —     | _pending first full CI run_ |
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,14 +149,21 @@ enforced floor, set at/just below the measured baseline. **Ratchet policy:** rai
 survived mutant, and never add a mutation/coverage suppression — fix survived mutants with real
 assertions.
 
-Measured baseline (widened scope, unit + integration; established by the introducing full run):
+Measured baseline (widened scope, unit + integration; 8-way sharded full run):
 
-| Area                     | Files | Mutation score              |
-| ------------------------ | ----- | --------------------------- |
-| `src/services/**`        | —     | _pending first full CI run_ |
-| `…/auth/repositories/**` | —     | _pending first full CI run_ |
-| `…/auth/stores/**`       | —     | _pending first full CI run_ |
-| Overall (`break` floor)  | —     | _pending first full CI run_ |
+| Area                         | Files | Mutation score |
+| ---------------------------- | ----- | -------------- |
+| `src/services/**`            | 9     | 100%           |
+| `…/auth/repositories/**`     | 7     | 100%           |
+| `…/auth/stores/**`           | 8     | 100%           |
+| `…/form-section/validations` | 4     | 100%           |
+| Overall (`break` = 88)       | 134   | 92.5%          |
+
+The logic layer is fully detected; the overall gap is `noCoverage` mutants in non-logic files
+(UI/providers/routes exercised by e2e/visual rather than unit/integration). Detections in the async
+logic layer land as Stryker `Timeout` (a mutant that breaks a promise chain hangs its covering test),
+which counts as detected. `break` starts at 88 — below the 92.5% baseline for margin — and ratchets
+toward 90+ as the scheduled full runs confirm stability.
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,13 @@ Measured baseline (widened scope, unit + integration; 8-way sharded full run):
 | `…/form-section/validations` | 4     | 100%           |
 | Overall (`break` = 88)       | 134   | 92.5%          |
 
-The logic layer is fully detected; the overall gap is `noCoverage` mutants in non-logic files
-(UI/providers/routes exercised by e2e/visual rather than unit/integration). Detections in the async
-logic layer land as Stryker `Timeout` (a mutant that breaks a promise chain hangs its covering test),
-which counts as detected. `break` starts at 88 — below the 92.5% baseline for margin — and ratchets
-toward 90+ as the scheduled full runs confirm stability.
+The mutate scope is 154 files; 134 produced mutants in the report (the other ~20 are pure re-export
+barrels or files whose only mutants are static and skipped by `ignoreStatic`). The logic layer is
+fully detected; the overall gap is `noCoverage` mutants in non-logic files (UI/providers/routes
+exercised by e2e/visual rather than unit/integration). Detections in the async logic layer land as
+Stryker `Timeout` (a mutant that breaks a promise chain hangs its covering test), which counts as
+detected. `break` starts at 88 — below the 92.5% baseline for margin — and ratchets toward 90+ as the
+scheduled full runs confirm stability.
 
 ## Code Quality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,14 @@ the union of every shard equals the full set exactly. Stryker runs a dedicated J
 suites, so a repository/service/store mutant is killed by the integration test that actually asserts
 on it instead of being left uncovered. (Stryker's jest-runner can't use Jest `projects` with
 `perTest` coverage, so the suites are unioned into one flat config; `tests/mutation/setup.ts` keys
-off the test path so the unit fetch-stub and the integration MSW server never collide.)
+off the test path so the unit fetch-stub and the integration MSW server never collide.) That config
+excludes the `tests/unit/{tooling,scripts,performance,load}` meta-tests — they read source files as
+text and break once Stryker instruments them — and runs ts-jest with `isolatedModules` (no per-file
+type-check). `stryker.config.mjs` sets `ignoreStatic: true`. Those three keep the run affordable:
+CI runners are 2-core, so parallelism comes from the shard count (currently 8), not from Stryker's
+in-process concurrency.
 
-`mutation-testing.yml` fans `make test-mutation-shard` across a 4-way matrix; each shard mutates a
+`mutation-testing.yml` fans `make test-mutation-shard` across an 8-way matrix; each shard mutates a
 deterministic, disjoint slice and uploads a per-shard JSON report. On pull requests the shards run
 **incrementally** (`MUTATION_INCREMENTAL=1` → Stryker `--incremental`): each shard restores its own
 `reports/stryker-incremental-<index>.json` from an `actions/cache` rolling key and only re-runs
@@ -148,7 +153,7 @@ against a lean dev-only container (`make start-dev`) because mutation tests mock
 need neither Mockoon nor Apollo.
 
 `mutation-testing-full.yml` runs weekly (`schedule:` + `workflow_dispatch`) as the authoritative
-pass: the same 4-way matrix, but **cold and from scratch** so the score can't inherit stale reused
+pass: the same 8-way matrix, but **cold and from scratch** so the score can't inherit stale reused
 results, and it saves a fresh incremental cache for PRs. Tune its cadence (e.g. nightly
 `0 3 * * *`) against CI cost. It is not a pull-request required check.
 
@@ -168,9 +173,9 @@ Run it locally either way (heavy — prefer letting CI shard it):
 make test-mutation                                   # full, gated, single-process run
 # or reproduce the sharded CI flow against a running dev service:
 make start-dev
-make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4   # repeat for 1..3
-make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1  # PR mode
-make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=8   # repeat for 1..7
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=8 MUTATION_INCREMENTAL=1  # PR mode
+make merge-mutation-reports MUTATION_SHARD_TOTAL=8
 ```
 
 To change the shard count, keep the `index` matrix in both `mutation-testing.yml` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,31 +121,61 @@ that PR instead of letting it finish. The release and sandbox-lifecycle workflow
 (`autorelease`, `sandbox-creating`, `sandbox-deleting`) use `cancel-in-progress: false` so an
 in-flight release or sandbox trigger is never aborted.
 
-**Mutation testing is sharded, not slowed.** Stryker over the whole component surface
-(`src/components/**/*.tsx`) took close to an hour as one job. `mutation-testing.yml` now fans
-`make test-mutation-shard` across a 4-way matrix; each shard mutates a deterministic, disjoint slice
-of the same file set (`stryker.shard.config.mjs`) and uploads a per-shard JSON report. A final
-`merge and enforce gate` job runs `make merge-mutation-reports`, which unions the shard reports and
-re-enforces the **unchanged** Stryker `break` threshold (read live from `stryker.config.mjs`) over
-the whole set, computing the mutation score exactly as an unsharded run would. Sharding by file is
-score-preserving: each mutant runs against the full suite regardless of which shard owns it. A
-missing shard report makes the merge fail closed (it never passes the gate vacuously). The merge math
-is unit-tested in `tests/unit/mutation-report.test.ts`. Shards run against a lean dev-only container
-(`make start-dev`) because mutation tests mock all backends and need neither Mockoon nor Apollo.
+**Mutation testing is sharded and incremental, not slowed.** Stryker mutates the whole logic layer
+plus module UI — repositories, `src/services/**`, auth stores/state, validation policies, and the
+module `.tsx` surface — not just `src/components/**/*.tsx`. The mutated set is the single source of
+truth in [`scripts/ci/mutation-scope.mjs`](scripts/ci/mutation-scope.mjs), whose exclusions mirror
+`jest.config.ts` `collectCoverageFrom` (types, styles, stories, generated code, DI-free i18n);
+`stryker.config.mjs` (`mutate`) and `stryker.shard.config.mjs` (per-shard slice) both consume it, so
+the union of every shard equals the full set exactly. Stryker runs a dedicated Jest config
+([`jest.mutation.config.ts`](jest.mutation.config.ts)) that unions the unit **and** integration
+suites, so a repository/service/store mutant is killed by the integration test that actually asserts
+on it instead of being left uncovered. (Stryker's jest-runner can't use Jest `projects` with
+`perTest` coverage, so the suites are unioned into one flat config; `tests/mutation/setup.ts` keys
+off the test path so the unit fetch-stub and the integration MSW server never collide.)
 
-Run it locally either way:
+`mutation-testing.yml` fans `make test-mutation-shard` across a 4-way matrix; each shard mutates a
+deterministic, disjoint slice and uploads a per-shard JSON report. On pull requests the shards run
+**incrementally** (`MUTATION_INCREMENTAL=1` → Stryker `--incremental`): each shard restores its own
+`reports/stryker-incremental-<index>.json` from an `actions/cache` rolling key and only re-runs
+mutants the diff touches — the report still lists every mutant, so the gate stays exact. The first
+run (cold cache) is a full sharded pass that seeds the cache; a `push:` trigger on `main` refreshes
+it so PRs branch off a warm base. A final `merge and enforce gate` job runs
+`make merge-mutation-reports`, which unions the shard reports and enforces the Stryker `break`
+threshold (read live from `stryker.config.mjs`) over the whole set. A missing shard report makes the
+merge fail closed. The merge math is unit-tested in `tests/unit/mutation-report.test.ts`. Shards run
+against a lean dev-only container (`make start-dev`) because mutation tests mock all backends and
+need neither Mockoon nor Apollo.
+
+`mutation-testing-full.yml` runs weekly (`schedule:` + `workflow_dispatch`) as the authoritative
+pass: the same 4-way matrix, but **cold and from scratch** so the score can't inherit stale reused
+results, and it saves a fresh incremental cache for PRs. Tune its cadence (e.g. nightly
+`0 3 * * *`) against CI cost. It is not a pull-request required check.
+
+**Scope, threshold band, and ratchet policy.** `stryker.config.mjs` sets
+`thresholds: { high, low, break }` as a coherent band. `break` is the enforced floor, set at/just
+below the measured baseline; `high`/`low` colour the HTML report. Ratchet policy: raise `break`
+toward `high` as suites improve — **never lower it to make CI pass**, and never narrow the mutated
+scope to dodge a survived mutant. Fix a survived mutant with a real assertion, not an exclusion or a
+`// stryker disable` / `istanbul ignore` suppression. Excluding a file from
+`scripts/ci/mutation-scope.mjs` is only legitimate for genuine non-logic (types, styles, stories,
+generated code, i18n). The measured per-area baseline is recorded in
+[`CLAUDE.md`](CLAUDE.md) under "Mutation testing scope and baseline".
+
+Run it locally either way (heavy — prefer letting CI shard it):
 
 ```bash
 make test-mutation                                   # full, gated, single-process run
 # or reproduce the sharded CI flow against a running dev service:
 make start-dev
 make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4   # repeat for 1..3
+make test-mutation-shard MUTATION_SHARD_INDEX=0 MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1  # PR mode
 make merge-mutation-reports MUTATION_SHARD_TOTAL=4
 ```
 
-To change the shard count, keep the `index` matrix in `mutation-testing.yml` and the merge job's
-`MUTATION_SHARD_TOTAL` in lock-step (`index` must be `[0 .. TOTAL-1]`); a mismatch fails closed at
-the merge gate rather than passing silently.
+To change the shard count, keep the `index` matrix in both `mutation-testing.yml` and
+`mutation-testing-full.yml` and the merge job's `MUTATION_SHARD_TOTAL` in lock-step (`index` must be
+`[0 .. TOTAL-1]`); a mismatch fails closed at the merge gate rather than passing silently.
 
 **Lighthouse runs as a matrix.** `performance-testing.yml` runs the desktop and mobile audits as two
 parallel matrix cells (`lighthouse desktop` / `lighthouse mobile`) instead of sequentially in one

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ UNIT_TESTS                  = $(MAKE) ensure-dev && $(EXEC_DEV_TTYLESS) env
 MUTATION_SHARD_TOTAL        ?= 1
 MUTATION_SHARD_INDEX        ?= 0
 MUTATION_REPORTS_DIR         = reports/mutation
+MUTATION_INCREMENTAL        ?=
+STRYKER_INCREMENTAL_FLAG     = $(if $(filter 1 true,$(MUTATION_INCREMENTAL)),--incremental,)
 
 STORYBOOK_BUILD             = $(BUNX) storybook build
 STORYBOOK_START             = $(STORYBOOK_CMD) --host 0.0.0.0 --no-open
@@ -546,7 +548,7 @@ test-mutation: ## Run mutation tests using Stryker after building the app
 	$(STRYKER_CMD)
 
 test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL in the running dev container
-	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) dev bun x stryker run stryker.shard.config.mjs
+	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) dev bun x stryker run stryker.shard.config.mjs $(STRYKER_INCREMENTAL_FLAG)
 
 merge-mutation-reports: ## Merge mutation shard reports and re-enforce the Stryker break gate in the running dev container
 	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) dev bun scripts/ci/merge-mutation-reports.ts

--- a/jest.mutation.config.ts
+++ b/jest.mutation.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from 'jest';
+
+import base from './jest.config';
+
+/**
+ * Jest config used only by Stryker. Stryker's jest-runner does not support Jest `projects` with
+ * `coverageAnalysis: perTest` (it reads a single top-level `testEnvironment`/`roots`), so the unit
+ * and integration suites are unioned into one flat config instead. Per-file setup lives in
+ * tests/mutation/setup.ts, which keys off the test path so the unit fetch-stub and the integration
+ * MSW server never collide. Coverage is disabled here: Stryker instruments its own coverage, and
+ * the 100% `coverageThreshold` from jest.config.ts would otherwise fail the mutation dry run.
+ */
+const config: Config = {
+  ...base,
+  roots: ['./tests/unit', './tests/integration'],
+  testMatch: [
+    '<rootDir>/tests/unit/**/*.test.{ts,tsx,js,jsx}',
+    '<rootDir>/tests/integration/**/*.integration.test.{ts,tsx}',
+  ],
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/tests/mutation/setup.ts'],
+  collectCoverage: false,
+  coverageThreshold: undefined,
+};
+
+export default config;

--- a/jest.mutation.config.ts
+++ b/jest.mutation.config.ts
@@ -2,14 +2,6 @@ import type { Config } from 'jest';
 
 import base from './jest.config';
 
-/**
- * Jest config used only by Stryker. Stryker's jest-runner does not support Jest `projects` with
- * `coverageAnalysis: perTest` (it reads a single top-level `testEnvironment`/`roots`), so the unit
- * and integration suites are unioned into one flat config instead. Per-file setup lives in
- * tests/mutation/setup.ts, which keys off the test path so the unit fetch-stub and the integration
- * MSW server never collide. Coverage is disabled here: Stryker instruments its own coverage, and
- * the 100% `coverageThreshold` from jest.config.ts would otherwise fail the mutation dry run.
- */
 const config: Config = {
   ...base,
   roots: ['./tests/unit', './tests/integration'],
@@ -17,8 +9,19 @@ const config: Config = {
     '<rootDir>/tests/unit/**/*.test.{ts,tsx,js,jsx}',
     '<rootDir>/tests/integration/**/*.integration.test.{ts,tsx}',
   ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/tests/unit/tooling/',
+    '/tests/unit/scripts/',
+    '/tests/unit/performance/',
+    '/tests/unit/load/',
+  ],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/tests/mutation/setup.ts'],
+  transform: {
+    ...base.transform,
+    '^.+\\.(ts|tsx)$': ['ts-jest', { isolatedModules: true }],
+  },
   collectCoverage: false,
   coverageThreshold: undefined,
 };

--- a/scripts/ci/mutation-scope.mjs
+++ b/scripts/ci/mutation-scope.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MUTATION_ROOT = 'src';
+
+/**
+ * Path predicate excluding non-logic sources from mutation. Mirrors the negations in
+ * `jest.config.ts` `collectCoverageFrom` so mutation scope and coverage scope stay identical
+ * (types, styles, stories, generated code, DI-free primitives). `rel` is a POSIX path.
+ */
+function isExcluded(rel) {
+  return (
+    rel.endsWith('.d.ts') ||
+    /\.(test|stories)\.(ts|tsx)$/.test(rel) ||
+    rel.endsWith('/types.ts') ||
+    rel.includes('/types/') ||
+    rel.includes('/styles/') ||
+    rel.endsWith('/theme.ts') ||
+    rel.includes('/__mocks__/') ||
+    rel.includes('/__fixtures__/') ||
+    rel.startsWith('src/test-utils/') ||
+    rel.startsWith('src/api/generated/') ||
+    rel.includes('/i18n/') ||
+    rel === 'src/index.tsx'
+  );
+}
+
+function collectSourceFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.posix.join(dir, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(full);
+    if (/\.(ts|tsx)$/.test(entry.name)) return [full];
+    return [];
+  });
+}
+
+/**
+ * Concrete, sorted list of source files Stryker mutates. The single source of truth for both
+ * `stryker.config.mjs` (`mutate`) and `stryker.shard.config.mjs` (sliced per shard), so the
+ * union of every shard equals the full set exactly.
+ */
+export function collectMutateFiles() {
+  return collectSourceFiles(MUTATION_ROOT)
+    .filter((file) => !isExcluded(file))
+    .sort();
+}

--- a/scripts/ci/mutation-scope.mjs
+++ b/scripts/ci/mutation-scope.mjs
@@ -3,11 +3,6 @@ import path from 'node:path';
 
 const MUTATION_ROOT = 'src';
 
-/**
- * Path predicate excluding non-logic sources from mutation. Mirrors the negations in
- * `jest.config.ts` `collectCoverageFrom` so mutation scope and coverage scope stay identical
- * (types, styles, stories, generated code, DI-free primitives). `rel` is a POSIX path.
- */
 function isExcluded(rel) {
   return (
     rel.endsWith('.d.ts') ||
@@ -34,11 +29,6 @@ function collectSourceFiles(dir) {
   });
 }
 
-/**
- * Concrete, sorted list of source files Stryker mutates. The single source of truth for both
- * `stryker.config.mjs` (`mutate`) and `stryker.shard.config.mjs` (sliced per shard), so the
- * union of every shard equals the full set exactly.
- */
 export function collectMutateFiles() {
   return collectSourceFiles(MUTATION_ROOT)
     .filter((file) => !isExcluded(file))

--- a/scripts/ci/mutation-scope.mjs
+++ b/scripts/ci/mutation-scope.mjs
@@ -3,21 +3,23 @@ import path from 'node:path';
 
 const MUTATION_ROOT = 'src';
 
+const EXCLUDED_PATTERNS = [
+  /\.d\.ts$/,
+  /\.(test|stories)\.(ts|tsx)$/,
+  /\/types\.ts$/,
+  /\/types\//,
+  /\/styles\//,
+  /\/theme\.ts$/,
+  /\/__mocks__\//,
+  /\/__fixtures__\//,
+  /^src\/test-utils\//,
+  /^src\/api\/generated\//,
+  /\/i18n\//,
+  /^src\/index\.tsx$/,
+];
+
 function isExcluded(rel) {
-  return (
-    rel.endsWith('.d.ts') ||
-    /\.(test|stories)\.(ts|tsx)$/.test(rel) ||
-    rel.endsWith('/types.ts') ||
-    rel.includes('/types/') ||
-    rel.includes('/styles/') ||
-    rel.endsWith('/theme.ts') ||
-    rel.includes('/__mocks__/') ||
-    rel.includes('/__fixtures__/') ||
-    rel.startsWith('src/test-utils/') ||
-    rel.startsWith('src/api/generated/') ||
-    rel.includes('/i18n/') ||
-    rel === 'src/index.tsx'
-  );
+  return EXCLUDED_PATTERNS.some((pattern) => pattern.test(rel));
 }
 
 function collectSourceFiles(dir) {

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -24,7 +24,7 @@ const config = {
     '.junie/',
     '.qlty/',
   ],
-  thresholds: { high: 90, low: 70, break: 30 },
+  thresholds: { high: 95, low: 90, break: 88 },
 };
 
 export default config;

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,3 +1,5 @@
+import { collectMutateFiles } from './scripts/ci/mutation-scope.mjs';
+
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {
   packageManager: 'npm',
@@ -7,10 +9,18 @@ const config = {
   plugins: ['@stryker-mutator/jest-runner'],
   tsconfigFile: 'tsconfig.json',
   jest: {
-    configFile: 'jest.config.ts',
+    // Union of the unit and integration suites so mutants in the logic layer are killed by the
+    // tests that actually assert on it (see jest.mutation.config.ts). The default jest.config.ts
+    // would only run tests/unit and leave repository/service/store mutants uncovered.
+    configFile: 'jest.mutation.config.ts',
     enableFindRelatedTests: false,
   },
-  mutate: ['./src/components/**/*.tsx'],
+  // Widened from ./src/components/**/*.tsx to the whole logic layer + module UI, minus non-logic
+  // files (types, styles, stories, generated, DI-free i18n). Single source of truth shared with
+  // stryker.shard.config.mjs so the union of shards equals this exact set.
+  mutate: collectMutateFiles(),
+  // PR runs pass --incremental so only changed mutants re-run; this is the cached report path.
+  incrementalFile: 'reports/stryker-incremental.json',
   ignorePatterns: [
     '**/*.stories.tsx',
     '**/*.stories.ts',
@@ -20,7 +30,10 @@ const config = {
     '.junie/',
     '.qlty/',
   ],
-  thresholds: { high: 100, break: 2.17 }, // TODO: Update `break` to 90 once full test coverage is implemented
+  // Ratchet policy: raise `break` toward `high` as suites improve; never lower it to make CI pass
+  // (see the mutation-testing section in CONTRIBUTING.md). `break` is a bootstrap floor pending the
+  // first full sharded run's measured baseline, after which it is ratcheted to just below it.
+  thresholds: { high: 90, low: 70, break: 30 },
 };
 
 export default config;

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -6,20 +6,14 @@ const config = {
   reporters: ['html', 'clear-text', 'progress'],
   testRunner: 'jest',
   coverageAnalysis: 'perTest',
+  ignoreStatic: true,
   plugins: ['@stryker-mutator/jest-runner'],
   tsconfigFile: 'tsconfig.json',
   jest: {
-    // Union of the unit and integration suites so mutants in the logic layer are killed by the
-    // tests that actually assert on it (see jest.mutation.config.ts). The default jest.config.ts
-    // would only run tests/unit and leave repository/service/store mutants uncovered.
     configFile: 'jest.mutation.config.ts',
     enableFindRelatedTests: false,
   },
-  // Widened from ./src/components/**/*.tsx to the whole logic layer + module UI, minus non-logic
-  // files (types, styles, stories, generated, DI-free i18n). Single source of truth shared with
-  // stryker.shard.config.mjs so the union of shards equals this exact set.
   mutate: collectMutateFiles(),
-  // PR runs pass --incremental so only changed mutants re-run; this is the cached report path.
   incrementalFile: 'reports/stryker-incremental.json',
   ignorePatterns: [
     '**/*.stories.tsx',
@@ -30,9 +24,6 @@ const config = {
     '.junie/',
     '.qlty/',
   ],
-  // Ratchet policy: raise `break` toward `high` as suites improve; never lower it to make CI pass
-  // (see the mutation-testing section in CONTRIBUTING.md). `break` is a bootstrap floor pending the
-  // first full sharded run's measured baseline, after which it is ratcheted to just below it.
   thresholds: { high: 90, low: 70, break: 30 },
 };
 

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -24,7 +24,7 @@ const config = {
     '.junie/',
     '.qlty/',
   ],
-  thresholds: { high: 95, low: 90, break: 88 },
+  thresholds: { high: 100, low: 90, break: 90 },
 };
 
 export default config;

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -12,9 +12,6 @@ const config = {
   mutate: sliced,
   reporters: ['json', 'clear-text', 'progress'],
   jsonReporter: { fileName: `reports/mutation/mutation-shard-${index}.json` },
-  // Per-shard incremental cache: with `--incremental`, each shard reuses prior results for its own
-  // unchanged slice and only re-runs mutants touched by the diff. The gate stays exact because the
-  // json report still lists every mutant in the slice (reused ones keep their prior status).
   incrementalFile: `reports/stryker-incremental-${index}.json`,
   thresholds: { ...base.thresholds, break: null },
 };

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -1,10 +1,9 @@
-import { collectMutateFiles } from './scripts/ci/mutation-scope.mjs';
 import base from './stryker.config.mjs';
 
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
 
-const sliced = collectMutateFiles().filter((_, i) => i % total === index % total);
+const sliced = base.mutate.filter((_, i) => i % total === index % total);
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -2,8 +2,11 @@ import base from './stryker.config.mjs';
 
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
+if (index >= total) {
+  throw new Error(`MUTATION_SHARD_INDEX (${index}) must be < MUTATION_SHARD_TOTAL (${total}).`);
+}
 
-const sliced = base.mutate.filter((_, i) => i % total === index % total);
+const sliced = base.mutate.filter((_, i) => i % total === index);
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -1,24 +1,10 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
+import { collectMutateFiles } from './scripts/ci/mutation-scope.mjs';
 import base from './stryker.config.mjs';
 
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
 
-/** Recursively collect the `.tsx` files Stryker mutates (excluding stories) under `dir`. */
-function collectTsxFiles(dir) {
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) return collectTsxFiles(full);
-    if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.stories.tsx')) return [full];
-    return [];
-  });
-}
-
-const sliced = collectTsxFiles('src/components')
-  .sort()
-  .filter((_, i) => i % total === index % total);
+const sliced = collectMutateFiles().filter((_, i) => i % total === index % total);
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {
@@ -26,6 +12,10 @@ const config = {
   mutate: sliced,
   reporters: ['json', 'clear-text', 'progress'],
   jsonReporter: { fileName: `reports/mutation/mutation-shard-${index}.json` },
+  // Per-shard incremental cache: with `--incremental`, each shard reuses prior results for its own
+  // unchanged slice and only re-runs mutants touched by the diff. The gate stays exact because the
+  // json report still lists every mutant in the slice (reused ones keep their prior status).
+  incrementalFile: `reports/stryker-incremental-${index}.json`,
   thresholds: { ...base.thresholds, break: null },
 };
 

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -293,3 +293,10 @@ EOF
   [ "$status" -eq 0 ]
   assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_TOTAL=4 dev bun scripts/ci/merge-mutation-reports.ts'
 }
+
+@test "test-mutation-shard appends --incremental when MUTATION_INCREMENTAL=1" {
+  reset_command_log
+  run_make_target test-mutation-shard MUTATION_SHARD_INDEX=1 MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1
+  [ "$status" -eq 0 ]
+  assert_log_contains 'dev bun x stryker run stryker.shard.config.mjs --incremental'
+}

--- a/tests/mutation/setup.ts
+++ b/tests/mutation/setup.ts
@@ -1,0 +1,16 @@
+import 'reflect-metadata';
+import '@testing-library/jest-dom';
+
+import { seedFaker } from '@tests/builders/seed';
+
+seedFaker();
+
+const { testPath } = expect.getState();
+const isIntegrationSuite = typeof testPath === 'string' && testPath.includes('/tests/integration/');
+
+if (isIntegrationSuite) {
+  require('../integration/setup');
+} else if (!globalThis.fetch) {
+  globalThis.fetch = (() =>
+    Promise.reject(new Error('fetch is not implemented in this test environment'))) as typeof fetch;
+}


### PR DESCRIPTION
Implements #121 — turns mutation testing from a near-disabled gate over 18 presentational components into a real, enforced quality gate over the whole logic layer.

## What changed

**Scope (18 → 154 files).** `scripts/ci/mutation-scope.mjs` is the single source of truth for the mutated set — the logic layer (repositories, `src/services/**`, auth stores/state, validation policies) plus module `.tsx`. Its exclusions mirror `jest.config.ts` `collectCoverageFrom` (types, styles, stories, generated code, DI-free i18n). Both `stryker.config.mjs` (`mutate`) and `stryker.shard.config.mjs` (per-shard slice) consume it, so the union of shards equals the full set exactly.

**Runs the tests that cover the logic.** `jest.mutation.config.ts` unions the unit **and** integration suites into one flat config (Stryker's jest-runner can't use Jest `projects` with `perTest` coverage). `tests/mutation/setup.ts` keys off the test path so the unit fetch-stub and the integration MSW server never collide. Result: repository/service/store mutants are killed by the integration tests that actually assert on them, instead of showing up as "no coverage".

**Affordable at scale — sharded incremental PRs + scheduled full.**
- `mutation-testing.yml` (PR): each of the 4 shards runs `--incremental` with its own `reports/stryker-incremental-<index>.json` restored from a rolling `actions/cache` key; only mutants the diff touches re-run, but the report still lists every mutant so the merge gate scores the whole set. First run (cold cache) is a full sharded pass that seeds the cache; a `push: main` trigger keeps the base warm for new PRs.
- `mutation-testing-full.yml` (scheduled weekly + `workflow_dispatch`): same matrix, cold and from scratch, as the authoritative baseline; refreshes the incremental caches.

**Real, enforced threshold band.** The no-op `break: 2.17` is replaced with a coherent `{ high, low, break }` band and a documented ratchet policy (raise `break`, never lower; never narrow scope to dodge a mutant; no suppressions). The merge gate reads `break` live from `stryker.config.mjs` and fails closed on a missing shard.

## Baseline (in progress)

`break` is currently a **bootstrap floor** so this PR's first (cold) full sharded run is green and reports the true score. Once that run reports, `break` is ratcheted to just below the measured baseline and the per-area table in `CLAUDE.md` is filled in. Measuring in CI (dedicated sharded runners) rather than locally is deliberate — a full local run is too heavy.

## Notes
- No production `src/` code changed; no suppression directives added.
- `#120`'s sharding + fail-closed merge gate are preserved and extended (not replaced).
- Docs: `CLAUDE.md` (scope + baseline + ratchet policy) and `CONTRIBUTING.md` ("CI speed and the mutation-testing gate").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands mutation testing into an enforced gate across the whole logic layer (154 files) with 8‑way sharded incremental PR runs and a weekly full baseline; thresholds now set to `{ high: 100, low: 90, break: 90 }` off a 92.5% overall baseline. Implements #121.

- **New Features**
  - Single source of truth for the mutated set in `scripts/ci/mutation-scope.mjs`; consumed by `stryker.config.mjs` and `stryker.shard.config.mjs`.
  - Runs unit + integration tests via `jest.mutation.config.ts`; `tests/mutation/setup.ts` isolates unit fetch stubs from integration MSW.
  - Threshold band set to `{ high: 100, low: 90, break: 90 }` and documented ratchet policy.

- **Refactors**
  - PR workflow shards to 8 with per‑shard `--incremental` and `actions/cache`; `push: main` keeps caches warm. Weekly `mutation-testing-full.yml` runs cold to re‑establish the baseline.
  - Shard config slices `base.mutate` to keep scope and shards in lockstep and now fails fast if `MUTATION_SHARD_INDEX >= MUTATION_SHARD_TOTAL`; per‑shard `incrementalFile` and JSON reports.
  - Stability/speed: exclude meta-tests; `ignoreStatic: true`; `ts-jest` `isolatedModules`; Makefile flag for incremental runs; dependency rules allow `tests/mutation`.
  - Simplified scope exclusions via an `EXCLUDED_PATTERNS` regex table; behavior unchanged (still 154 files in scope).

<sup>Written for commit dd3d46766c9b23ee932b5e867255c03d4c9b54eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

