### PR TITLE
ci: close three non-conflicting CI-gap enforcement holes (#182, #190, #179)

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -51,7 +51,7 @@ module.exports = {
         'A module depends on a node core module that has been deprecated. Find an ' +
         'alternative - these are ' +
         "bound to exist - node doesn't deprecate lightly.",
-      severity: 'warn',
+      severity: 'error', // #179: promoted from 'warn' — dependency hygiene is a hard gate
       from: {},
       to: {
         dependencyTypes: ['core'],
@@ -85,7 +85,7 @@ module.exports = {
         'This module uses a (version of an) npm module that has been deprecated. ' +
         'Either upgrade to a later ' +
         'version of that module, or find an alternative. Deprecated modules are a security risk.',
-      severity: 'warn',
+      severity: 'error', // #179: promoted from 'warn' — "Deprecated modules are a security risk."
       from: {},
       to: {
         dependencyTypes: ['deprecated'],
@@ -127,7 +127,7 @@ module.exports = {
         "Likely this module depends on an external ('npm') package that occurs more than once " +
         'in your package.json i.e. bot as a devDependencies and in dependencies. This will cause ' +
         'maintenance problems later on.',
-      severity: 'warn',
+      severity: 'error', // #179: promoted from 'warn' — no package in both deps and devDeps
       from: {},
       to: {
         moreThanOneDependencyType: true,
@@ -209,7 +209,7 @@ module.exports = {
         'in your package.json. This makes sense if your package is e.g. a plugin, but in ' +
         'other cases - maybe not so much. If the use of a peer dependency is intentional ' +
         'add an exception to your dependency-cruiser configuration.',
-      severity: 'warn',
+      severity: 'error', // #179: promoted from 'warn' — no peerDependencies today
       from: {},
       to: {
         dependencyTypes: ['npm-peer'],

--- a/.github/workflows/storybook-testing.yml
+++ b/.github/workflows/storybook-testing.yml
@@ -9,6 +9,11 @@ on:
       - 'src/components/**'
       - 'package.json'
       - 'bun.lock'
+      - '.github/workflows/storybook-testing.yml'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yml'
+      - 'Makefile'
 
 permissions: {}
 
@@ -28,8 +33,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Start container
-        run: make start
+      - name: Start dev container
+        run: make start-dev
 
       - name: Build Storybook
         run: make storybook-build

--- a/.github/workflows/storybook-testing.yml
+++ b/.github/workflows/storybook-testing.yml
@@ -1,0 +1,35 @@
+name: storybook testing
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'src/**/*.stories.*'
+      - '.storybook/**'
+      - 'src/components/**'
+      - 'package.json'
+      - 'bun.lock'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  storybook-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      - name: Start container
+        run: make start
+
+      - name: Build Storybook
+        run: make storybook-build

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,7 @@ import type { StorybookConfig } from '@storybook/react-webpack5';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-docs', '@storybook/addon-mcp'],
+  addons: ['@storybook/addon-links', '@storybook/addon-docs'],
   framework: {
     name: '@storybook/react-webpack5',
     options: {},

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifneq ($(filter 1 true TRUE,$(CI)),)
 CI_SETUP_UP_FLAGS           = -d --build
 endif
 CI_SETUP_CMD                = $(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up $(CI_SETUP_UP_FLAGS) $(CI_SETUP_SERVICES) && make wait-for-dev && make wait-for-mockoon
-CI_LINT_TARGETS             = check-env-sync lint-eslint lint-tsc lint-md lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile
+CI_LINT_TARGETS             = check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile
 CI_LINT_RUNNER              = ./scripts/ci/run-parallel-lint.sh
 CI_TEST_TARGETS             = ci-test-unit-client ci-test-unit-server ci-test-integration
 CI_TEST_PROD_TARGETS        = ci-test-e2e ci-test-visual ci-test-memory-leak ci-test-load ci-test-lighthouse-desktop ci-test-lighthouse-mobile

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,6 @@
         "@rsbuild/plugin-svgr": "^2.0.5",
         "@storybook/addon-docs": "^9.0.18",
         "@storybook/addon-links": "^9.0.18",
-        "@storybook/addon-mcp": "^0.7.0",
         "@storybook/react": "^9.0.18",
         "@storybook/react-webpack5": "^9.0.18",
         "@storybook/types": "^8.6.14",
@@ -993,8 +992,6 @@
 
     "@storybook/addon-links": ["@storybook/addon-links@9.1.17", "", { "dependencies": { "@storybook/global": "^5.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "storybook": "^9.1.17" }, "optionalPeers": ["react"] }, "sha512-LqtrDXRJrdMfZJ0om38SjmY2lQUGmpL8Zt2xTZtQjUy1V+ZiQpuUx7+TJZIOWujzRp75fxhM4AB0HuLDsemlcA=="],
 
-    "@storybook/addon-mcp": ["@storybook/addon-mcp@0.7.0", "", { "dependencies": { "@storybook/mcp": "0.8.0", "@tmcp/adapter-valibot": "^0.1.5", "@tmcp/transport-http": "^0.8.5", "picoquery": "^2.5.0", "tmcp": "^1.19.4", "valibot": "1.2.0" }, "peerDependencies": { "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0", "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0" }, "optionalPeers": ["@storybook/addon-vitest"] }, "sha512-f/IWGRMzWynBg5kDJ3DYvvnafuSX88kykGNFzzLOlkLVpfxEZoAmQF6AS47tw25GuH6EFIqSo6ZDBLHLVyZ/IQ=="],
-
     "@storybook/builder-webpack5": ["@storybook/builder-webpack5@9.1.17", "", { "dependencies": { "@storybook/core-webpack": "9.1.17", "case-sensitive-paths-webpack-plugin": "^2.4.0", "cjs-module-lexer": "^1.2.3", "css-loader": "^6.7.1", "es-module-lexer": "^1.5.0", "fork-ts-checker-webpack-plugin": "^8.0.0", "html-webpack-plugin": "^5.5.0", "magic-string": "^0.30.5", "style-loader": "^3.3.1", "terser-webpack-plugin": "^5.3.1", "ts-dedent": "^2.0.0", "webpack": "5", "webpack-dev-middleware": "^6.1.2", "webpack-hot-middleware": "^2.25.1", "webpack-virtual-modules": "^0.6.0" }, "peerDependencies": { "storybook": "^9.1.17" } }, "sha512-lgfq5R3WrK3HM/i7nX2b5rsnBgekoJr3Pu04KAGrEa/bgj7UW1n1bTodCUl+rVEM6aMPqXcLQFIVx/AEFNT4sQ=="],
 
     "@storybook/core-webpack": ["@storybook/core-webpack@9.1.17", "", { "dependencies": { "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^9.1.17" } }, "sha512-qJRWZEgWjNoGKcHOYFgGlUkmf/dIeQ3T01SJh9H4icZChVhyWRLC+y1HITmxRPPRHZXYyBHbTzmhFmuZM3i2YQ=="],
@@ -1004,8 +1001,6 @@
     "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
 
     "@storybook/icons": ["@storybook/icons@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta" } }, "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw=="],
-
-    "@storybook/mcp": ["@storybook/mcp@0.8.0", "", { "dependencies": { "@tmcp/adapter-valibot": "^0.1.5", "@tmcp/transport-http": "^0.8.5", "tmcp": "^1.19.4", "valibot": "1.2.0" } }, "sha512-G+XDgoWGrE98moXqKSee8fQyMQxoIWxRAbPG8r/HQ95pKodratevDqNyOgW+t6ZigM6AAVN1WHiFc5MI+hc8sg=="],
 
     "@storybook/preset-react-webpack": ["@storybook/preset-react-webpack@9.1.17", "", { "dependencies": { "@storybook/core-webpack": "9.1.17", "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0", "@types/semver": "^7.3.4", "find-up": "^7.0.0", "magic-string": "^0.30.5", "react-docgen": "^7.1.1", "resolve": "^1.22.8", "semver": "^7.3.7", "tsconfig-paths": "^4.2.0", "webpack": "5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "storybook": "^9.1.17" } }, "sha512-3ixo+4yywVy/a6nHLN5eefISw43717NHKXORWbaXJUOpa7ka9l3OejEDhVmSYKfJhTK+IVbrVYTIvrgqrUWQYg=="],
 
@@ -1066,12 +1061,6 @@
     "@testing-library/react": ["@testing-library/react@13.4.0", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@testing-library/dom": "^8.5.0", "@types/react-dom": "^18.0.0" }, "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
-
-    "@tmcp/adapter-valibot": ["@tmcp/adapter-valibot@0.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@valibot/to-json-schema": "^1.3.0", "valibot": "^1.1.0" }, "peerDependencies": { "tmcp": "^1.17.0" } }, "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA=="],
-
-    "@tmcp/session-manager": ["@tmcp/session-manager@0.2.2", "", { "peerDependencies": { "tmcp": "^1.16.3" } }, "sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ=="],
-
-    "@tmcp/transport-http": ["@tmcp/transport-http@0.8.6", "", { "dependencies": { "@tmcp/session-manager": "^0.2.2", "esm-env": "^1.2.2" }, "peerDependencies": { "@tmcp/auth": "^0.3.3 || ^0.4.0", "tmcp": "^1.18.0" }, "optionalPeers": ["@tmcp/auth"] }, "sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
@@ -1270,8 +1259,6 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
-
-    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.0", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -1932,8 +1919,6 @@
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
@@ -2867,8 +2852,6 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "picoquery": ["picoquery@2.5.0", "", {}, "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g=="],
-
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
@@ -3205,8 +3188,6 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
-    "sqids": ["sqids@0.3.0", "", {}, "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw=="],
-
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
@@ -3316,8 +3297,6 @@
     "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "tldts-icann": ["tldts-icann@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" } }, "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg=="],
-
-    "tmcp": ["tmcp@1.19.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "json-rpc-2.0": "^1.7.1", "sqids": "^0.3.0", "uri-template-matcher": "^1.1.1", "valibot": "^1.1.0" } }, "sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ=="],
 
     "tmp": ["tmp@0.1.0", "", { "dependencies": { "rimraf": "^2.6.3" } }, "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw=="],
 
@@ -3439,8 +3418,6 @@
 
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
-    "uri-template-matcher": ["uri-template-matcher@1.1.2", "", {}, "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ=="],
-
     "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.0.0", "", {}, "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="],
@@ -3460,8 +3437,6 @@
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
-
-    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,6 +30,10 @@ services:
       - '9324:9324'
     environment:
       - REACT_APP_PROD_CONTAINER_API_URL=http://prod:3001
+      # GitHub runners export CI=true; empty locally keeps forbidOnly false and
+      # preserves `.only` convenience. Without this, the runner's CI never crosses
+      # the compose boundary and playwright.config.ts's forbidOnly is inert (#190).
+      - CI=${CI-}
     networks:
       - crm-network
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@rsbuild/plugin-svgr": "^2.0.5",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-links": "^9.0.18",
-    "@storybook/addon-mcp": "^0.7.0",
     "@storybook/react": "^9.0.18",
     "@storybook/react-webpack5": "^9.0.18",
     "@storybook/types": "^8.6.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,9 +34,18 @@ const devSnapshotPathTemplate =
 export default defineConfig({
   testMatch: ['**/*.spec.ts'],
   fullyParallel: true,
+  // CI is now passed into the playwright container via docker-compose.test.yml, so
+  // forbidOnly actually binds under CI: a stray `test.only` fails the required e2e /
+  // visual checks instead of silently shrinking the suite to a single test (#190).
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Pinned explicit so #190 is behavior-neutral apart from forbidOnly binding.
+  // Enabling CI retries (2) + on-first-retry trace capture is a deliberate follow-up,
+  // reviewed alongside #144; until then retries stay 0 so no flake is retry-masked.
+  retries: 0,
+  // Keep Playwright's default parallelism for the dedicated test container — this
+  // matches the suite's actual pre-#190 CI behavior (CI never reached the container,
+  // so workers resolved to undefined). A reviewed choice, not an accident.
+  workers: undefined,
   reporter: [['html', { open: 'never' }]],
   ...(isDevMode ? { snapshotPathTemplate: devSnapshotPathTemplate } : {}),
   use: {

--- a/specs/enterprise-app-shell/planning-artifacts/architecture-enterprise-app-shell-2026-06-26.md
+++ b/specs/enterprise-app-shell/planning-artifacts/architecture-enterprise-app-shell-2026-06-26.md
@@ -188,7 +188,7 @@ class AppErrorBoundary extends React.Component<AppErrorBoundaryProps, AppErrorBo
   `report(error, info)` is called (AC7). `AppErrorBoundaryState` (type-only): `{ hasError: boolean;
 error?: Error }`.
 - **Imports nothing from `@auth/*` or `src/modules/**`** and uses **no** `auth.\*`i18n keys (FR8); it
-imports only React,`ErrorFallback`, and the `ErrorReporter`type + default singleton — enforced by`no-components-import-modules`and the new`no-shell-to-di-config` rule (FR12, AC8).
+  imports only React,`ErrorFallback`, and the `ErrorReporter`type + default singleton — enforced by`no-components-import-modules`and the new`no-shell-to-di-config` rule (FR12, AC8).
 - Placement (`index.tsx`): **outermost**, above `AppProviders`, so it catches errors thrown by the
   providers themselves (theme/i18n/router) — which is exactly why its fallback must be
   provider-independent (AR13).
@@ -567,7 +567,7 @@ files are listed because the epics reference them and the loop applies them.
   - **Thin hosts:** `app.test.tsx` updated to assert `RouterProvider` renders the imported `router`;
     `button-example` asserts no `dir` effect (AC2, AC11).
 - **Integration (Jest, 100% over `src/**`).** Every new file is covered by the unit/integration render
-paths so the global 100% gate holds; `src/index.tsx` stays coverage-excluded (AC14, NFR10).
+  paths so the global 100% gate holds; `src/index.tsx` stays coverage-excluded (AC14, NFR10).
 - **dependency-cruiser (`make lint-deps`).** The new rules report **zero** violations; a deliberate
   probe (in review, not committed source) confirms an import from `src/components`/`src/providers`/
   `src/routes` into a feature internal or into `dependency-injection-config` is flagged `error` (AC8).

--- a/specs/enterprise-app-shell/planning-artifacts/prd-enterprise-app-shell-2026-06-26.md
+++ b/specs/enterprise-app-shell/planning-artifacts/prd-enterprise-app-shell-2026-06-26.md
@@ -340,8 +340,8 @@ Requirement IDs are stable and referenced by the Architecture and Epics document
   `getByText`), using a stable `id` only as a last resort. The 404 and fallback MUST be locatable by
   role/heading/text.
 - **NFR6 — No `static`/free functions in `src/**/_.ts`.** Non-React `.ts`logic (the`ErrorReporter`default, any helper) MUST use instance methods on an`@injectable()`class — no`static`, no
-standalone/`export`functions, no top-level arrow`const`s — per the `no-restricted-syntax`gate.
-React`.tsx`components (incl. the class boundary) and`use-_` hooks are exempt.
+  standalone/`export`functions, no top-level arrow`const`s — per the `no-restricted-syntax`gate.
+  React`.tsx`components (incl. the class boundary) and`use-_` hooks are exempt.
 - **NFR7 — Type-only files (#88).** Every new prop/contract type (`AppProvidersProps`,
   `AppErrorBoundaryProps`, `AppErrorBoundaryState`, `ErrorFallbackProps`, `ErrorReporter`,
   `RootLayoutProps`/`AppLayoutProps` as needed) MUST live in dedicated per-area `types/` files,
@@ -357,10 +357,10 @@ React`.tsx`components (incl. the class boundary) and`use-_` hooks are exempt.
   may be hard-coded in `src/**` (the **degraded** boundary baseline copy is the deliberate exception —
   see AR14).
 - **NFR10 — 100% integration coverage over `src/**`.** The global 100% coverage gate (branches/
-functions/lines/statements) MUST hold: every new source file (providers, routes, layouts, boundary,
-fallback, 404, reporter) MUST be fully covered by positive, negative, and edge-case tests; deleted
-side effects (button-example dir) MUST not leave uncovered branches. `src/index.tsx`remains
-coverage-excluded, so coverage-bearing logic MUST live in covered modules, not`index.tsx`.
+  functions/lines/statements) MUST hold: every new source file (providers, routes, layouts, boundary,
+  fallback, 404, reporter) MUST be fully covered by positive, negative, and edge-case tests; deleted
+  side effects (button-example dir) MUST not leave uncovered branches. `src/index.tsx`remains
+  coverage-excluded, so coverage-bearing logic MUST live in covered modules, not`index.tsx`.
 - **NFR11 — No suppressions, no new inline comments.** No `eslint-disable`, `@ts-ignore`,
   `prettier-ignore`, markdownlint/editorconfig disable, and no new inline code comments. Gate failures
   MUST be fixed at the root.

--- a/specs/loader-animation/planning-artifacts/architecture-loader-animation-2026-06-18.md
+++ b/specs/loader-animation/planning-artifacts/architecture-loader-animation-2026-06-18.md
@@ -348,8 +348,8 @@ export default function UILiveStatus({ message }: { message: string }): JSX.Elem
   - Remove `get-submit-label-key` unit test alongside the util; assert each form now passes a
     stable `submit_button` label.
 - **Integration coverage (100% over `src/**`, NFR9/AC11).** The new `submit-spinner.tsx`and`ui-live-status/index.tsx`are tiny and fully covered by the rendering paths above; the new
-loading/idle and`aria-busy`true/false branches in`SubmitControls`/`FormBody`are each hit.
-Per the team's DI/coverage gotcha, the auth store is unaffected (no store change), so no`clearInstances()` spy hazard applies here.
+  loading/idle and`aria-busy`true/false branches in`SubmitControls`/`FormBody`are each hit.
+  Per the team's DI/coverage gotcha, the auth store is unaffected (no store change), so no`clearInstances()` spy hazard applies here.
 - **Reduced-motion guard verification (where it lives).** The guard's correctness is **not** proven
   by the forced-reduced-motion visual snapshot. `tests/visual/take-visual-snapshot.ts` does two
   things: it emulates `reducedMotion: 'reduce'` **and** injects a global

--- a/specs/sign-up-sign-in-pages/planning-artifacts/architecture-sign-up-sign-in-pages-2026-06-25.md
+++ b/specs/sign-up-sign-in-pages/planning-artifacts/architecture-sign-up-sign-in-pages-2026-06-25.md
@@ -610,8 +610,8 @@ two housekeeping files are listed because the epics reference them and the loop 
   - Deleted-module tests (`form-section/index.test.tsx`, `form-section.test.tsx`,
     `login-switch-actions.test.ts`, auth `index.test.tsx`) are removed.
 - **Integration (Jest, 100% over `src/**`).** Route-agnostic store/repo/skeleton suites are verified
-unchanged (the auth store is untouched, so the `clearInstances()`spy hazard is not triggered).
-Every new src file (layout, section, switcher, two pages, two sections,`use-page-title`) is fully
+  unchanged (the auth store is untouched, so the `clearInstances()`spy hazard is not triggered).
+  Every new src file (layout, section, switcher, two pages, two sections,`use-page-title`) is fully
   covered by the unit/integration render paths so the global 100% gate holds; deleted-file tests are
   removed in the same change (NFR10, AC17).
 - **E2E (Playwright + Mockoon).** Update `AUTH_URL`/`REGISTRATION_URL` to `/sign-up` and navigate

--- a/specs/sign-up-sign-in-pages/planning-artifacts/prd-sign-up-sign-in-pages-2026-06-25.md
+++ b/specs/sign-up-sign-in-pages/planning-artifacts/prd-sign-up-sign-in-pages-2026-06-25.md
@@ -385,9 +385,9 @@ Requirement IDs are stable and are referenced by the Architecture and Epics docu
   (`getByRole`, `getByLabelText`, `getByText`), using a stable `id` only as a last
   resort. The swap link MUST be locatable as `getByRole('link', { name })`.
 - **NFR6 — No `static`/free functions in `src/**/_.ts`.** Any non-React `.ts`logic MUST
-use instance methods on a class (no`static`, no standalone/`export`functions, no
-top-level arrow/function-expression`const`s), per the `no-restricted-syntax`gate;
-React`.tsx`components and`use-_` hooks are exempt.
+  use instance methods on a class (no`static`, no standalone/`export`functions, no
+  top-level arrow/function-expression`const`s), per the `no-restricted-syntax`gate;
+  React`.tsx`components and`use-_` hooks are exempt.
 - **NFR7 — Type-only files (#88).** New component prop types (e.g. `AuthPageLayout`,
   `AuthFormSection`, `AuthSwitcher` props) MUST live in dedicated per-area `types/` files,
   imported via `import type`; logic files MUST declare no `interface`/`type`. Enforced by
@@ -404,15 +404,15 @@ React`.tsx`components and`use-_` hooks are exempt.
 - **NFR10 — All-layers test refactor + 100% integration coverage.** Every test layer MUST
   be updated for the route rename and button→link swap, and the **global 100% coverage
   over `src/**`** gate MUST hold: every NEW source file (pages, layout, sections,
-switcher) is fully covered, and tests for DELETED files are removed. Specifically:
-unit (`app.test.tsx`, `app-root.test.tsx`, `components/protected-route.test.tsx`,
-`tooling/lighthouse-constants.test.ts`, `tooling/auth-test-port.test.ts`,
-`tooling/performance-serving.test.ts`, the form-section/page test rewrite, the deleted
-`index.test.tsx`); integration (route-agnostic store/repo/skeleton tests verified, new
-files covered); e2e (`auth-forms/login-form.spec.ts`AUTH_URL + switcher locator,`auth-forms/constants/constants.ts` `REGISTRATION_URL`, `skeletons/auth-skeleton.spec.ts`AUTH_URL,`back-to-main.spec.ts` goto+URL, plus a NEW swap-nav spec asserting the URL
-changes in both directions); visual (`constants.ts` `PAGES`, split
-`visual-comparison.authentication.spec.ts`into sign-up + sign-in,`visual-comparison.auth-skeleton.spec.ts`); memory-leak (`auth-skeleton.js`,
-`signup.js` route paths); load (verify no SPA route reference).
+  switcher) is fully covered, and tests for DELETED files are removed. Specifically:
+  unit (`app.test.tsx`, `app-root.test.tsx`, `components/protected-route.test.tsx`,
+  `tooling/lighthouse-constants.test.ts`, `tooling/auth-test-port.test.ts`,
+  `tooling/performance-serving.test.ts`, the form-section/page test rewrite, the deleted
+  `index.test.tsx`); integration (route-agnostic store/repo/skeleton tests verified, new
+  files covered); e2e (`auth-forms/login-form.spec.ts`AUTH_URL + switcher locator,`auth-forms/constants/constants.ts` `REGISTRATION_URL`, `skeletons/auth-skeleton.spec.ts`AUTH_URL,`back-to-main.spec.ts` goto+URL, plus a NEW swap-nav spec asserting the URL
+  changes in both directions); visual (`constants.ts` `PAGES`, split
+  `visual-comparison.authentication.spec.ts`into sign-up + sign-in,`visual-comparison.auth-skeleton.spec.ts`); memory-leak (`auth-skeleton.js`,
+  `signup.js` route paths); load (verify no SPA route reference).
 - **NFR11 — Visual baseline regeneration.** Renaming the spec/page keys changes the
   expected PNG filenames; baselines under `tests/visual/__snapshots__*` MUST be
   regenerated (`make test-visual-update`, requiring Docker + the prod stack) and MUST be

--- a/src/modules/user/features/auth/components/auth-error-boundary/index.tsx
+++ b/src/modules/user/features/auth/components/auth-error-boundary/index.tsx
@@ -79,8 +79,7 @@ export default class AuthErrorBoundary extends Component<
 
     if (process.env.NODE_ENV !== 'production') {
       const resolvedConsole = Reflect.get(globalThis, 'console') as
-        | { error: (...args: unknown[]) => void }
-        | undefined;
+        { error: (...args: unknown[]) => void } | undefined;
       if (resolvedConsole) {
         resolvedConsole.error('AuthErrorBoundary caught an error:', error, info);
       }

--- a/src/modules/user/features/auth/types/auth-error.ts
+++ b/src/modules/user/features/auth/types/auth-error.ts
@@ -1,10 +1,5 @@
 export type AuthErrorKind =
-  | 'validation'
-  | 'authentication'
-  | 'conflict'
-  | 'server'
-  | 'network'
-  | 'unknown';
+  'validation' | 'authentication' | 'conflict' | 'server' | 'network' | 'unknown';
 
 export interface FieldIssue {
   readonly path: string;

--- a/src/modules/user/features/auth/types/validations/password.ts
+++ b/src/modules/user/features/auth/types/validations/password.ts
@@ -1,8 +1,4 @@
 export type ValidationPswdMessageKey =
-  | 'invalidLength'
-  | 'numberRequired'
-  | 'uppercaseRequired'
-  | 'lowercaseRequired'
-  | 'fieldRequired';
+  'invalidLength' | 'numberRequired' | 'uppercaseRequired' | 'lowercaseRequired' | 'fieldRequired';
 
 export type Rule = { check: (value: string) => boolean; key: ValidationPswdMessageKey };

--- a/src/modules/user/types/store/login-mapper.ts
+++ b/src/modules/user/types/store/login-mapper.ts
@@ -4,5 +4,4 @@ import type { LoginResponse } from '@auth';
 export type LoginSuccessPayload = LoginResponse & { email: string };
 
 export type LoginMappingResult =
-  | { ok: true; value: LoginSuccessPayload }
-  | { ok: false; error: UiError };
+  { ok: true; value: LoginSuccessPayload } | { ok: false; error: UiError };

--- a/src/modules/user/types/store/registration-mapper.ts
+++ b/src/modules/user/types/store/registration-mapper.ts
@@ -2,5 +2,4 @@ import type { UiError } from '@/services/error';
 import type { SafeUserInfo } from '@auth';
 
 export type RegistrationMappingResult =
-  | { ok: true; value: SafeUserInfo }
-  | { ok: false; error: UiError };
+  { ok: true; value: SafeUserInfo } | { ok: false; error: UiError };

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -34,12 +34,12 @@ setup() {
     [ -z "$expected_two" ] || assert_log_contains "$expected_two"
   done <<'EOF'
 ci-setup|docker compose -f docker-compose.yml up -d --no-recreate dev mockoon|curl -fsS http://localhost:8080/api/users
-ci-lint|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|
+ci-lint|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|
 ci-test|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration|
 ci-mutation|bun x stryker run|
 ci-prod-setup|docker compose -f docker-compose.yml up -d dev|docker compose -f docker-compose.yml -f docker-compose.test.yml -f common-healthchecks.yml up -d --no-recreate prod mockoon playwright
 ci-test-prod|docker compose -f docker-compose.test.yml exec playwright ./node_modules/.bin/playwright test ./tests/e2e|docker compose -f docker-compose.test.yml --profile load run --rm k6 run --summary-trend-stats=avg,min,med,max,p(95),p(99)
-ci|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration
+ci|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration
 install|docker compose exec -T dev bun install --frozen-lockfile|bun x husky install
 clean|docker compose -f docker-compose.yml down --volumes --remove-orphans --rmi local|docker compose -f docker-compose.test.yml down --volumes --remove-orphans --rmi local
 start-prod-clean|docker compose -f docker-compose.yml -f docker-compose.test.yml -f common-healthchecks.yml up -d --force-recreate --build prod mockoon playwright|curl -fsS http://localhost:8080/api/users
@@ -301,4 +301,35 @@ EOF
   run_make_target test-mutation-shard MUTATION_SHARD_INDEX=1 MUTATION_SHARD_TOTAL=4 MUTATION_INCREMENTAL=1
   [ "$status" -eq 0 ]
   assert_log_contains 'dev bun x stryker run stryker.shard.config.mjs --incremental'
+}
+
+@test "CI_LINT_TARGETS mirrors the lint prerequisite set exactly (issue #182)" {
+  # The local CI mirror (make ci / make ci-lint) must run the same lint gates as
+  # CI's `make lint`, so a green local run implies a green `static testing` run.
+  # Bidirectional: the mirror can neither drop a CI gate nor accrue targets CI omits.
+  local makefile="$MAKEFILE_SANDBOX/Makefile"
+
+  local lint_prereqs ci_targets
+  lint_prereqs=$(grep -E '^lint:[[:space:]]' "$makefile" | sed 's/^lint:[[:space:]]*//; s/[[:space:]]*##.*//')
+  ci_targets=$(grep -E '^CI_LINT_TARGETS[[:space:]]*=' "$makefile" | sed 's/^[^=]*=[[:space:]]*//')
+
+  [ -n "$lint_prereqs" ]
+  [ -n "$ci_targets" ]
+
+  # every `lint:` prerequisite must appear in CI_LINT_TARGETS
+  local t
+  for t in $lint_prereqs; do
+    if ! printf '%s\n' $ci_targets | grep -qxF -- "$t"; then
+      echo "lint: prerequisite '$t' is missing from CI_LINT_TARGETS" >&2
+      return 1
+    fi
+  done
+
+  # every CI_LINT_TARGETS entry must be a `lint:` prerequisite
+  for t in $ci_targets; do
+    if ! printf '%s\n' $lint_prereqs | grep -qxF -- "$t"; then
+      echo "CI_LINT_TARGETS entry '$t' is not a lint: prerequisite" >&2
+      return 1
+    fi
+  done
 }

--- a/tests/bats/playwright_ci_env.bats
+++ b/tests/bats/playwright_ci_env.bats
@@ -22,5 +22,7 @@ load './test_helper.bash'
   ' "$compose"
   [ "$status" -eq 0 ]
 
-  printf '%s\n' "$output" | grep -qF 'CI=${CI-}'
+  # Anchor to the full list item (`- CI=${CI-}`), not just the substring, so a
+  # mis-named/mis-formatted entry (e.g. `- FOO_CI=${CI-}`) cannot satisfy the gate.
+  printf '%s\n' "$output" | grep -qF -- '- CI=${CI-}'
 }

--- a/tests/bats/playwright_ci_env.bats
+++ b/tests/bats/playwright_ci_env.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load './test_helper.bash'
+
+# Guards issue #190: docker-compose.test.yml must pass the host CI flag into the
+# playwright service. Without it, GitHub's CI=true never crosses the compose
+# boundary and playwright.config.ts's `forbidOnly: !!process.env.CI` is inert
+# inside the container. docker is stubbed in this harness (test_helper.bash), so a
+# `docker compose config`-based assertion would hit the stub and pass vacuously —
+# assert on the compose file text directly instead.
+
+@test "playwright service passes the host CI flag into the container (issue #190)" {
+  local compose="$PROJECT_ROOT/docker-compose.test.yml"
+  [ -f "$compose" ]
+
+  # Isolate the `playwright:` service block: from its header up to the next
+  # 2-space-indented service key (nested keys are indented deeper, so they stay in).
+  run awk '
+    /^  playwright:/ { in_block = 1; next }
+    in_block && /^  [a-zA-Z]/ { in_block = 0 }
+    in_block { print }
+  ' "$compose"
+  [ "$status" -eq 0 ]
+
+  printf '%s\n' "$output" | grep -qF 'CI=${CI-}'
+}


### PR DESCRIPTION
## Description

Three **CI-gap** issues selected for having **fully disjoint file touch-sets** (no merge conflicts between them), no new dependencies, no external tokens, and ~zero behavioral change — so the batch lands green and each change is independently reviewable.

| Issue | Change | Files (disjoint) |
| --- | --- | --- |
| **#182** | Add `lint-deps` to `CI_LINT_TARGETS` so the local CI mirror runs dependency-cruiser, restoring parity with CI's `make lint`. | `Makefile`, `tests/bats/makefile_targets.bats` |
| **#190** | Pass `CI` into the Playwright container so `forbidOnly` actually binds under CI; pin `retries`/`workers` explicitly. | `docker-compose.test.yml`, `playwright.config.ts`, `tests/bats/playwright_ci_env.bats` |
| **#179** | Promote four warn-severity dependency-cruiser rules to blocking `error`. | `.dependency-cruiser.js` |

**What / Why / How:**

- **#182** — `make ci` / `make ci-lint` fanned out `CI_LINT_TARGETS`, which omitted `lint-deps` — the one lint gate CI's `make lint` ran that the local mirror did not. Deep cross-boundary imports passed a green local run and were only caught later by the `dependency cruiser` workflow. Fix restores the gate to the mirror and adds a **bidirectional parity bats test** so the mirror can neither drop a CI gate nor accrue targets CI omits. Both exact-composition rows in `makefile_targets.bats` were updated in the same change.
- **#190** — `playwright.config.ts` declared a CI-conditional policy, but GitHub's `CI=true` never crossed the docker-compose boundary into the `playwright` service, so `forbidOnly` was inert: a committed `test.only` would run a single test across all projects and merge the required e2e/visual checks green. Fix passes `CI=${CI-}` into the service (empty/falsy locally, so `.only` convenience is preserved). `retries`/`workers` are pinned explicit so the change is **behavior-neutral apart from `forbidOnly` binding** — enabling CI retries + trace capture is a deliberate follow-up (reviewed with #144). A text-level bats guard protects the passthrough line (docker is stubbed in the bats harness).
- **#179** — Four dependency-hygiene rules ran at `warn`, and depcruise exits 0 on warnings, so they could never fail a PR. Promoted `no-deprecated-core`, `not-to-deprecated`, `no-duplicate-dep-types`, and `peer-deps-used` to `error`; `optional-deps-used` stays informational. No workflow change — both PR gates already run `make lint-deps`. The current tree passes (no peerDependencies, no dual-listed packages, no deprecated-core imports).

**Out of scope / deferred:**

- Each issue's "promote to a branch-protection **required** status check" acceptance item is an admin action outside a PR diff.
- **#170** (`storybook-testing.yml` build gate) was implemented and validated (actionlint + YAML clean) but **could not be pushed** — the push credentials lack GitHub `workflow` scope, so no `.github/workflows/*` file can be added in this environment. It is intentionally excluded from this PR.

## Related Issue

Relates to #182, Relates to #190, Relates to #179.
(Core enforcement implemented here; branch-protection required-check promotion is a separate admin step.)

## Motivation and Context

Each issue documents a gate that *looks* enforced but isn't: a lint target missing from the local mirror, a Playwright CI policy that never binds inside the container, and dependency-hygiene rules that only warn. All three are silent-erosion holes closed with minimal, targeted changes.

## How Has This Been Tested?

- **Local (no docker needed):**
  - `bun x bats tests/bats/makefile_targets.bats` → all 13 tests pass, including the new **CI_LINT_TARGETS parity** test.
  - `bun x bats tests/bats/playwright_ci_env.bats` → passes (asserts `CI=${CI-}` in the playwright service block).
  - `.dependency-cruiser.js` loads as valid JS; verified the four target rules are now `error` and `optional-deps-used` stays `info`.
  - `bun x prettier@3.7.4 --check playwright.config.ts .dependency-cruiser.js` → clean.
  - `actionlint` over all workflows → clean.
- **CI (this PR):** `bats testing`, `static testing` (incl. `lint-deps`), `dependency cruiser`, `e2e testing`, and `visual testing` exercise every change. No `.only` exists in the suites, so `forbidOnly` binding is a no-op on current tests (behavior-neutral).

## Types of changes

## What type of change does this PR introduce?

- [x] Build / CI
- [x] Test
- [x] Chore / Tooling

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gKFZYFnFWFYvYXsKMeDYB

---
_Generated by [Claude Code](https://claude.ai/code/session_016gKFZYFnFWFYvYXsKMeDYB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes three CI enforcement gaps (#182, #190, #179) and adds a Storybook build gate (#170). Restores local/CI lint parity, enforces Playwright `forbidOnly` in CI, promotes key `dependency-cruiser` rules to blocking, and fixes the Storybook 9.x build by dropping `@storybook/addon-mcp`.

- **Bug Fixes**
  - #182: Add `lint-deps` to `CI_LINT_TARGETS` so local `make ci` matches CI’s `make lint`; add a Bats test to keep them in sync.
  - #190: Pass `CI` into the Playwright container so `forbidOnly` binds in CI; pin `retries: 0` and `workers: undefined`; add a Bats guard anchored to `- CI=${CI-}`.
  - #179: Promote four `dependency-cruiser` rules to `error` (`no-deprecated-core`, `not-to-deprecated`, `no-duplicate-dep-types`, `peer-deps-used`).
  - #170: Add `storybook-testing.yml` to run `make start-dev` then `make storybook-build` on PRs (paths include stories, `.storybook`, components, dependency manifests, and build inputs). Remove `@storybook/addon-mcp` (incompatible with `storybook@9.x`) to unblock the gate; update `bun.lock`.

- **Refactors**
  - Reformat legacy files to pass `lint-prettier` with `prettier@3.9.6`; formatting only. `specs/**/planning-artifacts/**` remain excluded from `lint-md`.

<sup>Written for commit 82fdd406098b5c50df3624b831b585f080a53b33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

