### PR TITLE
ci(#193): harden CI enforcement gates (#164, #165, #189, #191, #193)

### DIFF
--- a/.claude/skills/quality-standards/SKILL.md
+++ b/.claude/skills/quality-standards/SKILL.md
@@ -36,15 +36,18 @@ suite and should not be used as a mutating formatter.
   `markdownlint-disable`. Fix the root cause.
 - Do not accept markdownlint failures in skills or docs.
 - Do not commit generated snapshots unless the visual change is intentional.
-- Do not weaken a dependency license failure (`make lint-licenses`) by editing the
-  checker invocation; replace the dependency or add its SPDX id to `ALLOWED_LICENSES`
-  in the `Makefile` as a reviewed one-line diff (issue #191).
-- Any new error-severity `no-restricted-syntax` / `no-restricted-imports` entry scoped to
-  `src/**` (e.g. a new architecture convention) must land with at least one must-fail fixture
-  in `scripts/ci/eslint-gate-fixtures.mjs`, or the rot-guard in
-  `tests/unit/tooling/eslint-gate-fixtures.test.ts` fails the build (issue #189). Config-level
-  gates in `eslint.config.mjs` are pinned by `tests/unit/config/eslint-policy.test.ts` (issue
-  #165) — a rule rename updates both.
+- Do not weaken a dependency license failure (`make lint-licenses`) by editing the gate;
+  replace the dependency or add its SPDX id to `ALLOWED_LICENSES` in the `Makefile` as a
+  reviewed one-line diff (issue #191). The gate evaluates SPDX expressions semantically via
+  `scripts/ci/check-licenses.mjs`, so `(GPL-3.0 AND MIT)` is rejected — never revert it to a
+  literal allowlist match.
+- Any new error-severity `no-restricted-syntax` entry scoped to `src/**` (e.g. a new
+  architecture convention) must land with at least one must-fail fixture in
+  `scripts/ci/eslint-gate-fixtures.mjs`, or the rot-guard in
+  `tests/unit/tooling/eslint-gate-fixtures.test.ts` fails the build (issue #189). New
+  `no-restricted-imports` entries are NOT tracked by the rot-guard today and must be verified
+  manually. Config-level gates in `eslint.config.mjs` are pinned by
+  `tests/unit/config/eslint-policy.test.ts` (issue #165) — a rule rename updates both.
 
 ## Focused Test Gates
 

--- a/.claude/skills/quality-standards/SKILL.md
+++ b/.claude/skills/quality-standards/SKILL.md
@@ -17,15 +17,16 @@ suite and should not be used as a mutating formatter.
 
 ## Quality Gates
 
-| Gate         | Command             |
-| ------------ | ------------------- |
-| Formatting   | `make format`       |
-| ESLint       | `make lint-eslint`  |
-| TypeScript   | `make lint-tsc`     |
-| Markdown     | `make lint-md`      |
-| Duplication  | `make lint-dup`     |
-| Metrics      | `make lint-metrics` |
-| Full quality | `make lint`         |
+| Gate         | Command              |
+| ------------ | -------------------- |
+| Formatting   | `make format`        |
+| ESLint       | `make lint-eslint`   |
+| TypeScript   | `make lint-tsc`      |
+| Markdown     | `make lint-md`       |
+| Duplication  | `make lint-dup`      |
+| Metrics      | `make lint-metrics`  |
+| Licenses     | `make lint-licenses` |
+| Full quality | `make lint`          |
 
 ## Protected Policy
 
@@ -35,6 +36,15 @@ suite and should not be used as a mutating formatter.
   `markdownlint-disable`. Fix the root cause.
 - Do not accept markdownlint failures in skills or docs.
 - Do not commit generated snapshots unless the visual change is intentional.
+- Do not weaken a dependency license failure (`make lint-licenses`) by editing the
+  checker invocation; replace the dependency or add its SPDX id to `ALLOWED_LICENSES`
+  in the `Makefile` as a reviewed one-line diff (issue #191).
+- Any new error-severity `no-restricted-syntax` / `no-restricted-imports` entry scoped to
+  `src/**` (e.g. a new architecture convention) must land with at least one must-fail fixture
+  in `scripts/ci/eslint-gate-fixtures.mjs`, or the rot-guard in
+  `tests/unit/tooling/eslint-gate-fixtures.test.ts` fails the build (issue #189). Config-level
+  gates in `eslint.config.mjs` are pinned by `tests/unit/config/eslint-policy.test.ts` (issue
+  #165) — a rule rename updates both.
 
 ## Focused Test Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,8 @@ diff in the `Makefile`. Never bypass or weaken the gate.
 ### ESLint gate integrity (issues #164, #165, #189)
 
 The convention gates in `eslint.config.mjs` encode policy, not style, so their **integrity** is
-itself tested — a config-level rule deletion or severity downgrade contains no `eslint-disable`
-token and would otherwise pass every existing check:
+itself tested — a config-level rule deletion or severity downgrade carries no inline suppression
+directive and would otherwise pass every existing check:
 
 - **`react-hooks/exhaustive-deps` and `no-await-in-loop` are `error`** (issue #164), not `warn` —
   a warning never fails `eslint .`. Because `eslint-comments/no-use` bans all disable directives,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ make lint-prettier  # Prettier --check formatting gate (verify-only, shares PRET
 make lint-shell     # ShellCheck over scripts, git hooks, Bats helpers (Docker, like lint-metrics)
 make lint-actionlint # actionlint gate over the GitHub Actions workflows (Docker, like lint-metrics)
 make lint-lockfile  # bun.lock resolution-provenance gate (npm registry allowlist)
+make lint-licenses  # dependency license SPDX-allowlist gate over the production tree (see below)
 make fmt-prettier   # Prettier
 make fmt-qlty       # qlty fmt
 make format         # Prettier + qlty fmt
@@ -188,6 +189,44 @@ make format         # Prettier + qlty fmt
 Git hooks are managed by Husky. Run `make husky` once after cloning.
 Agents should run `make format` before `make lint`. Formatting is intentionally
 separate from the `lint` verification suite.
+
+### Dependency license policy (issue #191)
+
+`make lint-licenses` fails the build on any **production** dependency (direct or transitive)
+whose SPDX license is outside the allowlist. It runs [`license-checker-rseidelsohn`](https://github.com/RSeidelsohn/license-checker-rseidelsohn)
+(pinned in `devDependencies` + `bun.lock`) with `--production --excludePrivatePackages
+--onlyAllow "$(ALLOWED_LICENSES)"`. It is a member of `CI_LINT_TARGETS` and the `lint:`
+aggregate, so it rides the existing `static testing` workflow via `make lint` — no dedicated
+workflow. `ALLOWED_LICENSES` (authoritative source: the `Makefile`) is trimmed to exactly the
+license families the production tree contains today, so every new family enters via an explicit,
+reviewed one-line diff. `--production` keeps the 86 devDependencies out of scope. The repo itself
+is CC0-1.0 and the SPA ships minified dependency code to browsers (a distribution event that
+triggers copyleft obligations), so a GPL/AGPL/SSPL or unlicensed dependency is a real defect.
+
+**Remediation policy** (mirrors the repo's root-cause-not-suppression rule): 1st — replace the
+offending dependency; 2nd — add its specific SPDX id as a reviewed one-line allowlist diff in the
+`Makefile`. Never bypass or filter the checker's output.
+
+### ESLint gate integrity (issues #164, #165, #189)
+
+The convention gates in `eslint.config.mjs` encode policy, not style, so their **integrity** is
+itself tested — a config-level rule deletion or severity downgrade contains no `eslint-disable`
+token and would otherwise pass every existing check:
+
+- **`react-hooks/exhaustive-deps` and `no-await-in-loop` are `error`** (issue #164), not `warn` —
+  a warning never fails `eslint .`. Because `eslint-comments/no-use` bans all disable directives,
+  an intentional mount-only effect must be **restructured** (refs / stored-callback pattern),
+  never suppressed. `react/jsx-no-bind` deliberately stays `warn` (issue #164 scope decision).
+- **`tests/unit/config/eslint-policy.test.ts`** (issue #165) pins the resolved severity + one
+  distinctive selector per load-bearing gate (issues #88/#90/#100/#107), resolved through a child
+  `node` process (`scripts/ci/print-eslint-policy-config.mjs`). A rule rename must update both the
+  config and this test.
+- **`tests/unit/tooling/eslint-gate-fixtures.test.ts`** (issue #189) runs a must-fail fixture
+  through each error-severity `no-restricted-syntax` selector (via the resolved config) and a
+  rot-guard asserting the fixture set exactly covers the live selector universe — so a **new**
+  error-severity selector added to `eslint.config.mjs` (scoped to `src/**`) cannot ship without a
+  must-fail fixture in `scripts/ci/eslint-gate-fixtures.mjs`, and a dropped/edited selector fails
+  loudly. Both tests ride the existing `unit testing` workflow via `make test-unit-all`.
 
 ## Agent Skill Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,19 +193,27 @@ separate from the `lint` verification suite.
 ### Dependency license policy (issue #191)
 
 `make lint-licenses` fails the build on any **production** dependency (direct or transitive)
-whose SPDX license is outside the allowlist. It runs [`license-checker-rseidelsohn`](https://github.com/RSeidelsohn/license-checker-rseidelsohn)
-(pinned in `devDependencies` + `bun.lock`) with `--production --excludePrivatePackages
---onlyAllow "$(ALLOWED_LICENSES)"`. It is a member of `CI_LINT_TARGETS` and the `lint:`
+whose SPDX license is not satisfied by the allowlist. It enumerates the production tree with
+[`license-checker-rseidelsohn`](https://github.com/RSeidelsohn/license-checker-rseidelsohn)
+(`--production --excludePrivatePackages --json`) and evaluates each license **semantically** via
+[`spdx-satisfies`](https://www.npmjs.com/package/spdx-satisfies) in `scripts/ci/check-licenses.mjs`
+(both pinned in `devDependencies` + `bun.lock`). Semantic evaluation is required, not a literal
+`--onlyAllow` match: `(MIT OR Apache-2.0)` passes because an allowed operand suffices, `(MIT AND
+BSD-3-Clause)` passes because both operands are allowed, `(GPL-3.0 AND MIT)` is **rejected**
+because the AND binds you to GPL, and any unparseable/unknown string (`UNKNOWN`, `SEE LICENSE IN
+…`, a guessed `MIT*`) is rejected fail-closed. It is a member of `CI_LINT_TARGETS` and the `lint:`
 aggregate, so it rides the existing `static testing` workflow via `make lint` — no dedicated
-workflow. `ALLOWED_LICENSES` (authoritative source: the `Makefile`) is trimmed to exactly the
-license families the production tree contains today, so every new family enters via an explicit,
-reviewed one-line diff. `--production` keeps the 86 devDependencies out of scope. The repo itself
-is CC0-1.0 and the SPA ships minified dependency code to browsers (a distribution event that
-triggers copyleft obligations), so a GPL/AGPL/SSPL or unlicensed dependency is a real defect.
+workflow. `ALLOWED_LICENSES` (authoritative source: the `Makefile`) lists the permitted SPDX
+**operand** ids, trimmed to what the production tree contains today, so every new family enters via
+an explicit, reviewed one-line diff. `--production` keeps the devDependencies out of scope. The
+repo itself is CC0-1.0 and the SPA ships minified dependency code to browsers (a distribution event
+that triggers copyleft obligations), so a GPL/AGPL/SSPL or unlicensed dependency is a real defect.
+The gate's own behaviour is pinned by `tests/unit/scripts/check-licenses.test.ts` (must-fail
+coverage for disallowed AND-compounds and unknown licenses).
 
 **Remediation policy** (mirrors the repo's root-cause-not-suppression rule): 1st — replace the
-offending dependency; 2nd — add its specific SPDX id as a reviewed one-line allowlist diff in the
-`Makefile`. Never bypass or filter the checker's output.
+offending dependency; 2nd — add its specific SPDX id to `ALLOWED_LICENSES` as a reviewed one-line
+diff in the `Makefile`. Never bypass or weaken the gate.
 
 ### ESLint gate integrity (issues #164, #165, #189)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,8 +269,9 @@ squash-merge-only, add the task number to the squash commit title at merge time 
 
 `make lint-licenses` gates the **license** of every production dependency (direct or transitive).
 It runs as part of `make lint` (it is a member of `CI_LINT_TARGETS` and the `lint:` aggregate),
-so the existing `static testing` workflow enforces it on every pull request. `scripts/ci/check-licenses.mjs`
-enumerates the production tree (`license-checker-rseidelsohn --json`) and evaluates each license
+so the existing `static testing` workflow enforces it on every pull request.
+`scripts/ci/check-licenses.mjs` enumerates the production tree
+(`license-checker-rseidelsohn --json`) and evaluates each license
 **semantically** with `spdx-satisfies`, so compound expressions are handled correctly — `(MIT OR
 Apache-2.0)` passes, `(GPL-3.0 AND MIT)` fails (the AND binds you to GPL), and unknown/unparseable
 strings fail closed. This is stricter than a literal allowlist match, which would wrongly accept an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,13 +269,17 @@ squash-merge-only, add the task number to the squash commit title at merge time 
 
 `make lint-licenses` gates the **license** of every production dependency (direct or transitive).
 It runs as part of `make lint` (it is a member of `CI_LINT_TARGETS` and the `lint:` aggregate),
-so the existing `static testing` workflow enforces it on every pull request — a dependency whose
-SPDX license is outside the allowlist fails the build. The allowlist lives in the `Makefile`
-(`ALLOWED_LICENSES`) and is trimmed to exactly the license families the production tree contains
-today; `--production` keeps devDependencies out of scope.
+so the existing `static testing` workflow enforces it on every pull request. `scripts/ci/check-licenses.mjs`
+enumerates the production tree (`license-checker-rseidelsohn --json`) and evaluates each license
+**semantically** with `spdx-satisfies`, so compound expressions are handled correctly — `(MIT OR
+Apache-2.0)` passes, `(GPL-3.0 AND MIT)` fails (the AND binds you to GPL), and unknown/unparseable
+strings fail closed. This is stricter than a literal allowlist match, which would wrongly accept an
+AND-compound whenever one operand happened to be allowed. The allowlist of permitted SPDX operand
+ids lives in the `Makefile` (`ALLOWED_LICENSES`), trimmed to exactly what the production tree
+contains today; `--production` keeps devDependencies out of scope.
 
 Because a dependency (or a transitive one) can **relicense between versions**, review the
 `make lint-licenses` result whenever you add or bump a dependency. If it fails, follow the
 root-cause-not-suppression remediation policy: first replace the offending dependency; only if
 that is impossible, add its specific SPDX id to `ALLOWED_LICENSES` as a reviewed one-line diff.
-Never bypass or filter the checker's output.
+Never bypass or weaken the gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,3 +264,18 @@ Dependabot cannot emit; that rule runs only in the local Husky `commit-msg` hook
 commitlint CI gate), so Dependabot pull requests are not blocked. Because the repository is
 squash-merge-only, add the task number to the squash commit title at merge time to keep
 `main`'s history conformant.
+
+### Dependency license policy (issue #191)
+
+`make lint-licenses` gates the **license** of every production dependency (direct or transitive).
+It runs as part of `make lint` (it is a member of `CI_LINT_TARGETS` and the `lint:` aggregate),
+so the existing `static testing` workflow enforces it on every pull request — a dependency whose
+SPDX license is outside the allowlist fails the build. The allowlist lives in the `Makefile`
+(`ALLOWED_LICENSES`) and is trimmed to exactly the license families the production tree contains
+today; `--production` keeps devDependencies out of scope.
+
+Because a dependency (or a transitive one) can **relicense between versions**, review the
+`make lint-licenses` result whenever you add or bump a dependency. If it fails, follow the
+root-cause-not-suppression remediation policy: first replace the offending dependency; only if
+that is impossible, add its specific SPDX id to `ALLOWED_LICENSES` as a reviewed one-line diff.
+Never bypass or filter the checker's output.

--- a/Makefile
+++ b/Makefile
@@ -366,15 +366,17 @@ lint-actionlint: ## Lint the GitHub Actions workflows with actionlint (requires 
 lint-lockfile: ## Fail if bun.lock resolves any package outside the npm registry allowlist (issue #176)
 	sh scripts/ci/check-lockfile-registries.sh
 
-# License gate remediation policy (issue #191, mirrors the repo's root-cause-not-suppression rule):
-# 1st: replace the offending dependency; 2nd: add the specific SPDX id as a reviewed one-line
-# allowlist diff. Never bypass or filter the checker's output. Compound SPDX expressions are
-# listed verbatim — the safe form if the pinned tool's expression evaluation ever regresses.
-# This list is trimmed to exactly what the production tree contains today.
-ALLOWED_LICENSES            = MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC-BY-4.0;(MIT OR Apache-2.0);(MIT AND BSD-3-Clause)
+# License gate allowlist (issue #191). These are the SPDX operand ids the production tree is
+# permitted to use; `scripts/ci/check-licenses.mjs` evaluates each dependency's license
+# expression against them SEMANTICALLY via spdx-satisfies (so `(MIT OR Apache-2.0)` and
+# `(MIT AND BSD-3-Clause)` are derived, not listed, and `(GPL-3.0 AND MIT)` is correctly
+# rejected — a literal `--onlyAllow` list cannot do this). Remediation policy (mirrors the
+# repo's root-cause-not-suppression rule): 1st replace the offending dependency; 2nd add its
+# specific SPDX id here as a reviewed one-line diff. Never bypass the checker.
+ALLOWED_LICENSES            = MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC-BY-4.0
 
 lint-licenses: ## Fail on any production dependency whose license is outside the SPDX allowlist (issue #191)
-	$(BUNX) license-checker-rseidelsohn --production --excludePrivatePackages --onlyAllow "$(ALLOWED_LICENSES)"
+	$(EXEC_DEV_TTYLESS) env ALLOWED_LICENSES='$(ALLOWED_LICENSES)' node scripts/ci/check-licenses.mjs
 
 check-env-sync: ## Assert .env and .env.example declare the same variable keys (issue #112)
 	sh scripts/check-env-sync.sh

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifneq ($(filter 1 true TRUE,$(CI)),)
 CI_SETUP_UP_FLAGS           = -d --build
 endif
 CI_SETUP_CMD                = $(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up $(CI_SETUP_UP_FLAGS) $(CI_SETUP_SERVICES) && make wait-for-dev && make wait-for-mockoon
-CI_LINT_TARGETS             = check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile
+CI_LINT_TARGETS             = check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile lint-licenses
 CI_LINT_RUNNER              = ./scripts/ci/run-parallel-lint.sh
 CI_TEST_TARGETS             = ci-test-unit-client ci-test-unit-server ci-test-integration
 CI_TEST_PROD_TARGETS        = ci-test-e2e ci-test-visual ci-test-memory-leak ci-test-load ci-test-lighthouse-desktop ci-test-lighthouse-mobile
@@ -165,7 +165,7 @@ RUN_MEMLAB                  = $(MEMLEAK_RUN_DOCKER)
 # .RECIPEPREFIX not overridden; keep default TAB
 .PHONY: $(filter-out node_modules,$(MAKECMDGOALS))
 .PHONY: clean lint lint-dup lint-metrics lint-metrics-run check-env-sync
-.PHONY: lint-eslint lint-tsc lint-md lint-deps lint-prettier lint-shell lint-actionlint lint-lockfile
+.PHONY: lint-eslint lint-tsc lint-md lint-deps lint-prettier lint-shell lint-actionlint lint-lockfile lint-licenses
 .PHONY: storybook
 .PHONY: all test
 all: help
@@ -366,6 +366,16 @@ lint-actionlint: ## Lint the GitHub Actions workflows with actionlint (requires 
 lint-lockfile: ## Fail if bun.lock resolves any package outside the npm registry allowlist (issue #176)
 	sh scripts/ci/check-lockfile-registries.sh
 
+# License gate remediation policy (issue #191, mirrors the repo's root-cause-not-suppression rule):
+# 1st: replace the offending dependency; 2nd: add the specific SPDX id as a reviewed one-line
+# allowlist diff. Never bypass or filter the checker's output. Compound SPDX expressions are
+# listed verbatim — the safe form if the pinned tool's expression evaluation ever regresses.
+# This list is trimmed to exactly what the production tree contains today.
+ALLOWED_LICENSES            = MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC-BY-4.0;(MIT OR Apache-2.0);(MIT AND BSD-3-Clause)
+
+lint-licenses: ## Fail on any production dependency whose license is outside the SPDX allowlist (issue #191)
+	$(BUNX) license-checker-rseidelsohn --production --excludePrivatePackages --onlyAllow "$(ALLOWED_LICENSES)"
+
 check-env-sync: ## Assert .env and .env.example declare the same variable keys (issue #112)
 	sh scripts/check-env-sync.sh
 
@@ -412,7 +422,7 @@ codegen-check: ensure-dev ## Reconcile contract versions and fail if generated A
 		exit 1; \
 	}
 
-lint: check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile ## Runs all linters: env-sync, ESLint, TypeScript, Markdown, dependency-cruiser, jscpd duplication, rust-code-analysis metrics, Prettier formatting, ShellCheck, actionlint, and the bun.lock provenance gate.
+lint: check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile lint-licenses ## Runs all linters: env-sync, ESLint, TypeScript, Markdown, dependency-cruiser, jscpd duplication, rust-code-analysis metrics, Prettier formatting, ShellCheck, actionlint, the bun.lock provenance gate, and the dependency license-policy gate.
 
 # ESLint suppression inventory policy. Standalone during MVP: intentionally not
 # wired into aggregate `lint` until the suppression baseline decision

--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
         "jscpd": "^4.2.5",
         "jsdoc": "^4.0.4",
         "jsdom": "^20.0.3",
+        "license-checker-rseidelsohn": "^5.0.1",
         "markdownlint-cli": "^0.49.1",
         "memlab": "^2.0.4",
         "msw": "^1.3.0",
@@ -560,6 +561,8 @@
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
 
+    "@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
+
     "@graphql-codegen/add": ["@graphql-codegen/add@7.1.0", "", { "dependencies": { "@graphql-codegen/plugin-helpers": "^7.1.0", "tslib": "^2.8.0" }, "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-bytJg1kel5zfgK3JSYbGwtpbNe6F9OPZSR6DiMDe9RVxblAgl6w4zEEPd/mM3rhNJ1VmGYLbNnf5e1eUfXQEbg=="],
 
     "@graphql-codegen/cli": ["@graphql-codegen/cli@7.2.0", "", { "dependencies": { "@babel/generator": "^7.18.13", "@babel/template": "^7.18.10", "@babel/types": "^7.18.13", "@graphql-codegen/client-preset": "^6.1.0", "@graphql-codegen/core": "^6.2.0", "@graphql-codegen/plugin-helpers": "^7.1.0", "@graphql-tools/apollo-engine-loader": "^8.0.28", "@graphql-tools/code-file-loader": "^8.1.28", "@graphql-tools/git-loader": "^8.0.32", "@graphql-tools/github-loader": "^9.0.6", "@graphql-tools/graphql-file-loader": "^8.1.11", "@graphql-tools/json-file-loader": "^8.0.26", "@graphql-tools/load": "^8.1.8", "@graphql-tools/merge": "^9.0.6", "@graphql-tools/url-loader": "^9.0.6", "@graphql-tools/utils": "^11.2.0", "@inquirer/prompts": "^8.3.2", "@whatwg-node/fetch": "^0.10.0", "chalk": "^5.6.0", "cosmiconfig": "^9.0.0", "debounce": "^3.0.0", "detect-indent": "^7.0.0", "graphql-config": "^5.1.6", "is-glob": "^4.0.1", "jiti": "^2.3.0", "json-to-pretty-yaml": "^1.2.2", "listr2": "^10.2.1", "log-symbols": "^7.0.0", "micromatch": "^4.0.5", "shell-quote": "^1.7.3", "string-env-interpolation": "^1.0.1", "ts-log": "^3.0.0", "tslib": "^2.4.0", "yaml": "^2.3.1", "yargs": "^18.0.0" }, "peerDependencies": { "@parcel/watcher": "^2.1.0", "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" }, "optionalPeers": ["@parcel/watcher"], "bin": { "gql-gen": "esm/bin.js", "graphql-codegen": "esm/bin.js", "graphql-code-generator": "esm/bin.js", "graphql-codegen-esm": "esm/bin.js", "graphql-codegen-cjs": "cjs/bin.js" } }, "sha512-JPJw2vquEIpO3b8XJyxFVTrYi6WRn/OKu/SlzQA+IwAVT7GZPeG+AHmfRXAvpVMj31899nTpQYEQGUxx3ZqubQ=="],
@@ -685,6 +688,10 @@
     "@inquirer/select": ["@inquirer/select@5.2.1", "", { "dependencies": { "@inquirer/ansi": "^2.0.7", "@inquirer/core": "^11.2.1", "@inquirer/figures": "^2.0.7", "@inquirer/type": "^4.0.7" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw=="],
 
     "@inquirer/type": ["@inquirer/type@4.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@isaacs/string-locale-compare": ["@isaacs/string-locale-compare@1.1.0", "", {}, "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
 
@@ -832,6 +839,34 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@npmcli/agent": ["@npmcli/agent@4.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^11.2.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg=="],
+
+    "@npmcli/arborist": ["@npmcli/arborist@9.6.0", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@isaacs/string-locale-compare": "^1.1.0", "@npmcli/fs": "^5.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/map-workspaces": "^5.0.0", "@npmcli/metavuln-calculator": "^9.0.2", "@npmcli/name-from-folder": "^4.0.0", "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/query": "^5.0.0", "@npmcli/redact": "^4.0.0", "@npmcli/run-script": "^10.0.0", "bin-links": "^6.0.0", "cacache": "^20.0.1", "common-ancestor-path": "^2.0.0", "hosted-git-info": "^9.0.0", "json-stringify-nice": "^1.1.4", "lru-cache": "^11.2.1", "minimatch": "^10.0.3", "nopt": "^9.0.0", "npm-install-checks": "^8.0.0", "npm-package-arg": "^13.0.0", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "pacote": "^21.0.2", "parse-conflict-json": "^5.0.1", "proc-log": "^6.0.0", "proggy": "^4.0.0", "promise-all-reject-late": "^1.0.0", "promise-call-limit": "^3.0.1", "semver": "^7.3.7", "ssri": "^13.0.0", "treeverse": "^3.0.0", "walk-up-path": "^4.0.0" }, "bin": { "arborist": "bin/index.js" } }, "sha512-Dku9UWbrrX+UCu8rQ1obGKaQAL4kwdt3hHCNXrd0n0R/4B8oq3CzloUAShwFjfsAGM6KY27gPuNftOUEZ4nhOw=="],
+
+    "@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
+
+    "@npmcli/git": ["@npmcli/git@7.0.2", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/promise-spawn": "^9.0.0", "ini": "^6.0.0", "lru-cache": "^11.2.1", "npm-pick-manifest": "^11.0.1", "proc-log": "^6.0.0", "semver": "^7.3.5", "which": "^6.0.0" } }, "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg=="],
+
+    "@npmcli/installed-package-contents": ["@npmcli/installed-package-contents@4.0.0", "", { "dependencies": { "npm-bundled": "^5.0.0", "npm-normalize-package-bin": "^5.0.0" }, "bin": { "installed-package-contents": "bin/index.js" } }, "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA=="],
+
+    "@npmcli/map-workspaces": ["@npmcli/map-workspaces@5.0.3", "", { "dependencies": { "@npmcli/name-from-folder": "^4.0.0", "@npmcli/package-json": "^7.0.0", "glob": "^13.0.0", "minimatch": "^10.0.3" } }, "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw=="],
+
+    "@npmcli/metavuln-calculator": ["@npmcli/metavuln-calculator@9.0.3", "", { "dependencies": { "cacache": "^20.0.0", "json-parse-even-better-errors": "^5.0.0", "pacote": "^21.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5" } }, "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg=="],
+
+    "@npmcli/name-from-folder": ["@npmcli/name-from-folder@4.0.0", "", {}, "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg=="],
+
+    "@npmcli/node-gyp": ["@npmcli/node-gyp@5.0.0", "", {}, "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ=="],
+
+    "@npmcli/package-json": ["@npmcli/package-json@7.0.5", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "spdx-expression-parse": "^4.0.0" } }, "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ=="],
+
+    "@npmcli/promise-spawn": ["@npmcli/promise-spawn@9.0.1", "", { "dependencies": { "which": "^6.0.0" } }, "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q=="],
+
+    "@npmcli/query": ["@npmcli/query@5.0.0", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" } }, "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ=="],
+
+    "@npmcli/redact": ["@npmcli/redact@4.0.0", "", {}, "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q=="],
+
+    "@npmcli/run-script": ["@npmcli/run-script@10.0.4", "", { "dependencies": { "@npmcli/node-gyp": "^5.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "node-gyp": "^12.1.0", "proc-log": "^6.0.0" } }, "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg=="],
+
     "@open-draft/until": ["@open-draft/until@1.0.3", "", {}, "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
@@ -976,6 +1011,18 @@
 
     "@sentry/utils": ["@sentry/utils@7.120.4", "", { "dependencies": { "@sentry/types": "7.120.4" } }, "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw=="],
 
+    "@sigstore/bundle": ["@sigstore/bundle@4.0.0", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A=="],
+
+    "@sigstore/core": ["@sigstore/core@3.2.1", "", {}, "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g=="],
+
+    "@sigstore/protobuf-specs": ["@sigstore/protobuf-specs@0.5.1", "", {}, "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g=="],
+
+    "@sigstore/sign": ["@sigstore/sign@4.1.1", "", { "dependencies": { "@gar/promise-retry": "^1.0.2", "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.0", "@sigstore/protobuf-specs": "^0.5.0", "make-fetch-happen": "^15.0.4", "proc-log": "^6.1.0" } }, "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ=="],
+
+    "@sigstore/tuf": ["@sigstore/tuf@4.0.2", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0", "tuf-js": "^4.1.0" } }, "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ=="],
+
+    "@sigstore/verify": ["@sigstore/verify@3.1.1", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.1", "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
@@ -1075,6 +1122,10 @@
     "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
+
+    "@tufjs/canonical-json": ["@tufjs/canonical-json@2.0.0", "", {}, "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="],
+
+    "@tufjs/models": ["@tufjs/models@4.1.0", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^10.1.1" } }, "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -1330,6 +1381,8 @@
 
     "abab": ["abab@2.0.6", "", {}, "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="],
 
+    "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -1385,6 +1438,8 @@
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-find-index": ["array-find-index@1.0.2", "", {}, "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw=="],
 
     "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
@@ -1494,6 +1549,8 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
+    "bin-links": ["bin-links@6.0.2", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
@@ -1529,6 +1586,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cacache": ["cacache@20.0.4", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0" } }, "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -1576,6 +1635,8 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "chrome-launcher": ["chrome-launcher@0.13.4", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^1.0.5", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0", "mkdirp": "^0.5.3", "rimraf": "^3.0.2" } }, "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
@@ -1608,6 +1669,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cmd-shim": ["cmd-shim@8.0.0", "", {}, "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA=="],
+
     "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
 
     "collect-v8-coverage": ["collect-v8-coverage@1.0.3", "", {}, "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw=="],
@@ -1627,6 +1690,8 @@
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
     "common-path-prefix": ["common-path-prefix@3.0.0", "", {}, "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="],
 
@@ -1950,6 +2015,8 @@
 
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
 
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
     "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
 
     "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
@@ -2028,6 +2095,8 @@
 
     "fs-extra": ["fs-extra@4.0.3", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg=="],
 
+    "fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
     "fs-monkey": ["fs-monkey@1.1.0", "", {}, "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
@@ -2064,7 +2133,7 @@
 
     "git-raw-commits": ["git-raw-commits@2.0.11", "", { "dependencies": { "dargs": "^7.0.0", "lodash": "^4.17.15", "meow": "^8.0.0", "split2": "^3.0.0", "through2": "^4.0.0" }, "bin": { "git-raw-commits": "cli.js" } }, "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A=="],
 
-    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -2122,7 +2191,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
 
@@ -2139,6 +2208,8 @@
     "htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
 
     "http-assert": ["http-assert@1.5.0", "", { "dependencies": { "deep-equal": "~1.0.1", "http-errors": "~1.8.0" } }, "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -2161,6 +2232,8 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "ignore-walk": ["ignore-walk@8.0.0", "", { "dependencies": { "minimatch": "^10.0.3" } }, "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A=="],
 
     "image-ssim": ["image-ssim@0.2.0", "", {}, "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="],
 
@@ -2430,6 +2503,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-nice": ["json-stringify-nice@1.1.4", "", {}, "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="],
+
     "json-to-pretty-yaml": ["json-to-pretty-yaml@1.2.2", "", { "dependencies": { "remedial": "^1.0.7", "remove-trailing-spaces": "^1.0.6" } }, "sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
@@ -2445,6 +2520,10 @@
     "jstransformer": ["jstransformer@1.0.0", "", { "dependencies": { "is-promise": "^2.0.0", "promise": "^7.0.1" } }, "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "just-diff": ["just-diff@6.0.2", "", {}, "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA=="],
+
+    "just-diff-apply": ["just-diff-apply@5.5.0", "", {}, "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw=="],
 
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
@@ -2474,6 +2553,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "license-checker-rseidelsohn": ["license-checker-rseidelsohn@5.0.1", "", { "dependencies": { "@npmcli/arborist": "9.6.0", "@npmcli/package-json": "7.0.5", "chalk": "4.1.2", "debug": "^4.3.4", "lodash.clonedeep": "^4.5.0", "mkdirp": "^1.0.4", "nopt": "^7.2.0", "semver": "^7.3.5", "spdx-correct": "^3.2.0", "spdx-expression-parse": "^4.0.0", "spdx-satisfies": "^6.0.0", "treeify": "^1.1.0" }, "bin": { "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn.js" } }, "sha512-9X+ikKxt9Hy3zOrOZzW1dXL4St5akoYjLt63Am9JZVzU6aTdN+xfDvqySpnJT+gF/h5RmtMk2waW6TDNNCKbqQ=="],
+
     "lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
 
     "lighthouse": ["lighthouse@12.6.1", "", { "dependencies": { "@paulirish/trace_engine": "0.0.53", "@sentry/node": "^7.0.0", "axe-core": "^4.10.3", "chrome-launcher": "^1.2.0", "configstore": "^5.0.1", "csp_evaluator": "1.1.5", "devtools-protocol": "0.0.1467305", "enquirer": "^2.3.6", "http-link-header": "^1.1.1", "intl-messageformat": "^10.5.3", "jpeg-js": "^0.4.4", "js-library-detector": "^6.7.0", "lighthouse-logger": "^2.0.1", "lighthouse-stack-packs": "1.12.2", "lodash-es": "^4.17.21", "lookup-closest-locale": "6.2.0", "metaviewport-parser": "0.3.0", "open": "^8.4.0", "parse-cache-control": "1.0.1", "puppeteer-core": "^24.10.0", "robots-parser": "^3.0.1", "semver": "^5.3.0", "speedline-core": "^1.4.3", "third-party-web": "^0.26.6", "tldts-icann": "^6.1.16", "ws": "^7.0.0", "yargs": "^17.3.1", "yargs-parser": "^21.0.0" }, "bin": { "lighthouse": "cli/index.js", "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js", "chrome-debug": "core/scripts/manual-chrome-launcher.js" } }, "sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A=="],
@@ -2501,6 +2582,8 @@
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@4.5.0", "", {}, "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="],
 
     "lodash.clonedeepwith": ["lodash.clonedeepwith@4.5.0", "", {}, "sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA=="],
 
@@ -2563,6 +2646,8 @@
     "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "make-fetch-happen": ["make-fetch-happen@15.0.6", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw=="],
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
@@ -2682,6 +2767,20 @@
 
     "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "minipass-fetch": ["minipass-fetch@5.0.2", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^2.0.0", "minizlib": "^3.0.1" }, "optionalDependencies": { "iconv-lite": "^0.7.2" } }, "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
@@ -2726,6 +2825,8 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "node-gyp": ["node-gyp@12.4.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw=="],
+
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
@@ -2734,9 +2835,25 @@
 
     "node-schedule": ["node-schedule@2.1.1", "", { "dependencies": { "cron-parser": "^4.2.0", "long-timeout": "0.1.1", "sorted-array-functions": "^1.3.0" } }, "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ=="],
 
+    "nopt": ["nopt@7.2.1", "", { "dependencies": { "abbrev": "^2.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w=="],
+
     "normalize-package-data": ["normalize-package-data@3.0.3", "", { "dependencies": { "hosted-git-info": "^4.0.1", "is-core-module": "^2.5.0", "semver": "^7.3.4", "validate-npm-package-license": "^3.0.1" } }, "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npm-bundled": ["npm-bundled@5.0.0", "", { "dependencies": { "npm-normalize-package-bin": "^5.0.0" } }, "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw=="],
+
+    "npm-install-checks": ["npm-install-checks@8.0.0", "", { "dependencies": { "semver": "^7.1.1" } }, "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA=="],
+
+    "npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
+
+    "npm-package-arg": ["npm-package-arg@13.0.2", "", { "dependencies": { "hosted-git-info": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^7.0.0" } }, "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA=="],
+
+    "npm-packlist": ["npm-packlist@10.0.4", "", { "dependencies": { "ignore-walk": "^8.0.0", "proc-log": "^6.0.0" } }, "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng=="],
+
+    "npm-pick-manifest": ["npm-pick-manifest@11.0.3", "", { "dependencies": { "npm-install-checks": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "npm-package-arg": "^13.0.0", "semver": "^7.3.5" } }, "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ=="],
+
+    "npm-registry-fetch": ["npm-registry-fetch@19.1.1", "", { "dependencies": { "@npmcli/redact": "^4.0.0", "jsonparse": "^1.3.1", "make-fetch-happen": "^15.0.0", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minizlib": "^3.0.1", "npm-package-arg": "^13.0.0", "proc-log": "^6.0.0" } }, "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
@@ -2798,17 +2915,23 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "p-map": ["p-map@7.0.6", "", {}, "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
+    "pacote": ["pacote@21.5.1", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/git": "^7.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "@npmcli/run-script": "^10.0.0", "cacache": "^20.0.0", "fs-minipass": "^3.0.0", "minipass": "^7.0.2", "npm-package-arg": "^13.0.0", "npm-packlist": "^10.0.1", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "sigstore": "^4.0.0", "ssri": "^13.0.0", "tar": "^7.4.3" }, "bin": { "pacote": "bin/index.js" } }, "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg=="],
+
     "param-case": ["param-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-cache-control": ["parse-cache-control@1.0.1", "", {}, "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="],
+
+    "parse-conflict-json": ["parse-conflict-json@5.0.1", "", { "dependencies": { "json-parse-even-better-errors": "^5.0.0", "just-diff": "^6.0.0", "just-diff-apply": "^5.2.0" } }, "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
@@ -2839,6 +2962,8 @@
     "path-root": ["path-root@0.1.1", "", { "dependencies": { "path-root-regex": "^0.1.0" } }, "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg=="],
 
     "path-root-regex": ["path-root-regex@0.1.2", "", {}, "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -2888,9 +3013,17 @@
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
+    "proggy": ["proggy@4.0.0", "", {}, "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
+
+    "promise-all-reject-late": ["promise-all-reject-late@1.0.1", "", {}, "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw=="],
+
+    "promise-call-limit": ["promise-call-limit@3.0.2", "", {}, "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -2979,6 +3112,8 @@
     "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
+
+    "read-cmd-shim": ["read-cmd-shim@6.0.0", "", {}, "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A=="],
 
     "read-pkg": ["read-pkg@5.2.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.0", "normalize-package-data": "^2.5.0", "parse-json": "^5.0.0", "type-fest": "^0.6.0" } }, "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg=="],
 
@@ -3142,6 +3277,8 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "sigstore": ["sigstore@4.1.1", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.2.1", "@sigstore/protobuf-specs": "^0.5.0", "@sigstore/sign": "^4.1.1", "@sigstore/tuf": "^4.0.2", "@sigstore/verify": "^3.1.1" } }, "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w=="],
+
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -3172,13 +3309,19 @@
 
     "spark-md5": ["spark-md5@3.0.2", "", {}, "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="],
 
+    "spdx-compare": ["spdx-compare@1.0.0", "", { "dependencies": { "array-find-index": "^1.0.2", "spdx-expression-parse": "^3.0.0", "spdx-ranges": "^2.0.0" } }, "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A=="],
+
     "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
 
     "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
 
-    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+    "spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
 
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
+
+    "spdx-ranges": ["spdx-ranges@2.1.1", "", {}, "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA=="],
+
+    "spdx-satisfies": ["spdx-satisfies@6.0.0", "", { "dependencies": { "spdx-compare": "^1.0.0", "spdx-expression-parse": "^3.0.0", "spdx-ranges": "^2.0.0" } }, "sha512-oOWQocnRbFVtBnBITfFgzjhnOklHossTvI+6C1hB2slvp3HgTsfru5wuo8HY2rQpwSm5JuIhNzIuqOfR5IuojQ=="],
 
     "speedline-core": ["speedline-core@1.4.3", "", { "dependencies": { "@types/node": "*", "image-ssim": "^0.2.0", "jpeg-js": "^0.4.1" } }, "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog=="],
 
@@ -3187,6 +3330,8 @@
     "sponge-case": ["sponge-case@2.0.3", "", {}, "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
     "stable-hash-x": ["stable-hash-x@0.2.0", "", {}, "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ=="],
 
@@ -3260,6 +3405,8 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
     "tar-fs": ["tar-fs@3.1.1", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg=="],
 
     "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
@@ -3318,6 +3465,10 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "treeify": ["treeify@1.1.0", "", {}, "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="],
+
+    "treeverse": ["treeverse@3.0.0", "", {}, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
+
     "trim-newlines": ["trim-newlines@3.0.1", "", {}, "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="],
 
     "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
@@ -3345,6 +3496,8 @@
     "tsutils": ["tsutils@3.21.0", "", { "dependencies": { "tslib": "^1.8.1" }, "peerDependencies": { "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta" } }, "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA=="],
 
     "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
+    "tuf-js": ["tuf-js@4.1.0", "", { "dependencies": { "@tufjs/models": "4.1.0", "debug": "^4.4.3", "make-fetch-happen": "^15.0.1" } }, "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
@@ -3383,6 +3536,8 @@
     "unc-path-regex": ["unc-path-regex@0.1.2", "", {}, "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg=="],
 
     "underscore": ["underscore@1.13.7", "", {}, "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="],
+
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -3440,6 +3595,8 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
     "value-or-promise": ["value-or-promise@1.0.12", "", {}, "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -3449,6 +3606,8 @@
     "w3c-xmlserializer": ["w3c-xmlserializer@4.0.0", "", { "dependencies": { "xml-name-validator": "^4.0.0" } }, "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw=="],
 
     "wait-on": ["wait-on@9.1.0", "", { "dependencies": { "axios": "^1.18.1", "joi": "^18.2.3", "lodash": "^4.18.1", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-PymrLXHLBM1Ju/Xspb2ADUhbPSMvbnuNvy/mN2hWtpbJ3da0h3Ky1LqwKPG5QSVR57liyO0iUpfipYl/s5qNvA=="],
+
+    "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
@@ -3704,6 +3863,8 @@
 
     "@jest/reporters/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@jest/reporters/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "@jest/reporters/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
     "@jest/reporters/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -3784,6 +3945,32 @@
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
+    "@npmcli/agent/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "@npmcli/agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "@npmcli/agent/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "@npmcli/arborist/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "@npmcli/arborist/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@npmcli/arborist/nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
+
+    "@npmcli/git/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "@npmcli/git/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "@npmcli/git/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
+    "@npmcli/map-workspaces/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@npmcli/metavuln-calculator/json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
+
+    "@npmcli/package-json/json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
+
+    "@npmcli/promise-spawn/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "@paulirish/trace_engine/third-party-web": ["third-party-web@0.29.2", "", {}, "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g=="],
 
     "@redocly/openapi-core/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -3850,6 +4037,8 @@
 
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "@tufjs/models/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
@@ -3882,6 +4071,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "bin-links/write-file-atomic": ["write-file-atomic@7.0.1", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg=="],
+
     "blamer/execa": ["execa@4.1.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "get-stream": "^5.0.0", "human-signals": "^1.1.1", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.0", "onetime": "^5.1.0", "signal-exit": "^3.0.2", "strip-final-newline": "^2.0.0" } }, "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA=="],
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3895,6 +4086,8 @@
     "boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "boxen/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "cacache/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "catharsis/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
@@ -4028,7 +4221,7 @@
 
     "git-raw-commits/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
-    "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
@@ -4046,7 +4239,7 @@
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+    "hosted-git-info/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "html-minifier-terser/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -4067,6 +4260,8 @@
     "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "ignore-walk/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -4100,6 +4295,8 @@
 
     "jest-config/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "jest-config/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "jest-config/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "jest-diff/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -4121,6 +4318,8 @@
     "jest-runner/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
     "jest-runtime/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-runtime/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
@@ -4158,6 +4357,8 @@
 
     "koa/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "license-checker-rseidelsohn/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "lighthouse/chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
     "lighthouse/lighthouse-logger": ["lighthouse-logger@2.0.2", "", { "dependencies": { "debug": "^4.4.1", "marky": "^1.2.2" } }, "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg=="],
@@ -4183,6 +4384,8 @@
     "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -4212,6 +4415,12 @@
 
     "minimist-options/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 
+    "minipass-fetch/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
     "msw/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "msw/inquirer": ["inquirer@8.2.7", "", { "dependencies": { "@inquirer/external-editor": "^1.0.0", "ansi-escapes": "^4.2.1", "chalk": "^4.1.1", "cli-cursor": "^3.1.0", "cli-width": "^3.0.0", "figures": "^3.0.0", "lodash": "^4.17.21", "mute-stream": "0.0.8", "ora": "^5.4.1", "run-async": "^2.4.0", "rxjs": "^7.5.5", "string-width": "^4.1.0", "strip-ansi": "^6.0.0", "through": "^2.3.6", "wrap-ansi": "^6.0.1" } }, "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA=="],
@@ -4220,7 +4429,15 @@
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "node-gyp/nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
+
+    "node-gyp/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "node-sarif-builder/fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
+
+    "normalize-package-data/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "normalize-package-data/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -4240,7 +4457,11 @@
 
     "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
+    "parse-conflict-json/json-parse-even-better-errors": ["json-parse-even-better-errors@5.0.0", "", {}, "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ=="],
+
     "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "pkg-dir/find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
 
@@ -4294,6 +4515,8 @@
 
     "restore-cursor/onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
 
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "sass/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
@@ -4320,6 +4543,12 @@
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "spdx-compare/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-correct/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
+    "spdx-satisfies/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "storybook/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -4338,11 +4567,15 @@
 
     "sync-fetch/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
+    "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
     "terser/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "terser/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -4383,6 +4616,8 @@
     "unixify/normalize-path": ["normalize-path@2.1.1", "", { "dependencies": { "remove-trailing-separator": "^1.0.1" } }, "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w=="],
 
     "unplugin/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "validate-npm-package-license/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
     "webpack/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -4490,6 +4725,8 @@
 
     "@jest/reporters/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "@jest/reporters/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "@jest/reporters/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "@jest/reporters/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -4576,6 +4813,16 @@
 
     "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
+    "@npmcli/arborist/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@npmcli/arborist/nopt/abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
+    "@npmcli/git/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
+    "@npmcli/map-workspaces/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@npmcli/promise-spawn/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
     "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
@@ -4652,6 +4899,8 @@
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "@tufjs/models/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "babel-jest/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4661,6 +4910,8 @@
     "babel-plugin-macros/cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
+    "bin-links/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "blamer/execa/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
@@ -4744,13 +4995,13 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
     "graphql-config/cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "graphql-config/cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "graphql-config/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
-
-    "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "html-webpack-plugin/@rspack/core/@module-federation/runtime-tools": ["@module-federation/runtime-tools@0.21.6", "", { "dependencies": { "@module-federation/runtime": "0.21.6", "@module-federation/webpack-bundler-runtime": "0.21.6" } }, "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q=="],
 
@@ -4761,6 +5012,8 @@
     "http-assert/http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
 
     "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
+    "ignore-walk/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "import-local/pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -4784,6 +5037,8 @@
 
     "jest-config/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-config/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "jest-diff/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "jest-each/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4801,6 +5056,8 @@
     "jest-runner/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jest-runtime/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "jest-runtime/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "jest-snapshot/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -4821,6 +5078,8 @@
     "jscpd/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "koa/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "license-checker-rseidelsohn/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -4848,6 +5107,10 @@
 
     "memlab/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "msw/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "msw/inquirer/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
@@ -4870,9 +5133,15 @@
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "node-gyp/nopt/abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
+    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
     "node-sarif-builder/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "node-sarif-builder/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "ora/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -4898,6 +5167,8 @@
 
     "restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
 
+    "rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "sass/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -4909,6 +5180,8 @@
     "string-length/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "tmp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "tsconfig-paths-webpack-plugin/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -4992,6 +5265,10 @@
 
     "@microsoft/api-extractor/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "@npmcli/arborist/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@npmcli/map-workspaces/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "@storybook/builder-webpack5/css-loader/@rspack/core/@module-federation/runtime-tools": ["@module-federation/runtime-tools@0.21.6", "", { "dependencies": { "@module-federation/runtime": "0.21.6", "@module-federation/webpack-bundler-runtime": "0.21.6" } }, "sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q=="],
 
     "@storybook/builder-webpack5/css-loader/@rspack/core/@rspack/binding": ["@rspack/binding@1.6.8", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.6.8", "@rspack/binding-darwin-x64": "1.6.8", "@rspack/binding-linux-arm64-gnu": "1.6.8", "@rspack/binding-linux-arm64-musl": "1.6.8", "@rspack/binding-linux-x64-gnu": "1.6.8", "@rspack/binding-linux-x64-musl": "1.6.8", "@rspack/binding-wasm32-wasi": "1.6.8", "@rspack/binding-win32-arm64-msvc": "1.6.8", "@rspack/binding-win32-ia32-msvc": "1.6.8", "@rspack/binding-win32-x64-msvc": "1.6.8" } }, "sha512-lUeL4mbwGo+nqRKqFDCm9vH2jv9FNMVt1X8jqayWRcOCPlj/2UVMEFgqjR7Pp2vlvnTKq//31KbDBJmDZq31RQ=="],
@@ -5042,6 +5319,8 @@
 
     "@stryker-mutator/instrumenter/@babel/plugin-proposal-decorators/@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@tufjs/models/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "blamer/execa/npm-run-path/path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -5076,6 +5355,8 @@
 
     "fork-ts-checker-webpack-plugin/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "graphql-config/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "html-webpack-plugin/@rspack/core/@module-federation/runtime-tools/@module-federation/runtime": ["@module-federation/runtime@0.21.6", "", { "dependencies": { "@module-federation/error-codes": "0.21.6", "@module-federation/runtime-core": "0.21.6", "@module-federation/sdk": "0.21.6" } }, "sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ=="],
@@ -5101,6 +5382,8 @@
     "html-webpack-plugin/@rspack/core/@rspack/binding/@rspack/binding-win32-ia32-msvc": ["@rspack/binding-win32-ia32-msvc@1.6.8", "", { "os": "win32", "cpu": "ia32" }, "sha512-cFgRE3APxrY4AEdooVk2LtipwNNT/9mrnjdC5lVbsIsz+SxvGbZR231bxDJEqP15+RJOaD07FO1sIjINFqXMEg=="],
 
     "html-webpack-plugin/@rspack/core/@rspack/binding/@rspack/binding-win32-x64-msvc": ["@rspack/binding-win32-x64-msvc@1.6.8", "", { "os": "win32", "cpu": "x64" }, "sha512-cIuhVsZYd3o3Neo1JSAhJYw6BDvlxaBoqvgwRkG1rs0ExFmEmgYyG7ip9pFKnKNWph/tmW3rDYypmEfjs1is7g=="],
+
+    "ignore-walk/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "import-local/pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -5128,11 +5411,15 @@
 
     "msw/inquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "normalize-package-data/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "renderkid/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
+
+    "tmp/rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "sass-loader": "^13.3.3",
         "semver": "^7.8.5",
         "serve": "^14.2.6",
+        "spdx-satisfies": "^6.0.0",
         "storybook": "^9.1.5",
         "style-loader": "^3.3.4",
         "ts-jest": "^29.4.11",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -280,11 +280,20 @@ export default [
       ...importPlugin.flatConfigs.typescript.rules,
       ...jsxA11y.flatConfigs.recommended.rules,
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
+      // issue #164: promoted from 'warn' — a missing hook dependency ships stale-closure
+      // bugs with a green ESLint status; zero violations today, so the flip is free. Since
+      // `eslint-comments/no-use` bans all disable directives, intentional mount-only effects
+      // must be restructured (refs / stored-callback), never suppressed. See CLAUDE.md.
+      'react-hooks/exhaustive-deps': 'error',
       ...eslintComments.configs.recommended.rules,
       'eslint-comments/no-use': 'error',
+      // issue #164: `react/jsx-no-bind` deliberately stays 'warn' — React's guidance does not
+      // treat inline handler props as a defect, and with disables banned, promoting it would
+      // force useCallback everywhere with no escape hatch (see issue #164 scope decision 2).
       'react/jsx-no-bind': 'warn',
-      'no-await-in-loop': 'warn',
+      // issue #164: promoted from 'warn' — sequential-await perf regressions in src merged
+      // silently; zero violations today. Tests stay 'off' (test-file override below).
+      'no-await-in-loop': 'error',
       'no-restricted-syntax': 'warn',
       'no-alert': 'error',
       'no-console': ['error', { allow: ['warn', 'error'] }],

--- a/jest.mutation.config.ts
+++ b/jest.mutation.config.ts
@@ -15,6 +15,10 @@ const config: Config = {
     '/tests/unit/scripts/',
     '/tests/unit/performance/',
     '/tests/unit/load/',
+    // Config-integrity meta-test (issue #165): resolves eslint.config.mjs via a child process
+    // and exercises no src, so it kills zero mutants — same rationale as the tooling meta-tests
+    // above, kept out of the mutation suite to avoid subprocess churn under Stryker.
+    '/tests/unit/config/eslint-policy\\.test\\.ts$',
   ],
   testEnvironment: require.resolve('./tests/jsdom-fetch-environment.cjs'),
   setupFilesAfterEnv: ['<rootDir>/tests/mutation/setup.ts'],

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "sass-loader": "^13.3.3",
     "semver": "^7.8.5",
     "serve": "^14.2.6",
+    "spdx-satisfies": "^6.0.0",
     "storybook": "^9.1.5",
     "style-loader": "^3.3.4",
     "ts-jest": "^29.4.11",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "jscpd": "^4.2.5",
     "jsdoc": "^4.0.4",
     "jsdom": "^20.0.3",
+    "license-checker-rseidelsohn": "^5.0.1",
     "markdownlint-cli": "^0.49.1",
     "memlab": "^2.0.4",
     "msw": "^1.3.0",

--- a/scripts/ci/check-licenses.mjs
+++ b/scripts/ci/check-licenses.mjs
@@ -1,0 +1,122 @@
+// scripts/ci/check-licenses.mjs
+//
+// SPDX-aware dependency license gate (issue #191). Enumerates the production dependency tree
+// with license-checker-rseidelsohn (--json) and validates every declared license against the
+// SPDX allowlist in ALLOWED_LICENSES using `spdx-satisfies`, which evaluates compound
+// expressions SEMANTICALLY:
+//   - `(A OR B)`  passes iff at least one operand is allowed (you may take that option);
+//   - `(A AND B)` passes iff EVERY operand is allowed (you are bound by all of them);
+//   - a non-SPDX / unknown string ("UNKNOWN", "SEE LICENSE IN …", "Custom", guessed "MIT*")
+//     throws in the parser and is treated as DISALLOWED (fail-closed).
+//
+// A literal `--onlyAllow` allowlist (the prior implementation) is NOT sufficient: license-
+// checker's operand matching lets `(GPL-3.0-only AND MIT)` pass merely because MIT is allowed,
+// even though the AND expression binds you to GPL. This gate closes that hole.
+//
+// Runs in a plain `node` process from the Makefile (`make lint-licenses`). `--stdin` reads a
+// license map from stdin instead of shelling out, so the gate's own logic is unit-tested
+// (tests/unit/scripts/check-licenses.test.ts) without fixture node_modules trees.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import spdxSatisfies from 'spdx-satisfies';
+
+/**
+ * Parse the semicolon-separated SPDX operand allowlist (e.g. "MIT;Apache-2.0;ISC").
+ * @param {string} raw value of ALLOWED_LICENSES
+ * @returns {string[]} trimmed, non-empty SPDX operand ids
+ */
+function parseAllowed(raw) {
+  return (raw || '')
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Normalize license-checker's `licenses` field (string | string[]) to one SPDX expression.
+ * An array means several licenses were detected for one package; join with AND so the pool must
+ * satisfy every one (fail-closed).
+ * @param {string|string[]} licenses
+ * @returns {string} an SPDX expression (empty string when no license was detected)
+ */
+function toExpression(licenses) {
+  if (Array.isArray(licenses)) return licenses.map((license) => `(${license})`).join(' AND ');
+  return String(licenses ?? '');
+}
+
+/**
+ * @param {string} expression an SPDX license expression
+ * @param {string[]} allowed the permitted operand pool
+ * @returns {boolean} true iff `expression` is satisfied by `allowed`; unparseable/unknown
+ *   strings throw in the parser and are rejected (fail-closed).
+ */
+function isAllowed(expression, allowed) {
+  if (!expression) return false;
+  try {
+    return spdxSatisfies(expression, allowed);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {Record<string, {licenses?: string|string[]}>} licenseMap license-checker JSON output
+ * @param {string[]} allowed the permitted operand pool
+ * @returns {{pkg: string, license: string}[]} packages whose license is not satisfied by `allowed`
+ */
+function findOffenders(licenseMap, allowed) {
+  const offenders = [];
+  for (const [pkg, info] of Object.entries(licenseMap)) {
+    const expression = toExpression(info?.licenses);
+    if (!isAllowed(expression, allowed)) {
+      offenders.push({ pkg, license: expression || '(none)' });
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Obtain the production dependency license map — from stdin in `--stdin` (test) mode, otherwise
+ * by shelling out to license-checker-rseidelsohn over the production tree.
+ * @returns {Record<string, {licenses?: string|string[]}>}
+ */
+function readLicenseMap() {
+  if (process.argv.includes('--stdin')) {
+    return JSON.parse(readFileSync(0, 'utf8'));
+  }
+  const json = execFileSync(
+    'node_modules/.bin/license-checker-rseidelsohn',
+    ['--production', '--excludePrivatePackages', '--json'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  return JSON.parse(json);
+}
+
+const allowed = parseAllowed(process.env.ALLOWED_LICENSES);
+if (allowed.length === 0) {
+  process.stderr.write('check-licenses: ALLOWED_LICENSES is empty — refusing to run.\n');
+  process.exit(2);
+}
+
+const licenseMap = readLicenseMap();
+const offenders = findOffenders(licenseMap, allowed);
+
+if (offenders.length > 0) {
+  process.stderr.write(
+    'Dependency license gate failed — licenses not satisfied by the SPDX allowlist:\n'
+  );
+  for (const offender of offenders) {
+    process.stderr.write(`  ${offender.pkg}: ${offender.license}\n`);
+  }
+  process.stderr.write(`Allowed operands: ${allowed.join(', ')}\n`);
+  process.stderr.write(
+    'Remediation (issue #191): replace the dependency, or add its SPDX id to ALLOWED_LICENSES ' +
+      'in the Makefile as a reviewed one-line diff. Never bypass the checker.\n'
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `license gate: ${Object.keys(licenseMap).length} production dependencies satisfy the SPDX allowlist.\n`
+);

--- a/scripts/ci/eslint-gate-fixtures.mjs
+++ b/scripts/ci/eslint-gate-fixtures.mjs
@@ -10,6 +10,7 @@
 // jest.config.ts runs CJS Jest with no --experimental-vm-modules, and ESLint v9 loads the flat
 // eslint.config.mjs via a native dynamic import() that fails inside Jest's vm context.
 import { ESLint, Linter } from 'eslint';
+import flatConfig from '../../eslint.config.mjs';
 
 const eslint = new ESLint({ cwd: process.cwd() });
 
@@ -133,8 +134,19 @@ const FIXTURES = [
     rule: 'no-restricted-syntax',
     tag: 'issue #100',
   },
+  // S.arrowConst is a 3-alternative comma-separated selector; one fixture per branch so a
+  // broken alternative cannot pass unnoticed (plain top-level const, export const, default export).
   {
-    id: 'arrow-const',
+    id: 'arrow-const-plain',
+    file: PROBES.logic,
+    code: 'const a = (): void => {};',
+    covers: [S.arrowConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'arrow-const-export',
     file: PROBES.logic,
     code: 'export const a = (): void => {};',
     covers: [S.arrowConst],
@@ -143,9 +155,40 @@ const FIXTURES = [
     tag: 'issue #100',
   },
   {
-    id: 'funcexpr-const',
+    id: 'arrow-default-export',
+    file: PROBES.logic,
+    code: 'export default (): void => {};',
+    covers: [S.arrowConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  // S.funcExprConst is likewise a 3-alternative selector: plain const, export const, and a
+  // default-exported function EXPRESSION. The expression branch needs parentheses — a bare
+  // `export default function () {}` parses as a FunctionDeclaration (covered by S.defaultFuncDecl,
+  // the `default-generator` fixture), not a FunctionExpression.
+  {
+    id: 'funcexpr-const-plain',
     file: PROBES.logic,
     code: 'const b = function (): void {};',
+    covers: [S.funcExprConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'funcexpr-const-export',
+    file: PROBES.logic,
+    code: 'export const b = function (): void {};',
+    covers: [S.funcExprConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'funcexpr-default-export',
+    file: PROBES.logic,
+    code: 'export default (function (): void {});',
     covers: [S.funcExprConst],
     expect: 'fail',
     rule: 'no-restricted-syntax',
@@ -170,7 +213,17 @@ const FIXTURES = [
     rule: 'no-restricted-syntax',
     tag: 'issue #88',
   },
-  // process.env ban (#112) — computed access is the adversarial variant that once bypassed the gate
+  // process.env ban (#112) — a 2-alternative selector; both branches get a fixture. Computed
+  // access (`process['env']`) is the adversarial variant that once bypassed the dot-only gate.
+  {
+    id: 'process-env-dot',
+    file: PROBES.logic,
+    code: 'const e = process.env;',
+    covers: [S.processEnv],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #112',
+  },
   {
     id: 'process-env-computed',
     file: PROBES.logic,
@@ -217,6 +270,10 @@ const FIXTURES = [
     rule: 'no-restricted-syntax',
     tag: 'issue #88',
   },
+  // S.stmtInType bans 13 homogeneous statement node types in one selector. One representative
+  // (IfStatement) proves the selector is wired; a per-branch fixture for every type is not
+  // feasible — `WithStatement` is a hard SyntaxError in a strict ES module, so it cannot be
+  // exercised through the parser at all.
   {
     id: 'statement-in-type',
     file: PROBES.typeOnly,
@@ -315,14 +372,29 @@ async function runFixture(fx) {
 const probes = {};
 for (const [key, file] of Object.entries(PROBES)) probes[key] = await resolveProbe(file);
 
-// Universe: every error-severity no-restricted-syntax selector across the src scopes.
-const universe = [
-  ...new Set(
-    Object.values(probes)
-      .filter((p) => p.severity === 2)
-      .flatMap((p) => p.selectors)
-  ),
-].sort();
+// Universe: every error-severity `no-restricted-syntax` selector in EVERY src-scoped override
+// block, derived from the flat config itself — NOT from the handful of representative probe
+// paths. A selector added to a new/unprobed `src/**` scope therefore still enters the universe
+// (and the rot-guard demands a fixture for it). A block counts as src-scoped when any of its
+// `files` globs targets `src/`; the warn-level base block and the tests-scoped overrides are
+// excluded by the severity + scope filters. Config selector strings are identical to those
+// `calculateConfigForFile` resolves (ESLint never rewrites them).
+const SRC_ERROR_SEVERITIES = new Set(['error', 2]);
+function isSrcScoped(files) {
+  return Array.isArray(files) && files.some((f) => typeof f === 'string' && f.startsWith('src/'));
+}
+function deriveUniverse(config) {
+  const selectors = new Set();
+  for (const entry of config) {
+    const nrs = entry?.rules?.['no-restricted-syntax'];
+    if (!Array.isArray(nrs) || !SRC_ERROR_SEVERITIES.has(nrs[0]) || !isSrcScoped(entry.files)) {
+      continue;
+    }
+    for (const selector of selectorsOf(nrs)) selectors.add(selector);
+  }
+  return [...selectors].sort();
+}
+const universe = deriveUniverse(flatConfig);
 
 const fixtures = [];
 for (const fx of FIXTURES) {

--- a/scripts/ci/eslint-gate-fixtures.mjs
+++ b/scripts/ci/eslint-gate-fixtures.mjs
@@ -323,25 +323,36 @@ const FIXTURES = [
   },
 ];
 
+/** @param {unknown} entry a resolved rule value @returns {unknown} its severity (index 0 of an array form) */
 function severityOf(entry) {
   return Array.isArray(entry) ? entry[0] : entry;
 }
+/** @param {unknown} entry a resolved `no-restricted-syntax` value @returns {string[]} its selector strings */
 function selectorsOf(entry) {
   return Array.isArray(entry)
     ? entry.slice(1).map((e) => (typeof e === 'string' ? e : e.selector))
     : [];
 }
 
+/**
+ * Resolve the effective `no-restricted-syntax` severity + selectors for a virtual src path.
+ * @param {string} file a representative (possibly non-existent) path under a src override scope
+ * @returns {Promise<{severity: unknown, selectors: string[]}>}
+ */
 async function resolveProbe(file) {
   const cfg = await eslint.calculateConfigForFile(file);
   const nrs = cfg.rules?.['no-restricted-syntax'];
   return { severity: severityOf(nrs), selectors: selectorsOf(nrs) };
 }
 
-// Strip type-aware parser settings: calculateConfigForFile returns `parserOptions.project`
-// (type-checked linting), which rejects the virtual fixture paths ("TSConfig does not include
-// this file"). The gates under test are purely syntactic (no-restricted-syntax /
-// no-restricted-imports), so a non-type-aware parse is both sufficient and correct.
+/**
+ * Strip type-aware parser settings: calculateConfigForFile returns `parserOptions.project`
+ * (type-checked linting), which rejects the virtual fixture paths ("TSConfig does not include
+ * this file"). The gates under test are purely syntactic (no-restricted-syntax /
+ * no-restricted-imports), so a non-type-aware parse is both sufficient and correct.
+ * @param {object} languageOptions resolved languageOptions from calculateConfigForFile
+ * @returns {object} the same options with type-aware project settings removed
+ */
 function sanitizeLanguageOptions(languageOptions) {
   const parserOptions = { ...(languageOptions.parserOptions || {}) };
   delete parserOptions.project;
@@ -352,6 +363,11 @@ function sanitizeLanguageOptions(languageOptions) {
   return { ...languageOptions, parserOptions };
 }
 
+/**
+ * Lint a fixture's code with the RESOLVED languageOptions + rule for its scope.
+ * @param {{file: string, code: string, rule: string}} fx a fixture entry
+ * @returns {Promise<{ruleId: string|null, message: string, line: number}[]>} the rule's messages
+ */
 async function runFixture(fx) {
   const cfg = await eslint.calculateConfigForFile(fx.file);
   const linter = new Linter({ configType: 'flat' });
@@ -369,8 +385,11 @@ async function runFixture(fx) {
   return messages.map((m) => ({ ruleId: m.ruleId, message: m.message, line: m.line }));
 }
 
-const probes = {};
-for (const [key, file] of Object.entries(PROBES)) probes[key] = await resolveProbe(file);
+// Resolve all probes concurrently (independent calculateConfigForFile calls).
+const probeEntries = await Promise.all(
+  Object.entries(PROBES).map(async ([key, file]) => [key, await resolveProbe(file)])
+);
+const probes = Object.fromEntries(probeEntries);
 
 // Universe: every error-severity `no-restricted-syntax` selector in EVERY src-scoped override
 // block, derived from the flat config itself — NOT from the handful of representative probe
@@ -380,9 +399,14 @@ for (const [key, file] of Object.entries(PROBES)) probes[key] = await resolvePro
 // excluded by the severity + scope filters. Config selector strings are identical to those
 // `calculateConfigForFile` resolves (ESLint never rewrites them).
 const SRC_ERROR_SEVERITIES = new Set(['error', 2]);
+/** @param {unknown} files a flat-config block's `files` @returns {boolean} true if any glob targets src/ */
 function isSrcScoped(files) {
   return Array.isArray(files) && files.some((f) => typeof f === 'string' && f.startsWith('src/'));
 }
+/**
+ * @param {Array<{files?: unknown, rules?: Record<string, unknown>}>} config the flat config array
+ * @returns {string[]} sorted union of error-severity no-restricted-syntax selectors in src scopes
+ */
 function deriveUniverse(config) {
   const selectors = new Set();
   for (const entry of config) {
@@ -396,18 +420,17 @@ function deriveUniverse(config) {
 }
 const universe = deriveUniverse(flatConfig);
 
-const fixtures = [];
-for (const fx of FIXTURES) {
-  const messages = await runFixture(fx);
-  fixtures.push({
+// Run all fixtures concurrently; each resolves its own config and lints in isolation.
+const fixtures = await Promise.all(
+  FIXTURES.map(async (fx) => ({
     id: fx.id,
     file: fx.file,
     covers: fx.covers,
     expect: fx.expect,
     rule: fx.rule,
     tag: fx.tag,
-    messages,
-  });
-}
+    messages: await runFixture(fx),
+  }))
+);
 
 process.stdout.write(JSON.stringify({ probes, universe, fixtures }));

--- a/scripts/ci/eslint-gate-fixtures.mjs
+++ b/scripts/ci/eslint-gate-fixtures.mjs
@@ -1,0 +1,341 @@
+// scripts/ci/eslint-gate-fixtures.mjs
+//
+// Adversarial coverage for the custom ESLint enforcement selectors in eslint.config.mjs
+// (issue #189). Resolves the effective flat-config for representative src paths, runs
+// forbidden-pattern fixtures through the RESOLVED rule options + languageOptions (parser and
+// parserOptions come from calculateConfigForFile, never hand-built), and enumerates the
+// error-severity selector universe so a new selector cannot ship without a must-fail fixture.
+//
+// Runs in a plain `node` child process (spawned by tests/unit/tooling/eslint-gate-fixtures.test.ts):
+// jest.config.ts runs CJS Jest with no --experimental-vm-modules, and ESLint v9 loads the flat
+// eslint.config.mjs via a native dynamic import() that fails inside Jest's vm context.
+import { ESLint, Linter } from 'eslint';
+
+const eslint = new ESLint({ cwd: process.cwd() });
+
+// One virtual probe per load-bearing src override scope. calculateConfigForFile resolves by
+// glob, so the files need not exist — the resolved block is what matters.
+const PROBES = {
+  logic: 'src/services/__probe__.ts', // non-React logic .ts (no-static #100 + data-testid + type-decl + process.env)
+  component: 'src/components/__probe__.tsx', // component (data-testid + type-decl)
+  typeOnly: 'src/modules/user/features/auth/types/__probe__.ts', // type-only file (#88 purity)
+  hook: 'src/modules/user/features/auth/stores/use-__probe__.ts', // hook — EXEMPT from #100
+  env: 'src/config/env/__probe__.ts', // env config (#112 process.env)
+};
+
+// Exact selector strings, copied verbatim from the resolved config. The rot-guard compares the
+// live universe against the union of fixture `covers`, so any edit to a selector string in
+// eslint.config.mjs changes the universe and fails until a fixture is updated to match.
+const S = {
+  testidJsx: "JSXAttribute[name.name='data-testid']",
+  testidProp: "Property[key.value='data-testid']",
+  testidPropSig: "TSPropertySignature[key.value='data-testid']",
+  staticMethod: 'MethodDefinition[static=true]',
+  staticProp: 'PropertyDefinition[static=true]',
+  funcDecl: 'Program > FunctionDeclaration',
+  exportFuncDecl: 'Program > ExportNamedDeclaration > FunctionDeclaration',
+  defaultFuncDecl: 'ExportDefaultDeclaration > FunctionDeclaration',
+  arrowConst:
+    "Program > VariableDeclaration > VariableDeclarator[init.type='ArrowFunctionExpression'], Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator[init.type='ArrowFunctionExpression'], ExportDefaultDeclaration > ArrowFunctionExpression",
+  funcExprConst:
+    "Program > VariableDeclaration > VariableDeclarator[init.type='FunctionExpression'], Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator[init.type='FunctionExpression'], ExportDefaultDeclaration > FunctionExpression",
+  interfaceInLogic: 'TSInterfaceDeclaration',
+  typeAliasInLogic: 'TSTypeAliasDeclaration',
+  processEnv:
+    "MemberExpression[object.name='process'][property.name='env'],MemberExpression[object.name='process'][property.value='env']",
+  varInType: 'VariableDeclaration:not([declare=true])',
+  funcInType: 'FunctionDeclaration:not([declare=true])',
+  classInType: 'ClassDeclaration:not([declare=true])',
+  enumInType: 'TSEnumDeclaration:not([declare=true])',
+  stmtInType:
+    'ExpressionStatement, IfStatement, ForStatement, ForInStatement, ForOfStatement, WhileStatement, DoWhileStatement, SwitchStatement, TryStatement, ThrowStatement, WithStatement, LabeledStatement, DebuggerStatement',
+  defaultExportInType: 'ExportDefaultDeclaration > *:not(TSInterfaceDeclaration)',
+};
+
+// Must-FAIL fixtures — one per error-severity selector string in the src scopes, covering the
+// adversarial variants human review had to catch by hand (statics, generators, default-export
+// functions, top-level arrow/function-expression consts, data-testid as JSXAttribute AND as a
+// prop-type signature, interface/type declarations in logic files, runtime in type-only files,
+// process.env access, and the #107 deep cross-boundary import). Must-PASS fixtures pin the
+// sanctioned exemptions (use-* hooks, static members in .tsx error boundaries).
+const FIXTURES = [
+  // data-testid ban (#90)
+  {
+    id: 'jsx-data-testid',
+    file: PROBES.component,
+    code: 'const A = () => <div data-testid="x" />;',
+    covers: [S.testidJsx],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #90',
+  },
+  {
+    id: 'obj-data-testid',
+    file: PROBES.logic,
+    code: "const o = { 'data-testid': 'x' };",
+    covers: [S.testidProp],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #90',
+  },
+  {
+    id: 'propsig-data-testid',
+    file: PROBES.typeOnly,
+    code: "export interface P { 'data-testid': string }",
+    covers: [S.testidPropSig],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #90',
+  },
+  // no-static / no-free-function (#100)
+  {
+    id: 'static-method',
+    file: PROBES.logic,
+    code: 'class C { static m(): void {} }',
+    covers: [S.staticMethod],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'static-prop',
+    file: PROBES.logic,
+    code: 'class C { static x = 1; }',
+    covers: [S.staticProp],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'func-decl',
+    file: PROBES.logic,
+    code: 'function f(): void {}',
+    covers: [S.funcDecl],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'export-func-decl',
+    file: PROBES.logic,
+    code: 'export function g(): void {}',
+    covers: [S.exportFuncDecl],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'default-generator',
+    file: PROBES.logic,
+    code: 'export default function* h(): Generator<number> { yield 1; }',
+    covers: [S.defaultFuncDecl],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'arrow-const',
+    file: PROBES.logic,
+    code: 'export const a = (): void => {};',
+    covers: [S.arrowConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  {
+    id: 'funcexpr-const',
+    file: PROBES.logic,
+    code: 'const b = function (): void {};',
+    covers: [S.funcExprConst],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #100',
+  },
+  // type declarations in logic files (#88)
+  {
+    id: 'interface-in-logic',
+    file: PROBES.logic,
+    code: 'interface I { a: string }',
+    covers: [S.interfaceInLogic],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'typealias-in-logic',
+    file: PROBES.logic,
+    code: 'type T = string;',
+    covers: [S.typeAliasInLogic],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  // process.env ban (#112) — computed access is the adversarial variant that once bypassed the gate
+  {
+    id: 'process-env-computed',
+    file: PROBES.logic,
+    code: "const e = process['env'];",
+    covers: [S.processEnv],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #112',
+  },
+  // type-only-file purity (#88)
+  {
+    id: 'var-in-type',
+    file: PROBES.typeOnly,
+    code: 'const x = 1;',
+    covers: [S.varInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'func-in-type',
+    file: PROBES.typeOnly,
+    code: 'function f() {}',
+    covers: [S.funcInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'class-in-type',
+    file: PROBES.typeOnly,
+    code: 'class C {}',
+    covers: [S.classInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'enum-in-type',
+    file: PROBES.typeOnly,
+    code: 'enum E { A }',
+    covers: [S.enumInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'statement-in-type',
+    file: PROBES.typeOnly,
+    code: 'if (globalThis) { /* runtime */ }',
+    covers: [S.stmtInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  {
+    id: 'default-export-in-type',
+    file: PROBES.typeOnly,
+    code: 'export default 1;',
+    covers: [S.defaultExportInType],
+    expect: 'fail',
+    rule: 'no-restricted-syntax',
+    tag: 'issue #88',
+  },
+  // module/feature public-API boundary (#107) — deep cross-boundary import
+  {
+    id: 'deep-auth-import',
+    file: PROBES.component,
+    code: "import { LoginAPI } from '@auth/repositories/login-api';\nconst A = () => <div>{String(LoginAPI)}</div>;",
+    covers: [],
+    expect: 'fail',
+    rule: 'no-restricted-imports',
+    tag: '',
+  },
+  // Must-PASS exemptions
+  {
+    id: 'hook-arrow-const-exempt',
+    file: PROBES.hook,
+    code: 'export const useX = (): void => {};',
+    covers: [],
+    expect: 'pass',
+    rule: 'no-restricted-syntax',
+    tag: '',
+  },
+  {
+    id: 'tsx-static-error-boundary-exempt',
+    file: PROBES.component,
+    code: 'class EB { static getDerivedStateFromError() { return {}; } }',
+    covers: [],
+    expect: 'pass',
+    rule: 'no-restricted-syntax',
+    tag: '',
+  },
+];
+
+function severityOf(entry) {
+  return Array.isArray(entry) ? entry[0] : entry;
+}
+function selectorsOf(entry) {
+  return Array.isArray(entry)
+    ? entry.slice(1).map((e) => (typeof e === 'string' ? e : e.selector))
+    : [];
+}
+
+async function resolveProbe(file) {
+  const cfg = await eslint.calculateConfigForFile(file);
+  const nrs = cfg.rules?.['no-restricted-syntax'];
+  return { severity: severityOf(nrs), selectors: selectorsOf(nrs) };
+}
+
+// Strip type-aware parser settings: calculateConfigForFile returns `parserOptions.project`
+// (type-checked linting), which rejects the virtual fixture paths ("TSConfig does not include
+// this file"). The gates under test are purely syntactic (no-restricted-syntax /
+// no-restricted-imports), so a non-type-aware parse is both sufficient and correct.
+function sanitizeLanguageOptions(languageOptions) {
+  const parserOptions = { ...(languageOptions.parserOptions || {}) };
+  delete parserOptions.project;
+  delete parserOptions.projectService;
+  delete parserOptions.program;
+  delete parserOptions.EXPERIMENTAL_useProjectService;
+  delete parserOptions.tsconfigRootDir;
+  return { ...languageOptions, parserOptions };
+}
+
+async function runFixture(fx) {
+  const cfg = await eslint.calculateConfigForFile(fx.file);
+  const linter = new Linter({ configType: 'flat' });
+  const messages = linter.verify(
+    fx.code,
+    [
+      {
+        files: ['**/*.ts', '**/*.tsx'],
+        languageOptions: sanitizeLanguageOptions(cfg.languageOptions),
+        rules: { [fx.rule]: cfg.rules[fx.rule] },
+      },
+    ],
+    { filename: fx.file }
+  );
+  return messages.map((m) => ({ ruleId: m.ruleId, message: m.message, line: m.line }));
+}
+
+const probes = {};
+for (const [key, file] of Object.entries(PROBES)) probes[key] = await resolveProbe(file);
+
+// Universe: every error-severity no-restricted-syntax selector across the src scopes.
+const universe = [
+  ...new Set(
+    Object.values(probes)
+      .filter((p) => p.severity === 2)
+      .flatMap((p) => p.selectors)
+  ),
+].sort();
+
+const fixtures = [];
+for (const fx of FIXTURES) {
+  const messages = await runFixture(fx);
+  fixtures.push({
+    id: fx.id,
+    file: fx.file,
+    covers: fx.covers,
+    expect: fx.expect,
+    rule: fx.rule,
+    tag: fx.tag,
+    messages,
+  });
+}
+
+process.stdout.write(JSON.stringify({ probes, universe, fixtures }));

--- a/scripts/ci/print-eslint-policy-config.mjs
+++ b/scripts/ci/print-eslint-policy-config.mjs
@@ -1,0 +1,27 @@
+// scripts/ci/print-eslint-policy-config.mjs
+//
+// Resolves the effective flat-config for a fixed set of representative source paths and
+// prints one JSON blob to stdout. Consumed by tests/unit/config/eslint-policy.test.ts via a
+// single child_process spawn (issue #165).
+//
+// WHY A CHILD PROCESS: jest.config.ts runs CJS Jest with no --experimental-vm-modules, and
+// ESLint v9 loads the flat `eslint.config.mjs` via a native dynamic import() that fails inside
+// Jest's vm context. Resolving the config in a plain `node` process here sidesteps that
+// entirely; the test only parses this blob and asserts on it.
+import { ESLint } from 'eslint';
+
+// One representative real path per load-bearing override scope in eslint.config.mjs,
+// including the hook EXEMPTION so a config edit that accidentally applies the no-static gate
+// (issue #100) to hooks also goes red.
+const SAMPLES = [
+  'src/services/https-client/fetch-https-client.ts', // non-hook logic .ts — no-static gate (#100)
+  'src/modules/user/features/auth/components/form-section/components/form-field.tsx', // component
+  'src/modules/user/types/api-errors/validation-error.ts', // type-only file — type-purity gate (#88)
+  'src/modules/user/features/auth/stores/use-auth-token.ts', // hook — must stay EXEMPT from #100
+];
+
+const eslint = new ESLint({ cwd: process.cwd() });
+const entries = await Promise.all(
+  SAMPLES.map(async (file) => [file, await eslint.calculateConfigForFile(file)])
+);
+process.stdout.write(JSON.stringify(Object.fromEntries(entries)));

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -112,3 +112,4 @@ lint-prettier	bats	tests/bats/makefile_targets.bats	Validated as a member of the
 lint-shell	bats	tests/bats/makefile_targets.bats	Validated as a member of the CI lint target list passed to run-parallel-lint.sh.
 lint-lockfile	bats	tests/bats/lockfile_registries.bats	Validated as the bun.lock registry-allowlist gate with rogue-URL, rogue-specifier, lookalike-host, version-bump, and clean-pass fixtures.
 lint-actionlint	bats	tests/bats/makefile_targets.bats	Validated as a member of the CI lint target list passed to run-parallel-lint.sh.
+lint-licenses	bats	tests/bats/makefile_targets.bats	Validated as a member of the CI lint target list passed to run-parallel-lint.sh.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -34,12 +34,12 @@ setup() {
     [ -z "$expected_two" ] || assert_log_contains "$expected_two"
   done <<'EOF'
 ci-setup|docker compose -f docker-compose.yml up -d --no-recreate dev mockoon|curl -fsS http://localhost:8080/api/users
-ci-lint|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|
+ci-lint|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile lint-licenses|
 ci-test|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration|
 ci-mutation|bun x stryker run|
 ci-prod-setup|docker compose -f docker-compose.yml up -d dev|docker compose -f docker-compose.yml -f docker-compose.test.yml -f common-healthchecks.yml up -d --no-recreate prod mockoon playwright
 ci-test-prod|docker compose -f docker-compose.test.yml exec playwright ./node_modules/.bin/playwright test ./tests/e2e|docker compose -f docker-compose.test.yml --profile load run --rm k6 run --summary-trend-stats=avg,min,med,max,p(95),p(99)
-ci|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration
+ci|run-parallel-lint.sh check-env-sync lint-eslint lint-tsc lint-md lint-deps lint-dup lint-metrics lint-prettier lint-shell lint-actionlint lint-lockfile lint-licenses|run-parallel-tests.sh ci-test-unit-client ci-test-unit-server ci-test-integration
 install|docker compose exec -T dev bun install --frozen-lockfile|bun x husky install
 clean|docker compose -f docker-compose.yml down --volumes --remove-orphans --rmi local|docker compose -f docker-compose.test.yml down --volumes --remove-orphans --rmi local
 start-prod-clean|docker compose -f docker-compose.yml -f docker-compose.test.yml -f common-healthchecks.yml up -d --force-recreate --build prod mockoon playwright|curl -fsS http://localhost:8080/api/users

--- a/tests/bats/test_discovery_contract.bats
+++ b/tests/bats/test_discovery_contract.bats
@@ -22,15 +22,21 @@ TEST_ROOTS='tests/unit tests/integration tests/apollo-server tests/e2e tests/vis
 # status BEFORE the sed pipe (which would mask it): a non-zero exit means broken config OR a
 # crash after partial output — either way the discovered set would be silently partial, so fail
 # hard rather than hand back a truncated list. (`--listTests` exits 1 when no tests match, which
-# also surfaces a silently-narrowed suite.)
+# also surfaces a silently-narrowed suite.) stderr is captured (not discarded) and replayed on
+# failure so a broken config / module-resolution error is visible in the CI log, while stdout
+# stays clean for parsing.
 list_jest() {
-  local out status
-  out="$(cd "$PROJECT_ROOT" && TEST_ENV="$1" bun x jest --listTests 2>/dev/null)"
+  local out status err
+  err="$(mktemp)"
+  out="$(cd "$PROJECT_ROOT" && TEST_ENV="$1" bun x jest --listTests 2>"$err")"
   status=$?
   if [ "$status" -ne 0 ]; then
     echo "list_jest($1): 'jest --listTests' exited $status (broken config or no tests)" >&2
+    cat "$err" >&2 || true
+    rm -f "$err"
     return "$status"
   fi
+  rm -f "$err"
   printf '%s\n' "$out" | sed "s|^$PROJECT_ROOT/||"
 }
 
@@ -44,14 +50,19 @@ list_playwright() {
   # Capture playwright's own exit status before parsing, so a listing failure (broken config, or
   # a crash after partial output) fails the gate instead of being masked by the parse pipe. The
   # trailing `bun -e` parse is the function's last stage, so a malformed-JSON parse error also
-  # propagates as a non-zero return.
-  local raw status
-  raw="$(cd "$PROJECT_ROOT" && bun x playwright test --list --reporter=json tests/e2e tests/visual 2>/dev/null)"
+  # propagates as a non-zero return. stderr is captured and replayed on failure (not discarded to
+  # /dev/null) so the runner's diagnostics reach the CI log, while stdout stays clean JSON.
+  local raw status err
+  err="$(mktemp)"
+  raw="$(cd "$PROJECT_ROOT" && bun x playwright test --list --reporter=json tests/e2e tests/visual 2>"$err")"
   status=$?
   if [ "$status" -ne 0 ]; then
     echo "list_playwright: 'playwright test --list' exited $status" >&2
+    cat "$err" >&2 || true
+    rm -f "$err"
     return "$status"
   fi
+  rm -f "$err"
   printf '%s' "$raw" \
     | sed -n '/^{/,$p' \
     | bun -e '

--- a/tests/bats/test_discovery_contract.bats
+++ b/tests/bats/test_discovery_contract.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# Contract (issue #193): every file under the five test roots that DECLARES tests (a top-level
+# `test(` / `it(` / `describe(`, including `.each`/`.skip`/`.only`/`.fixme` modifiers via the
+# `(\.[A-Za-z]+)?` group) must be DISCOVERED by a runner. Jest test-match is suffix-exact and
+# Playwright's is directory+glob; nothing else proves a declared spec is actually executed. A
+# spec named `tests/e2e/foo.test.ts` (Jest-habit suffix, discovered by no runner) or
+# `tests/integration/bar.test.tsx` (missing the `.integration` infix) type-checks, lints clean,
+# and never runs — a green check certifying a test that never executed. This gate closes that.
+#
+# Known future false-positive vector — do NOT widen the grep to fix it: a shared-suite helper
+# (describe/it inside an exported function) placed under these roots would flag. Repo convention
+# keeps such helpers in tests/utils/ and tests/builders/ (outside the roots); the fix is moving
+# the file, never editing this grep.
+
+load './test_helper.bash'
+
+TEST_ROOTS='tests/unit tests/integration tests/apollo-server tests/e2e tests/visual'
+
+# jest --listTests prints ABSOLUTE container paths; strip to repo-relative.
+list_jest() {
+  ( cd "$PROJECT_ROOT" && TEST_ENV="$1" bun x jest --listTests 2>/dev/null ) \
+    | sed "s|^$PROJECT_ROOT/||"
+}
+
+# Every e2e/visual spec uses test.describe, so the JSON reporter nests specs inside child suites
+# — extract `.file` RECURSIVELY (a flat `.suites[].specs[].file` would miss them and produce
+# false orphans). `.file` is config-root-relative = repo-relative (config sits at repo root).
+# Playwright/dotenv prints `◇ injected env ...` banner lines to stdout before the JSON, so slice
+# from the first line that opens the top-level object (`^{`). Prod mode lists 3 projects
+# (chromium/firefox/webkit) so each spec appears 3× — deduped downstream by `sort -u`.
+list_playwright() {
+  ( cd "$PROJECT_ROOT" && bun x playwright test --list --reporter=json tests/e2e tests/visual 2>/dev/null ) \
+    | sed -n '/^{/,$p' \
+    | bun -e '
+        const seen = new Set();
+        const walk = (n) => {
+          if (n && typeof n === "object") {
+            if (typeof n.file === "string") seen.add(n.file);
+            Object.values(n).forEach(walk);
+          }
+        };
+        walk(JSON.parse(await Bun.stdin.text()));
+        console.log([...seen].join("\n"));
+      '
+}
+
+declared_files() {
+  ( cd "$PROJECT_ROOT" \
+    && grep -rlE '^[[:space:]]*(test|it|describe)(\.[A-Za-z]+)?\(' $TEST_ROOTS ) \
+    | sort -u
+}
+
+discovered_files() {
+  {
+    list_jest client
+    list_jest integration
+    list_jest server
+    list_playwright
+  } | sed 's|^\./||' | sort -u
+}
+
+@test "every test-declaring file is discovered by a runner" {
+  local declared discovered orphans
+  declared="$(declared_files)"
+  discovered="$(discovered_files)"
+  orphans="$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$discovered"))"
+  if [ -n "$orphans" ]; then
+    echo 'Undiscovered test-declaring files (matched by no runner):' >&2
+    echo "$orphans" >&2
+    return 1
+  fi
+}
+
+@test "no runner discovers zero tests (discovery not silently narrowed)" {
+  local env count
+  for env in client integration server; do
+    count="$(list_jest "$env" | grep -c .)"
+    if [ "$count" -eq 0 ]; then
+      echo "jest TEST_ENV=$env discovered zero test files" >&2
+      return 1
+    fi
+  done
+  count="$(list_playwright | grep -c .)"
+  if [ "$count" -eq 0 ]; then
+    echo 'playwright discovered zero spec files' >&2
+    return 1
+  fi
+}

--- a/tests/bats/test_discovery_contract.bats
+++ b/tests/bats/test_discovery_contract.bats
@@ -47,9 +47,19 @@ list_playwright() {
 }
 
 declared_files() {
-  ( cd "$PROJECT_ROOT" \
-    && grep -rlE '^[[:space:]]*(test|it|describe)(\.[A-Za-z]+)*\(' $TEST_ROOTS ) \
-    | sort -u
+  # Capture grep's exit status BEFORE the sort pipe, which would otherwise mask it: grep exits
+  # 0 (matches), 1 (no matches — valid), or >1 (a real error, e.g. a missing/unreadable root).
+  # A silently-partial declared set would let an entire test root vanish undetected.
+  local matches status
+  matches="$(cd "$PROJECT_ROOT" \
+    && grep -rlE '^[[:space:]]*(test|it|describe)(\.[A-Za-z]+)*\(' -- $TEST_ROOTS)"
+  status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "declared_files: grep failed (status $status) — a test root is missing or unreadable" >&2
+    return "$status"
+  fi
+  [ -n "$matches" ] && printf '%s\n' "$matches" | sort -u
+  return 0
 }
 
 discovered_files() {
@@ -63,7 +73,9 @@ discovered_files() {
 
 @test "every test-declaring file is discovered by a runner" {
   local declared discovered orphans
-  declared="$(declared_files)"
+  # Separate declaration from assignment so the command-substitution status is not masked by
+  # `local`, and propagate a real inventory-scan failure instead of proceeding on a partial list.
+  declared="$(declared_files)" || return 1
   discovered="$(discovered_files)"
   orphans="$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$discovered"))"
   if [ -n "$orphans" ]; then

--- a/tests/bats/test_discovery_contract.bats
+++ b/tests/bats/test_discovery_contract.bats
@@ -18,10 +18,20 @@ load './test_helper.bash'
 
 TEST_ROOTS='tests/unit tests/integration tests/apollo-server tests/e2e tests/visual'
 
-# jest --listTests prints ABSOLUTE container paths; strip to repo-relative.
+# jest --listTests prints ABSOLUTE container paths; strip to repo-relative. Capture jest's exit
+# status BEFORE the sed pipe (which would mask it): a non-zero exit means broken config OR a
+# crash after partial output — either way the discovered set would be silently partial, so fail
+# hard rather than hand back a truncated list. (`--listTests` exits 1 when no tests match, which
+# also surfaces a silently-narrowed suite.)
 list_jest() {
-  ( cd "$PROJECT_ROOT" && TEST_ENV="$1" bun x jest --listTests 2>/dev/null ) \
-    | sed "s|^$PROJECT_ROOT/||"
+  local out status
+  out="$(cd "$PROJECT_ROOT" && TEST_ENV="$1" bun x jest --listTests 2>/dev/null)"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "list_jest($1): 'jest --listTests' exited $status (broken config or no tests)" >&2
+    return "$status"
+  fi
+  printf '%s\n' "$out" | sed "s|^$PROJECT_ROOT/||"
 }
 
 # Every e2e/visual spec uses test.describe, so the JSON reporter nests specs inside child suites
@@ -31,7 +41,18 @@ list_jest() {
 # from the first line that opens the top-level object (`^{`). Prod mode lists 3 projects
 # (chromium/firefox/webkit) so each spec appears 3× — deduped downstream by `sort -u`.
 list_playwright() {
-  ( cd "$PROJECT_ROOT" && bun x playwright test --list --reporter=json tests/e2e tests/visual 2>/dev/null ) \
+  # Capture playwright's own exit status before parsing, so a listing failure (broken config, or
+  # a crash after partial output) fails the gate instead of being masked by the parse pipe. The
+  # trailing `bun -e` parse is the function's last stage, so a malformed-JSON parse error also
+  # propagates as a non-zero return.
+  local raw status
+  raw="$(cd "$PROJECT_ROOT" && bun x playwright test --list --reporter=json tests/e2e tests/visual 2>/dev/null)"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "list_playwright: 'playwright test --list' exited $status" >&2
+    return "$status"
+  fi
+  printf '%s' "$raw" \
     | sed -n '/^{/,$p' \
     | bun -e '
         const seen = new Set();
@@ -63,12 +84,18 @@ declared_files() {
 }
 
 discovered_files() {
-  {
-    list_jest client
-    list_jest integration
-    list_jest server
-    list_playwright
-  } | sed 's|^\./||' | sort -u
+  # Collect each runner's list into a variable and propagate its status (|| return) BEFORE the
+  # sort pipe. Relying on the final `sort` status would mask a runner that failed after emitting
+  # partial output — its truncated list could then hide orphans.
+  local client integration server playwright
+  client="$(list_jest client)" || return $?
+  integration="$(list_jest integration)" || return $?
+  server="$(list_jest server)" || return $?
+  playwright="$(list_playwright)" || return $?
+  printf '%s\n%s\n%s\n%s\n' "$client" "$integration" "$server" "$playwright" \
+    | sed 's|^\./||' \
+    | grep -v '^[[:space:]]*$' \
+    | sort -u
 }
 
 @test "every test-declaring file is discovered by a runner" {
@@ -76,7 +103,7 @@ discovered_files() {
   # Separate declaration from assignment so the command-substitution status is not masked by
   # `local`, and propagate a real inventory-scan failure instead of proceeding on a partial list.
   declared="$(declared_files)" || return 1
-  discovered="$(discovered_files)"
+  discovered="$(discovered_files)" || return 1
   orphans="$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$discovered"))"
   if [ -n "$orphans" ]; then
     echo 'Undiscovered test-declaring files (matched by no runner):' >&2
@@ -86,16 +113,24 @@ discovered_files() {
 }
 
 @test "no runner discovers zero tests (discovery not silently narrowed)" {
-  local env count
+  local env listing
+  # Capture each listing and propagate its status (a runner that errors returns non-zero) before
+  # counting, so a broken/partial listing fails loudly rather than passing on a non-zero count.
   for env in client integration server; do
-    count="$(list_jest "$env" | grep -c .)"
-    if [ "$count" -eq 0 ]; then
+    listing="$(list_jest "$env")" || {
+      echo "jest TEST_ENV=$env listing failed" >&2
+      return 1
+    }
+    if [ "$(printf '%s' "$listing" | grep -c .)" -eq 0 ]; then
       echo "jest TEST_ENV=$env discovered zero test files" >&2
       return 1
     fi
   done
-  count="$(list_playwright | grep -c .)"
-  if [ "$count" -eq 0 ]; then
+  listing="$(list_playwright)" || {
+    echo 'playwright listing failed' >&2
+    return 1
+  }
+  if [ "$(printf '%s' "$listing" | grep -c .)" -eq 0 ]; then
     echo 'playwright discovered zero spec files' >&2
     return 1
   fi

--- a/tests/bats/test_discovery_contract.bats
+++ b/tests/bats/test_discovery_contract.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 #
 # Contract (issue #193): every file under the five test roots that DECLARES tests (a top-level
-# `test(` / `it(` / `describe(`, including `.each`/`.skip`/`.only`/`.fixme` modifiers via the
-# `(\.[A-Za-z]+)?` group) must be DISCOVERED by a runner. Jest test-match is suffix-exact and
+# `test(` / `it(` / `describe(`, including CHAINED modifiers — `.each`/`.skip`/`.only`/`.fixme`
+# and combinations like `test.concurrent.each(` / `describe.each.only(` — via the
+# `(\.[A-Za-z]+)*` group) must be DISCOVERED by a runner. Jest test-match is suffix-exact and
 # Playwright's is directory+glob; nothing else proves a declared spec is actually executed. A
 # spec named `tests/e2e/foo.test.ts` (Jest-habit suffix, discovered by no runner) or
 # `tests/integration/bar.test.tsx` (missing the `.integration` infix) type-checks, lints clean,
@@ -47,7 +48,7 @@ list_playwright() {
 
 declared_files() {
   ( cd "$PROJECT_ROOT" \
-    && grep -rlE '^[[:space:]]*(test|it|describe)(\.[A-Za-z]+)?\(' $TEST_ROOTS ) \
+    && grep -rlE '^[[:space:]]*(test|it|describe)(\.[A-Za-z]+)*\(' $TEST_ROOTS ) \
     | sort -u
 }
 

--- a/tests/unit/config/eslint-policy.test.ts
+++ b/tests/unit/config/eslint-policy.test.ts
@@ -4,8 +4,8 @@
 // or severity downgrade fails CI (issue #165). Both existing enforcement layers — `make
 // lint-eslint` and the `eslint-suppressions` grep — verify the rules AS CONFIGURED are obeyed
 // and not suppressed inline; neither verifies the rules REMAIN configured. A config-level
-// rule-off or an `eslint.config.mjs` selector deletion contains no `eslint-disable` token and
-// passes the grep by construction, after which `lint-eslint` runs green because the rule it
+// rule-off or an `eslint.config.mjs` selector deletion carries no inline suppression directive
+// and passes the grep by construction, after which `lint-eslint` runs green because the rule it
 // would have fired no longer exists. This test closes that bypass.
 //
 // Assertions pin severities + one distinctive selector/message substring per gate — NEVER

--- a/tests/unit/config/eslint-policy.test.ts
+++ b/tests/unit/config/eslint-policy.test.ts
@@ -1,0 +1,83 @@
+// tests/unit/config/eslint-policy.test.ts
+//
+// Pins the load-bearing convention gates in eslint.config.mjs so a config-level rule deletion
+// or severity downgrade fails CI (issue #165). Both existing enforcement layers — `make
+// lint-eslint` and the `eslint-suppressions` grep — verify the rules AS CONFIGURED are obeyed
+// and not suppressed inline; neither verifies the rules REMAIN configured. A config-level
+// rule-off or an `eslint.config.mjs` selector deletion contains no `eslint-disable` token and
+// passes the grep by construction, after which `lint-eslint` runs green because the rule it
+// would have fired no longer exists. This test closes that bypass.
+//
+// Assertions pin severities + one distinctive selector/message substring per gate — NEVER
+// full-config snapshots (config-evolution friction). Cross-reference: the CLAUDE.md
+// "Enforcement" paragraphs for issues #88 (type-only files), #90 (data-testid), #100/#89
+// (no-static / no-free-function), and #107 (module/feature public-API imports) — a rule rename
+// must update both the config and this test together.
+//
+// Config resolution runs in a child `node` process (scripts/ci/print-eslint-policy-config.mjs),
+// NOT in-process: jest.config.ts runs CJS Jest with no --experimental-vm-modules, and ESLint v9
+// loads the flat eslint.config.mjs via a native dynamic import() that fails inside Jest's vm.
+import { execFileSync } from 'node:child_process';
+
+const LOGIC_TS = 'src/services/https-client/fetch-https-client.ts'; // non-hook logic .ts
+const COMPONENT_TSX =
+  'src/modules/user/features/auth/components/form-section/components/form-field.tsx';
+const TYPE_ONLY_TS = 'src/modules/user/types/api-errors/validation-error.ts';
+const HOOK_TS = 'src/modules/user/features/auth/stores/use-auth-token.ts';
+
+interface ResolvedConfig {
+  rules: Record<string, unknown>;
+}
+
+const configs: Record<string, ResolvedConfig> = JSON.parse(
+  execFileSync('node', ['scripts/ci/print-eslint-policy-config.mjs'], { encoding: 'utf8' })
+);
+
+const severityOf = (rule: unknown): unknown => (Array.isArray(rule) ? rule[0] : rule);
+const jsonOf = (rule: unknown): string => JSON.stringify(rule ?? []);
+
+describe('eslint.config.mjs policy integrity (issue #165)', () => {
+  it('pins the no-static gate (#100) at error on non-hook logic files', () => {
+    const nrs = configs[LOGIC_TS].rules['no-restricted-syntax'];
+    expect(severityOf(nrs)).toBe(2);
+    expect(jsonOf(nrs)).toContain('PropertyDefinition[static=true]');
+    expect(jsonOf(nrs)).toContain('MethodDefinition[static=true]');
+  });
+
+  it('keeps hooks EXEMPT from the no-static gate (issue #100 override for use-*)', () => {
+    const nrs = configs[HOOK_TS].rules['no-restricted-syntax'];
+    // The gate itself stays active on hooks (data-testid / type-purity)...
+    expect(severityOf(nrs)).toBe(2);
+    // ...but the static/free-function selectors must NOT apply — hooks are functions by design.
+    expect(jsonOf(nrs)).not.toContain('PropertyDefinition[static=true]');
+    expect(jsonOf(nrs)).not.toContain('MethodDefinition[static=true]');
+  });
+
+  it('keeps the data-testid ban (issue #90) at error on components and logic files', () => {
+    const componentNrs = configs[COMPONENT_TSX].rules['no-restricted-syntax'];
+    expect(severityOf(componentNrs)).toBe(2);
+    expect(jsonOf(componentNrs)).toContain("JSXAttribute[name.name='data-testid']");
+    expect(jsonOf(configs[LOGIC_TS].rules['no-restricted-syntax'])).toContain(
+      "JSXAttribute[name.name='data-testid']"
+    );
+  });
+
+  it('keeps the type-only-file purity gate (issue #88) at error on files under types/', () => {
+    const nrs = configs[TYPE_ONLY_TS].rules['no-restricted-syntax'];
+    expect(severityOf(nrs)).toBe(2);
+    expect(jsonOf(nrs)).toContain('VariableDeclaration:not([declare=true])');
+  });
+
+  it('keeps eslint-comments/no-use and max-len pinned on logic files', () => {
+    const rules = configs[LOGIC_TS].rules;
+    expect(severityOf(rules['eslint-comments/no-use'])).toBe(2);
+    expect(rules['max-len']).toEqual([2, { code: 100 }]);
+  });
+
+  it('keeps the module/feature public-API import boundary (issue #107) pinned', () => {
+    // The @auth/*/* deep-import ban resolves onto cross-boundary logic files (services) and
+    // type files, guarding the feature public-API contract for ESLint's half of the gate.
+    expect(jsonOf(configs[LOGIC_TS].rules['no-restricted-imports'])).toContain('@auth/*/*');
+    expect(severityOf(configs[LOGIC_TS].rules['no-restricted-imports'])).toBe(2);
+  });
+});

--- a/tests/unit/scripts/check-licenses.test.ts
+++ b/tests/unit/scripts/check-licenses.test.ts
@@ -1,0 +1,59 @@
+// tests/unit/scripts/check-licenses.test.ts
+//
+// Must-fail / must-pass coverage for the SPDX-aware dependency license gate (issue #191). The
+// gate replaced a literal `--onlyAllow` allowlist — which let `(GPL-3.0 AND MIT)` through
+// because MIT is an allowed operand — with semantic `spdx-satisfies` evaluation. This suite
+// pins that behaviour by feeding synthetic license maps to `scripts/ci/check-licenses.mjs`
+// via its `--stdin` mode and asserting the exit code, so a regression to loose operand matching
+// (or an accidental fail-open on unknown licenses) fails the build.
+//
+// The gate script is ESM and shells out, so it runs in a child `node` process rather than being
+// imported into jest's CJS vm.
+import { spawnSync } from 'node:child_process';
+
+const ALLOWED = 'MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;0BSD;CC-BY-4.0';
+
+function runGate(licenseMap: Record<string, { licenses: string | string[] }>): number {
+  const result = spawnSync('node', ['scripts/ci/check-licenses.mjs', '--stdin'], {
+    input: JSON.stringify(licenseMap),
+    env: { ...process.env, ALLOWED_LICENSES: ALLOWED },
+    encoding: 'utf8',
+  });
+  return result.status ?? 1;
+}
+
+describe('SPDX-aware dependency license gate (issue #191)', () => {
+  it.each([
+    ['plain allowed license (MIT)', { 'mit@1.0.0': { licenses: 'MIT' } }],
+    ['allowed OR compound', { 'a@1.0.0': { licenses: '(MIT OR Apache-2.0)' } }],
+    [
+      'allowed AND compound (both operands allowed)',
+      { 'b@1.0.0': { licenses: '(MIT AND BSD-3-Clause)' } },
+    ],
+    ['OR compound with one allowed operand', { 'c@1.0.0': { licenses: '(GPL-3.0-only OR MIT)' } }],
+    ['array of allowed licenses', { 'd@1.0.0': { licenses: ['MIT', 'ISC'] } }],
+  ])('passes: %s', (_label, map) => {
+    expect(runGate(map)).toBe(0);
+  });
+
+  it.each([
+    // The regression the gate exists to catch: an AND compound binds you to every operand, so a
+    // disallowed copyleft operand must fail even though MIT is allowed.
+    [
+      'AND compound with a disallowed operand',
+      { 'gpl-and@1.0.0': { licenses: '(GPL-3.0-only AND MIT)' } },
+    ],
+    ['plain disallowed copyleft (GPL)', { 'gpl@1.0.0': { licenses: 'GPL-3.0-only' } }],
+    ['plain disallowed copyleft (AGPL)', { 'agpl@1.0.0': { licenses: 'AGPL-3.0-only' } }],
+    [
+      'OR compound with no allowed operand',
+      { 'o@1.0.0': { licenses: '(GPL-3.0-only OR AGPL-3.0-only)' } },
+    ],
+    ['unknown / undetected license', { 'u@1.0.0': { licenses: 'UNKNOWN' } }],
+    ['non-SPDX custom string', { 's@1.0.0': { licenses: 'SEE LICENSE IN LICENSE.txt' } }],
+    ['guessed (starred) license', { 'g@1.0.0': { licenses: 'MIT*' } }],
+    ['array with one disallowed member', { 'arr@1.0.0': { licenses: ['MIT', 'GPL-3.0-only'] } }],
+  ])('rejects: %s', (_label, map) => {
+    expect(runGate(map)).not.toBe(0);
+  });
+});

--- a/tests/unit/tooling/eslint-gate-fixtures.test.ts
+++ b/tests/unit/tooling/eslint-gate-fixtures.test.ts
@@ -1,3 +1,5 @@
+// @jest-environment @stryker-mutator/jest-runner/jest-env/node
+//
 // tests/unit/tooling/eslint-gate-fixtures.test.ts
 //
 // Adversarial, must-fail coverage for the custom ESLint enforcement selectors in

--- a/tests/unit/tooling/eslint-gate-fixtures.test.ts
+++ b/tests/unit/tooling/eslint-gate-fixtures.test.ts
@@ -1,0 +1,105 @@
+// tests/unit/tooling/eslint-gate-fixtures.test.ts
+//
+// Adversarial, must-fail coverage for the custom ESLint enforcement selectors in
+// eslint.config.mjs (issue #189). `make lint-eslint` proves the rules AS CONFIGURED are obeyed,
+// but nothing else proves a configured selector actually MATCHES the code it was written to ban.
+// A syntactically wrong selector, a reordered flat-config override that drops a selector family
+// (flat config REPLACES, not merges, `no-restricted-syntax`), or a narrowed `files`/`ignores`
+// scope all silently stop a gate firing while CI stays green. This suite closes that gap in
+// three layers:
+//
+//   1. Wiring — the resolved `no-restricted-syntax` severity per src scope is error (2).
+//   2. Behavior — a must-fail fixture per selector fires with the expected issue tag, and the
+//      sanctioned exemptions (use-* hooks, static members in .tsx error boundaries) stay clean.
+//   3. Rot-guard — the union of fixture `covers` equals the live error-severity selector
+//      universe, so a NEW selector added to eslint.config.mjs cannot ship without a fixture.
+//
+// The ESLint Node API (config resolution + Linter#verify with RESOLVED languageOptions) runs in
+// a child `node` process — jest's CJS vm cannot load ESLint v9's dynamic import() of the flat
+// config. Assertions match only the stable issue tag (e.g. "issue #100"), never full message
+// text. Fixture table + selector strings: scripts/ci/eslint-gate-fixtures.mjs.
+import { execFileSync } from 'node:child_process';
+
+interface FixtureResult {
+  id: string;
+  file: string;
+  covers: string[];
+  expect: 'fail' | 'pass';
+  rule: string;
+  tag: string;
+  messages: { ruleId: string | null; message: string; line: number }[];
+}
+
+interface GateReport {
+  probes: Record<string, { severity: number; selectors: string[] }>;
+  universe: string[];
+  fixtures: FixtureResult[];
+}
+
+const report: GateReport = JSON.parse(
+  execFileSync('node', ['scripts/ci/eslint-gate-fixtures.mjs'], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 16,
+  })
+);
+
+describe('custom ESLint selector coverage (issue #189)', () => {
+  describe('wiring: no-restricted-syntax is error-severity in every src scope', () => {
+    it.each(Object.keys(report.probes))('scope %s resolves at error (2)', (scope) => {
+      expect(report.probes[scope].severity).toBe(2);
+    });
+
+    it('the error-severity selector universe is non-empty and includes load-bearing gates', () => {
+      expect(report.universe.length).toBeGreaterThan(0);
+      expect(report.universe).toEqual(
+        expect.arrayContaining([
+          'MethodDefinition[static=true]', // #100
+          "JSXAttribute[name.name='data-testid']", // #90
+          'TSInterfaceDeclaration', // #88 (logic files)
+          'VariableDeclaration:not([declare=true])', // #88 (type-only files)
+        ])
+      );
+    });
+  });
+
+  describe('behavior: forbidden-pattern fixtures fire; sanctioned exemptions stay clean', () => {
+    const failFixtures = report.fixtures.filter((f) => f.expect === 'fail');
+    const passFixtures = report.fixtures.filter((f) => f.expect === 'pass');
+
+    it.each(failFixtures.map((f) => [f.id, f] as const))(
+      'must-fail fixture %s fires its gate',
+      (_id, fx) => {
+        const ruleMatches = fx.messages.filter((m) => m.ruleId === fx.rule);
+        expect(ruleMatches.length).toBeGreaterThan(0);
+        // No parse errors masquerading as "clean".
+        expect(fx.messages.some((m) => m.ruleId === null)).toBe(false);
+        if (fx.tag) {
+          expect(ruleMatches.some((m) => m.message.includes(fx.tag))).toBe(true);
+        }
+      }
+    );
+
+    it.each(passFixtures.map((f) => [f.id, f] as const))(
+      'exempt fixture %s does not fire',
+      (_id, fx) => {
+        expect(fx.messages.filter((m) => m.ruleId === fx.rule)).toHaveLength(0);
+        expect(fx.messages.some((m) => m.ruleId === null)).toBe(false);
+      }
+    );
+  });
+
+  describe('rot-guard: every error-severity src selector has a must-fail fixture', () => {
+    it('fixture coverage exactly equals the live selector universe', () => {
+      const covered = new Set(
+        report.fixtures.filter((f) => f.expect === 'fail').flatMap((f) => f.covers)
+      );
+      const universe = new Set(report.universe);
+      const uncovered = [...universe].filter((s) => !covered.has(s));
+      const extra = [...covered].filter((s) => !universe.has(s));
+      // A new/edited selector in eslint.config.mjs surfaces here as `uncovered`; a removed
+      // selector surfaces as `extra`. Add or update a fixture in
+      // scripts/ci/eslint-gate-fixtures.mjs — never delete the assertion.
+      expect({ uncovered, extra }).toEqual({ uncovered: [], extra: [] });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Closes five **non-conflicting** `[ci-gap]` issues in a single batch. Each one rides an
**existing** workflow (no `.github/workflows/*` edit) and touches disjoint files, so they compose
cleanly:

| # | Gate | Enforced by (existing workflow) |
| --- | --- | --- |
| **#164** | Promote `react-hooks/exhaustive-deps` + `no-await-in-loop` to `error` | `static testing` → `make lint` |
| **#165** | ESLint config-integrity policy test | `unit testing` → `make test-unit-all` |
| **#189** | Adversarial must-fail fixtures for the custom ESLint selectors | `unit testing` → `make test-unit-all` |
| **#191** | Dependency license-policy gate (SPDX allowlist over the production tree) | `static testing` → `make lint` |
| **#193** | Test-discovery contract (declared ⇒ discovered) | `bats testing` → `make test-bats` |

**What / How**

- **#164** — flips the two rules to `error` in `eslint.config.mjs` (zero current violations, so
  the flip is free). `react/jsx-no-bind` deliberately stays `warn` per the issue's scope decision
  (promoting it would force `useCallback` everywhere with no escape hatch, since
  `eslint-comments/no-use` bans disables).
- **#165** — `tests/unit/config/eslint-policy.test.ts` pins the resolved severity + one
  distinctive selector per load-bearing gate (#88/#90/#100/#107), resolved through a child `node`
  process (`scripts/ci/print-eslint-policy-config.mjs`) — ESLint v9's flat-config dynamic
  `import()` cannot load inside Jest's CJS vm. Closes the "delete the rule instead of the code"
  bypass that no `eslint-disable` grep can see.
- **#189** — `tests/unit/tooling/eslint-gate-fixtures.test.ts` runs a must-fail fixture through
  **every** error-severity `no-restricted-syntax` selector (via the *resolved* config +
  `Linter#verify`), pins the sanctioned exemptions (`use-*` hooks, `.tsx` error-boundary statics),
  and a **rot-guard** asserts the fixture set exactly covers the live selector universe — a new
  `src/**` selector cannot ship without a fixture.
- **#191** — `make lint-licenses` fails on any production dependency outside the SPDX allowlist
  (`license-checker-rseidelsohn`, pinned in `devDependencies`/`bun.lock`). Folded into
  `CI_LINT_TARGETS` + `lint:` so it runs via the existing `make lint` — **no dedicated workflow
  step** (a deliberate adaptation of the issue's proposal to honor the no-workflow-change
  constraint). Allowlist trimmed to exactly the license families the current tree contains.
- **#193** — `tests/bats/test_discovery_contract.bats` asserts every file under the five test
  roots that *declares* tests is *discovered* by a runner (`jest --listTests` per `TEST_ENV` +
  `playwright test --list`), and that no runner discovers zero tests. Closes the
  silently-unexecuted-test hole (wrong suffix / missing `.integration` infix).

**Scope / Out-of-scope**

- Out of scope (deliberately excluded from this batch): issues requiring `.github/workflows/*`
  edits, and gates with large burn-downs that would bloat this PR (e.g. `jest-fail-on-console`,
  `no-conditional-expect`) — they belong in their own PRs.

## Related Issue

Closes #164
Closes #165
Closes #189
Closes #191
Closes #193

## Motivation and Context

These gates were scored coverage-present / enforcement-missing: the rules or conventions exist but
nothing fails a build when they are silently disabled, when a custom selector goes dead, when a
copyleft/unlicensed dependency enters the shipped tree, or when a spec is never executed. Each
change turns a "someone forgot / a reviewer must catch it" gap into a deterministic red check,
without weakening any existing gate.

## How Has This Been Tested?

All gates were validated locally (Node/Bun; the Docker-only gates — `lint-metrics`, `lint-shell`,
`lint-actionlint`, `codegen-check` — are unaffected because this PR touches no `src/`, shell, or
workflow files):

- `eslint .` on `src` → 0 errors; new files lint clean.
- `tsc --noEmit` → clean.
- Unit suites: client **1566** ✓ (150 suites, coverage held at 100%), server **118** ✓,
  integration **404** ✓.
- Full Bats suite (`bun x bats -r tests/bats`) → **73/73** ✓ (incl. the #182 CI_LINT mirror, the
  make-target contract, and the new discovery contract).
- `prettier --check`, `markdownlint`, `depcruise` (684 modules), `lint-lockfile`, and
  `make lint-licenses` → all pass.
- **Seeded-defect proofs**: #165 fails when a gate severity is downgraded; #189's rot-guard/fixtures
  fail when a selector is dropped; #193 fails on a wrong-suffix orphan spec — each reverts to green.

## Types of changes

## What type of change does this PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (docs)
- [ ] Refactor
- [ ] Performance
- [x] Test
- [x] Chore / Tooling
- [x] Build / CI

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have only one commit (if not, I have squashed it into a single commit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbteoodWWqR3YnjwpiVR2u)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI by adding a semantic SPDX license gate, stricter ESLint rules, and a test-discovery contract that now fails on runner listing errors and surfaces stderr for easier debugging.

- **New Features**
  - ESLint (#164): promote `react-hooks/exhaustive-deps` and `no-await-in-loop` to error; keep `react/jsx-no-bind` as warn. Runs via `make lint`.
  - ESLint policy integrity (#165): unit test resolves the flat config in a child process and fails on rule deletion or downgrade.
  - Selector coverage (#189): must-fail fixtures for every error-severity `no-restricted-syntax` selector; derive the selector universe from all src-scoped blocks and add fixtures for each comma-separated branch.
  - License gate (#191): `make lint-licenses` enforces a production-deps license policy using semantic SPDX evaluation via `spdx-satisfies` (handles AND/OR; unknowns fail closed); wired into `CI_LINT_TARGETS` and `lint`.
  - Test discovery (#193): Bats test asserts all declared tests are discovered by Jest/Playwright; matches chained modifiers; propagates grep status and fails on runner listing errors; captures and replays runner stderr on failure for visibility.

- **Dependencies**
  - Added `license-checker-rseidelsohn` and `spdx-satisfies` for the license policy gate.

<sup>Written for commit eff7706ad911c5e269d27245d62df7a4e594bda7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

