### PR TITLE
feat(#145): load configuration at runtime and add a typed feature-flag service

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -5,6 +5,7 @@
 // one eagerly pulls the whole DI graph, which must stay off the auth paint path).
 const DI_COMPOSITION_ROOTS = [
   '^src/config/dependency-injection-config[.]ts$',
+  '^src/config/runtime/di[.]ts$',
   '^src/services/[^/]+/di[.]ts$',
   '^src/utils/[^/]+/di[.]ts$',
   '^src/modules/[^/]+/config/di[.]ts$',

--- a/.env
+++ b/.env
@@ -42,6 +42,15 @@ REACT_APP_RELEASE=
 REACT_APP_SENTRY_DSN=
 REACT_APP_SENTRY_ENVIRONMENT=development
 
+# Runtime configuration (issue #145). Read by the production container ENTRYPOINT, which renders
+# the inline app-config block of the built HTML shell at start-up — the same image therefore
+# serves any environment without a rebuild. Empty means "keep the committed default from
+# public/index.html". Feature flags are APP_CONFIG_FLAG_<UPPER_SNAKE_NAME> and take exactly
+# "true" or "false"; see docs/feature-flags.md and src/config/runtime/README.md.
+APP_CONFIG_API_BASE_URL=
+APP_CONFIG_GRAPHQL_URL=
+APP_CONFIG_FLAG_FORGOT_PASSWORD=
+
 # Upstream user-service contract versions. GraphQL and OpenAPI are reconciled to a
 # single pinned version (scripts/check-contract-versions.sh asserts they match) so the
 # generated contract artifacts (src/api/generated/**) cannot silently drift.

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,15 @@ REACT_APP_RELEASE=
 REACT_APP_SENTRY_DSN=
 REACT_APP_SENTRY_ENVIRONMENT=development
 
+# Runtime configuration (issue #145). Read by the production container ENTRYPOINT, which renders
+# the inline app-config block of the built HTML shell at start-up — the same image therefore
+# serves any environment without a rebuild. Empty means "keep the committed default from
+# public/index.html". Feature flags are APP_CONFIG_FLAG_<UPPER_SNAKE_NAME> and take exactly
+# "true" or "false"; see docs/feature-flags.md and src/config/runtime/README.md.
+APP_CONFIG_API_BASE_URL=
+APP_CONFIG_GRAPHQL_URL=
+APP_CONFIG_FLAG_FORGOT_PASSWORD=
+
 # Upstream user-service contract versions. GraphQL and OpenAPI are reconciled to a
 # single pinned version (scripts/check-contract-versions.sh asserts they match) so the
 # generated contract artifacts (src/api/generated/**) cannot silently drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,7 +447,8 @@ The project uses tsyringe for DI with **per-module / per-infra composition roots
      `src/services/observability/{di,tokens}.ts` (`OBSERVABILITY_TOKENS`),
      `src/services/error/{di,tokens}.ts` (`ERROR_TOKENS`),
      `src/services/error-reporting/{di,tokens}.ts` (`ERROR_REPORTING_TOKENS`),
-     `src/utils/error/{di,tokens}.ts` (`ERROR_UTILS_TOKENS`).
+     `src/utils/error/{di,tokens}.ts` (`ERROR_UTILS_TOKENS`),
+     `src/config/runtime/{di,tokens}.ts` (`RUNTIME_TOKENS`).
    - Module: `src/modules/user/config/{di,tokens}.ts` (`AUTH_TOKENS`).
 2. Each root is a `ModuleRegistrar` (`src/config/types/module-registrar.ts`) singleton.
    `src/config/dependency-injection-config.ts` is a **thin aggregator** holding **zero**
@@ -501,6 +502,77 @@ class AuthStoreSelectors {
 }
 export default new AuthStoreSelectors();
 ```
+
+### Runtime configuration and feature flags (issue #145)
+
+Everything under `@/config/env` is **build-time** configuration: RSBuild inlines `REACT_APP_*` into
+the bundle, so changing one needs a rebuild. `@/config/runtime` is the **runtime** layer — an
+administrator changes a value and restarts the container, and the _same_ built artifact is promoted
+across environments ("build once, deploy many"). Build-time values remain the defaults; runtime
+values win.
+
+**Where it lives.** An inline JSON block in the HTML shell (`public/index.html`), carried by a
+`script` element with `id="app-runtime-config"` and `type="application/json"` — a data block, not
+executable code, so it needs no CSP nonce. `serve.json` already sends `Cache-Control: no-cache`
+for `/index.html`, so a redeploy is never served stale.
+
+**Why inline rather than a fetched `app-config.json`.** The mobile Lighthouse floor (0.84) has no
+headroom. A config request is not preload-scanner-discoverable — it can only start after
+`index.js` executes — so awaiting it before `root.render()` serializes a round trip onto FCP/LCP.
+The inline block is read synchronously at zero request cost, which also keeps the module-eval
+router construction in `src/routes/routes.tsx` working unchanged.
+
+**Two layers, mirroring `@/config/env`** (measured, not assumed: importing `zod` from the boot path
+grows the eager entrypoint from 373 kB to 436 kB raw, or 418 kB with `zod/mini`, against the
+470 kB `raw.maxInitialEntrypointBytes` budget):
+
+| File                              | Deps  | Use it from                                      |
+| --------------------------------- | ----- | ------------------------------------------------ |
+| `runtime/app-config-source.ts`    | none  | paint path / any zod-free code                   |
+| `runtime/app-config.ts`           | `zod` | container code (`RUNTIME_TOKENS.AppConfig`)      |
+| `runtime/app-config-schema.ts`    | `zod` | the zod contract                                 |
+| `runtime/feature-flag-service.ts` | none  | flag reads (`RUNTIME_TOKENS.FeatureFlagService`) |
+
+Both singletons are registered with `useValue` rather than decorated `@injectable()`, exactly like
+the observability render-path leaves (issue #115): the auth page must be able to read a flag
+without pulling tsyringe into the eager chunk, and registering the instance is what lets
+container-resolved classes inject it instead of value-importing it (issue #130).
+
+**Fail-fast, at the earliest point that can act:**
+
+1. **Container start** — `scripts/docker-entrypoint.sh` runs `scripts/render-app-config.js`, which
+   rejects a non-`http(s)` URL, a flag value that is not exactly `true`/`false`, and an
+   `APP_CONFIG_FLAG_*` variable naming a flag that does not exist; the entrypoint exits non-zero,
+   so a misconfigured deployment never serves.
+2. **Browser boot** — `src/index.tsx` calls `appConfigSource.load()` before `createRoot`, so a
+   malformed block throws immediately instead of silently degrading to defaults.
+3. **Container-resolved code** — `appConfig` zod-validates with `z.prettifyError`, and a unit test
+   validates the **committed** block in `public/index.html` against the schema so the shipped
+   default cannot drift from the contract.
+
+**Settings:** `apiBaseUrl` (`APP_CONFIG_API_BASE_URL`, consumed by `@/utils/url-builder`),
+`graphqlUrl` (`APP_CONFIG_GRAPHQL_URL`, injected into `GraphQLUrl`), and
+`flags.<name>` (`APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>`). Languages stay build-time — `src/i18n.js`
+initializes i18next at module evaluation and `src/config/i18n-config.js` is `require`d by node
+tooling without a TypeScript loader, so that is an i18n boot-path restructuring, not a config
+change.
+
+**Reading a flag** — components use the container-free bridge; the flag name is a `FeatureFlag`
+union member, so a typo is a compile error:
+
+```typescript
+const showForgotPassword = useFeatureFlag('forgotPassword');
+```
+
+**Flag lifecycle** (introduce default-off → roll out per environment → remove) is documented in
+[`docs/feature-flags.md`](docs/feature-flags.md); the module contract is
+[`src/config/runtime/README.md`](src/config/runtime/README.md). A new flag must be declared in four
+places — the `FeatureFlag` union, `FEATURE_FLAG_DEFAULTS`, `app-config-schema.ts`, and the
+committed block in `public/index.html` — and
+`tests/unit/tooling/runtime-config-contract.test.ts` fails the build when those drift apart.
+
+**No suppression:** satisfy the gate by declaring the flag everywhere it belongs, never by
+loosening the schema, and never by moving the config read onto a blocking fetch.
 
 ### No static methods or free functions (issues #100, #89)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,8 +550,9 @@ container-resolved classes inject it instead of value-importing it (issue #130).
    validates the **committed** block in `public/index.html` against the schema so the shipped
    default cannot drift from the contract.
 
-**Settings:** `apiBaseUrl` (`APP_CONFIG_API_BASE_URL`, consumed by `@/utils/url-builder`),
-`graphqlUrl` (`APP_CONFIG_GRAPHQL_URL`, injected into `GraphQLUrl`), and
+**Settings:** `apiBaseUrl` (`APP_CONFIG_API_BASE_URL`, consumed by `@/utils/url-builder`, falling
+back to `REACT_APP_MOCKOON_URL`), `graphqlUrl` (`APP_CONFIG_GRAPHQL_URL`, injected into
+`GraphQLUrl`, falling back to `REACT_APP_GRAPHQL_URL`), and
 `flags.<name>` (`APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>`). Languages stay build-time — `src/i18n.js`
 initializes i18next at module evaluation and `src/config/i18n-config.js` is `require`d by node
 tooling without a TypeScript loader, so that is an i18n boot-path restructuring, not a config

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,14 @@ RUN apk add --no-cache curl=${CURL_VERSION} && \
     npm install -g serve@14.2.0 && \
     mkdir -p /app && chown -R node:node /app
 COPY --chown=node:node serve.json ./serve.json
+# Runtime configuration renderer (issue #145): rewrites the inline app-config block in the built
+# HTML shell from APP_CONFIG_* variables at container start, so one image serves any environment.
+# Copied before the bundle so a code change does not invalidate this layer, and vice versa.
+COPY --chown=node:node scripts/docker-entrypoint.sh scripts/render-app-config.js ./scripts/
 COPY --from=build --chown=node:node /app/dist-production ./dist
 USER node
 
 EXPOSE 3001
 
+ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]
 CMD ["serve", "-s", "dist", "-l", "tcp://0.0.0.0:3001", "-c", "/app/serve.json"]

--- a/README.md
+++ b/README.md
@@ -303,6 +303,24 @@ Docker
   make wait-for-prod: waits for the prod service to be ready on port 3001
 ```
 
+### Runtime configuration
+
+The production image is configured at **container start**, not at build time, so one tested
+artifact can be promoted across environments. Set `APP_CONFIG_*` variables and restart — no
+rebuild:
+
+```bash
+  APP_CONFIG_GRAPHQL_URL=https://api.example.com/graphql \
+  APP_CONFIG_FLAG_FORGOT_PASSWORD=false \
+  docker compose -f docker-compose.yml -f docker-compose.test.yml up -d --force-recreate prod
+```
+
+The entrypoint validates every value and exits non-zero on an invalid URL, a flag value that is
+not exactly `true`/`false`, or a variable naming a flag that does not exist, so a misconfigured
+deployment never starts serving. Build-time `REACT_APP_*` values remain as defaults.
+See [runtime configuration](src/config/runtime/README.md) and
+[feature flags](docs/feature-flags.md).
+
 ### Load Testing with K6
 
 This project includes a dedicated load testing service using K6, configured via a Docker Compose profile.
@@ -341,6 +359,8 @@ If you're having trouble, head for
 as it's frequently updated.
 
 - [Architecture Decision Records (ADRs)](docs/adr/README.md)
+- [Feature flags — lifecycle and rollout](docs/feature-flags.md)
+- [Runtime configuration (`@/config/runtime`)](src/config/runtime/README.md)
 
 You can generate complete API-level documentation by running `doc` in the top-level
 folder, and documentation will appear in the `docs` folder, though you'll need to have

--- a/agents.md
+++ b/agents.md
@@ -763,6 +763,49 @@ const myStoreFactory = new MyStoreFactory();
 export const useMyStore = myStoreFactory.create(container.resolve(MyStoreActions));
 ```
 
+### Runtime Configuration and Feature Flags (issue #145)
+
+`@/config/env` is build-time (`REACT_APP_*` inlined by RSBuild — changing one needs a rebuild).
+`@/config/runtime` is runtime: an inline JSON block in `public/index.html` that the production
+container entrypoint rewrites from `APP_CONFIG_*` variables at start-up, so the same tested
+artifact is promoted across environments. Runtime values win over build-time defaults.
+
+It is split in two layers for the same reason `@/config/env` is — `zod` must not reach the auth
+paint path (measured: `zod` adds 62 kB raw to the eager entrypoint, `zod/mini` 45 kB, against a
+470 kB budget and a mobile Lighthouse floor of 0.84):
+
+```typescript
+// Paint path / any zod-free code — dependency-free, synchronous, memoized
+import appConfigSource from '@/config/runtime/app-config-source';
+
+// Container-resolved code — zod-validated, frozen, fails fast
+@injectable()
+export default class GraphQLUrl {
+  constructor(@inject(RUNTIME_TOKENS.AppConfig) private readonly appConfig: AppConfigReader) {}
+}
+```
+
+Both `RUNTIME_TOKENS.AppConfig` and `RUNTIME_TOKENS.FeatureFlagService` are registered with
+`useValue` over module singletons rather than decorated `@injectable()` — the observability
+render-path pattern (issue #115).
+
+Read a flag from a component through the container-free bridge:
+
+```typescript
+import useFeatureFlag from '@/hooks/use-feature-flag';
+
+const showForgotPassword = useFeatureFlag('forgotPassword');
+```
+
+Adding a flag means declaring it in four places — the `FeatureFlag` union
+(`src/config/runtime/types/feature-flag.ts`), `FEATURE_FLAG_DEFAULTS`
+(`feature-flag-service.ts`), `app-config-schema.ts`, and the committed block in
+`public/index.html` — plus `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` in `.env`, `.env.example` and the
+`prod` service in `docker-compose.test.yml`.
+`tests/unit/tooling/runtime-config-contract.test.ts` fails the build when those drift.
+Flags default **off**, and the full lifecycle (introduce → roll out → remove) is in
+[`docs/feature-flags.md`](docs/feature-flags.md).
+
 ### Zustand Store Pattern
 
 Stores use Zustand (`create` + `devtools`) and stay container-free. Resolve the DI

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,13 @@ services:
     restart: unless-stopped
     ports:
       - '3001:3001'
+    environment:
+      # Runtime configuration (issue #145). Rendered into the built HTML shell by the container
+      # entrypoint, so the same image serves any environment. Empty means "keep the committed
+      # default", which is what local, e2e and Lighthouse runs use.
+      - APP_CONFIG_API_BASE_URL=${APP_CONFIG_API_BASE_URL-}
+      - APP_CONFIG_GRAPHQL_URL=${APP_CONFIG_GRAPHQL_URL-}
+      - APP_CONFIG_FLAG_FORGOT_PASSWORD=${APP_CONFIG_FLAG_FORGOT_PASSWORD-}
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3001']
       interval: 10s

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -107,6 +107,11 @@ housekeeping: while a flag exists, one of its two branches is running untested i
 the flag defaults to `false`. Enable it only once the recovery flow is implemented, then follow
 stage 3 and delete the flag.
 
+That precondition is enforced, not merely documented:
+`tests/unit/tooling/runtime-config-contract.test.ts` fails the build if the committed default for
+`forgotPassword` is ever flipped to `true` while no route contract registers
+`ROUTE_PATHS.passwordRecovery`. A flag that gates a link should carry the same kind of gate.
+
 ## Rules
 
 - **Default off.** A new flag ships disabled. The only reason to declare a default of `true` is a

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,120 @@
+# Feature flags
+
+Feature flags let a deployed instance turn behaviour on or off **without a rebuild or a code
+change** — incremental rollout for new work, and an emergency kill switch for shipped work
+(issue #145).
+
+A flag is not a permanent configuration option. Every flag is a temporary construct with a
+planned removal date; a flag that outlives its rollout becomes an untested code path.
+
+## How a flag is evaluated
+
+Flags live in the `flags` object of the runtime configuration block in the HTML shell. The
+production container renders that block from `APP_CONFIG_FLAG_*` environment variables at
+start-up, so the same image behaves differently per environment. See
+`src/config/runtime/README.md` for the mechanism.
+
+```ts
+// In a React component or hook
+import useFeatureFlag from '@/hooks/use-feature-flag';
+
+const showForgotPassword = useFeatureFlag('forgotPassword');
+```
+
+```ts
+// In a container-resolved class
+import { inject, injectable } from 'tsyringe';
+
+import RUNTIME_TOKENS from '@/config/runtime/tokens';
+import type { FeatureFlagService } from '@/config/runtime/feature-flag-service';
+
+@injectable()
+export default class SomeService {
+  constructor(
+    @inject(RUNTIME_TOKENS.FeatureFlagService) private readonly flags: FeatureFlagService
+  ) {}
+}
+```
+
+Both paths resolve to the same singleton. The value is constant for the lifetime of the document,
+so a flag read needs no subscription and no live-region announcement.
+
+`isEnabled(flag)` returns the value from the runtime configuration when it is a boolean, and the
+flag's declared default otherwise. An unknown flag name is a **compile error** (the `FeatureFlag`
+union), and an `APP_CONFIG_FLAG_*` variable naming a flag that does not exist **fails container
+start** — a typo can never silently do nothing.
+
+## Lifecycle
+
+### 1. Introduce — default off
+
+A new flag is added with a default of `false`, so merging it changes nothing that ships. This is
+what makes a flag safe to merge before the feature is finished.
+
+1. Add the name to the `FeatureFlag` union in `src/config/runtime/types/feature-flag.ts` and to
+   `FEATURE_FLAG_DEFAULTS` in `src/config/runtime/feature-flag-service.ts` with the value `false`.
+2. Add the key to the `flags` object in `public/index.html` with the value `false`, and to the
+   `flags` shape in `src/config/runtime/app-config-schema.ts`.
+3. Declare `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` (empty) in both `.env` and `.env.example`, and
+   pass it through the `prod` service in `docker-compose.test.yml`.
+4. Gate the code with `useFeatureFlag(...)` / `isEnabled(...)`.
+5. Test **both** branches. The off branch is what ships, so it is the one that must keep every
+   existing assertion, visual baseline and e2e flow green; the on branch needs its own coverage
+   because 100% branch coverage is enforced.
+
+Add the flag and its gated code in the same change. A flag with no call site is dead
+configuration, and gated code with no flag is an unreviewed feature.
+
+### 2. Roll out — enable per environment
+
+Set the variable on the target environment and restart the container. No rebuild, no redeploy of
+a new artifact:
+
+```sh
+APP_CONFIG_FLAG_FORGOT_PASSWORD=true docker compose -f docker-compose.yml \
+  -f docker-compose.test.yml up -d --force-recreate prod
+```
+
+Roll forward one environment at a time (staging, then production). To disable, set the variable
+back to `false` (or clear it, which restores the declared default) and restart. Because the value
+is read from the HTML shell and `index.html` is served `no-cache`, the change takes effect on the
+next page load.
+
+Keep the default `false` in the committed block while a flag is rolling out. Flipping the
+committed default is step 3, not a shortcut for step 2.
+
+### 3. Remove — delete the flag, keep one branch
+
+Once the feature is enabled everywhere and stable, the flag has to go. Removal is not optional
+housekeeping: while a flag exists, one of its two branches is running untested in production.
+
+1. Delete the call sites, keeping the code of the branch that won.
+2. Delete the name from the `FeatureFlag` union, `FEATURE_FLAG_DEFAULTS`,
+   `app-config-schema.ts`, and the `flags` object in `public/index.html`.
+3. Delete `APP_CONFIG_FLAG_<NAME>` from `.env`, `.env.example` and `docker-compose.test.yml`.
+4. Delete the flag-specific tests and collapse the remaining ones onto the surviving behaviour.
+5. Unset the variable in every environment. Leaving it set is harmless — the renderer will reject
+   it on the next restart, which is the intended signal that the environment is stale.
+
+## Current flags
+
+| Flag             | Default | Meaning                                                       |
+| ---------------- | ------- | ------------------------------------------------------------- |
+| `forgotPassword` | `false` | Shows the "Forgot password?" link on the sign-in options row. |
+
+`forgotPassword` is the worked example of stage 1. The link points at
+`ROUTE_PATHS.passwordRecovery`, and the recovery route does not exist yet — which is exactly why
+the flag defaults to `false`. Enable it only once the recovery flow is implemented, then follow
+stage 3 and delete the flag.
+
+## Rules
+
+- **Default off.** A new flag ships disabled. The only reason to declare a default of `true` is a
+  kill switch retrofitted onto behaviour that already ships, and that should be rare enough to
+  argue for in review.
+- **Boolean only.** Flags are on/off. Anything that needs a value is a configuration setting
+  (`apiBaseUrl`, `graphqlUrl`), not a flag.
+- **No nesting.** Do not gate a flag on another flag; the combinations are untestable.
+- **No flag in a hot loop.** Read it once per component, not per iteration.
+- **Give it an owner and a removal trigger** in the pull request that introduces it — "remove when
+  the recovery flow ships", not "remove eventually".

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -253,13 +253,14 @@ export default [
 
   // Playwright specs are not React Testing Library. The `page` fixture is destructured from the
   // test callback argument, which `testing-library/prefer-screen-queries` misreads as a `render()`
-  // result — so the rule fires on exactly the semantic `page.getByRole(...)` queries the testing
-  // convention in CLAUDE.md requires. Scope the RTL rule set to the suites it was written for.
+  // result — so this ONE rule fires on exactly the semantic `page.getByRole(...)` queries the
+  // testing convention in CLAUDE.md requires, and its advice (`screen.getByRole`) is unavailable
+  // there. Every other testing-library rule stays on for these suites.
   {
     files: ['tests/e2e/**/*.ts', 'tests/visual/**/*.ts'],
-    rules: Object.fromEntries(
-      Object.keys(testingLibrary.configs['flat/react'].rules).map((rule) => [rule, 'off'])
-    ),
+    rules: {
+      'testing-library/prefer-screen-queries': 'off',
+    },
   },
 
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -251,6 +251,17 @@ export default [
     },
   },
 
+  // Playwright specs are not React Testing Library. The `page` fixture is destructured from the
+  // test callback argument, which `testing-library/prefer-screen-queries` misreads as a `render()`
+  // result — so the rule fires on exactly the semantic `page.getByRole(...)` queries the testing
+  // convention in CLAUDE.md requires. Scope the RTL rule set to the suites it was written for.
+  {
+    files: ['tests/e2e/**/*.ts', 'tests/visual/**/*.ts'],
+    rules: Object.fromEntries(
+      Object.keys(testingLibrary.configs['flat/react'].rules).map((rule) => [rule, 'off'])
+    ),
+  },
+
   {
     files: tsGlobs,
     ignores: ['**/*.d.ts'],

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,17 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000" />
     <title>VilnaCRM</title>
+    <!--
+      Runtime configuration (issue #145). Read synchronously at boot by
+      src/config/runtime/app-config-source.ts. The production entrypoint
+      (scripts/docker-entrypoint.sh -> scripts/render-app-config.js) rewrites the JSON below
+      from APP_CONFIG_* environment variables at container start, so the same built image
+      serves any environment without a rebuild. The values here are the committed defaults;
+      see src/config/runtime/README.md and docs/feature-flags.md.
+    -->
+    <script id="app-runtime-config" type="application/json">
+      { "flags": { "forgotPassword": false } }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# scripts/docker-entrypoint.sh - render the runtime configuration, then hand off to the server.
+#
+# WHY: RSBuild inlines every REACT_APP_* value at build time, so without a container-start
+# rendering step each environment would need its own build and the artifact that was tested in
+# staging could not be promoted to production unchanged (issue #145). Rendering here means the
+# same image serves any environment: set APP_CONFIG_* variables and restart, no rebuild.
+#
+# Fails fast: an invalid APP_CONFIG_* value aborts the entrypoint with a non-zero status, so a
+# misconfigured deployment never starts serving rather than degrading silently in the browser.
+#
+# POSIX sh on purpose - the production image is node:alpine with no bash, no jq and no envsubst.
+
+set -eu
+
+APP_ROOT="${APP_ROOT:-/app}"
+APP_CONFIG_HTML="${APP_CONFIG_HTML:-${APP_ROOT}/dist/index.html}"
+APP_CONFIG_RENDERER="${APP_CONFIG_RENDERER:-${APP_ROOT}/scripts/render-app-config.js}"
+
+if [ ! -f "$APP_CONFIG_HTML" ]; then
+  printf 'docker-entrypoint: HTML shell not found at %s\n' "$APP_CONFIG_HTML" >&2
+  exit 1
+fi
+
+if [ ! -f "$APP_CONFIG_RENDERER" ]; then
+  printf 'docker-entrypoint: renderer not found at %s\n' "$APP_CONFIG_RENDERER" >&2
+  exit 1
+fi
+
+node "$APP_CONFIG_RENDERER" "$APP_CONFIG_HTML"
+
+exec "$@"

--- a/scripts/render-app-config.js
+++ b/scripts/render-app-config.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * scripts/render-app-config.js - render the runtime configuration block of the built HTML shell
+ * from APP_CONFIG_* environment variables (issue #145).
+ *
+ * WHY: every REACT_APP_* value is inlined into the JS bundle at build time by RSBuild, so without
+ * this step each environment would need its own build and the same tested artifact could not be
+ * promoted from staging to production. This script rewrites the inline
+ * `<script id="app-runtime-config" type="application/json">` block that the app reads
+ * synchronously at boot, so one image serves any environment.
+ *
+ * WHY AN INLINE BLOCK AND NOT A FETCHED FILE: the auth pages are gated by a Lighthouse mobile
+ * performance floor with no headroom. A separate config request would serialize a round trip onto
+ * first paint; an inline JSON block costs zero requests and zero added latency.
+ *
+ * The committed block in public/index.html is the single source of truth for which flags exist:
+ * a flag environment variable naming a key that is not already present is rejected, so a typo
+ * fails container start instead of silently doing nothing.
+ *
+ * Run by scripts/docker-entrypoint.sh; also runnable directly:
+ *   node scripts/render-app-config.js dist/index.html
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+const CONFIG_ELEMENT_ID = 'app-runtime-config';
+const FLAG_ENV_PREFIX = 'APP_CONFIG_FLAG_';
+
+// Tolerant of attribute order and of any extra attributes an HTML minifier may leave behind.
+const BLOCK_PATTERN = new RegExp(
+  `(<script[^>]*\\bid="${CONFIG_ELEMENT_ID}"[^>]*>)([\\s\\S]*?)(</script>)`
+);
+
+const URL_SETTINGS = [
+  { envVar: 'APP_CONFIG_API_BASE_URL', key: 'apiBaseUrl' },
+  { envVar: 'APP_CONFIG_GRAPHQL_URL', key: 'graphqlUrl' },
+];
+
+function toCamelCase(upperSnakeCase) {
+  return upperSnakeCase.toLowerCase().replace(/_([a-z0-9])/g, (_match, char) => char.toUpperCase());
+}
+
+function assertHttpUrl(envVar, raw) {
+  let parsed;
+
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${envVar} must be an absolute URL, got "${raw}".`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${envVar} must use http or https, got "${raw}".`);
+  }
+}
+
+function parseBoolean(envVar, raw) {
+  if (raw === 'true') {
+    return true;
+  }
+
+  if (raw === 'false') {
+    return false;
+  }
+
+  throw new Error(`${envVar} must be exactly "true" or "false", got "${raw}".`);
+}
+
+function readSetting(env, envVar) {
+  const raw = env[envVar];
+
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
+}
+
+function applyUrlSettings(config, env) {
+  for (const { envVar, key } of URL_SETTINGS) {
+    const value = readSetting(env, envVar);
+
+    if (value !== undefined) {
+      assertHttpUrl(envVar, value);
+      config[key] = value;
+    }
+  }
+}
+
+function assertKnownFlag(flags, envVar, flag) {
+  if (Object.prototype.hasOwnProperty.call(flags, flag)) {
+    return;
+  }
+
+  const known = Object.keys(flags).sort().join(', ') || '(none)';
+
+  throw new Error(`${envVar} names unknown feature flag "${flag}". Known flags: ${known}.`);
+}
+
+function applyFlagSettings(config, env) {
+  const flags = config.flags && typeof config.flags === 'object' ? config.flags : {};
+  const flagVars = Object.keys(env).filter((name) => name.startsWith(FLAG_ENV_PREFIX));
+
+  for (const envVar of flagVars) {
+    const value = readSetting(env, envVar);
+
+    if (value !== undefined) {
+      const flag = toCamelCase(envVar.slice(FLAG_ENV_PREFIX.length));
+
+      assertKnownFlag(flags, envVar, flag);
+      flags[flag] = parseBoolean(envVar, value);
+    }
+  }
+
+  config.flags = flags;
+}
+
+function parseExistingConfig(json) {
+  let parsed;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error(
+      `the #${CONFIG_ELEMENT_ID} block does not contain valid JSON: ${error.message}`
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`the #${CONFIG_ELEMENT_ID} block must contain a JSON object.`);
+  }
+
+  return parsed;
+}
+
+function renderAppConfig(html, env) {
+  const match = BLOCK_PATTERN.exec(html);
+
+  if (!match) {
+    throw new Error(`no <script id="${CONFIG_ELEMENT_ID}"> block found in the HTML shell.`);
+  }
+
+  const config = parseExistingConfig(match[2]);
+
+  applyUrlSettings(config, env);
+  applyFlagSettings(config, env);
+
+  // Escaping `<` keeps a value containing `</script` from terminating the block early.
+  const rendered = JSON.stringify(config).replace(/</g, '\\u003c');
+
+  return html.replace(BLOCK_PATTERN, (_full, open, _body, close) => `${open}${rendered}${close}`);
+}
+
+function main(argv, env) {
+  const target = argv[2];
+
+  if (!target) {
+    throw new Error('usage: node scripts/render-app-config.js <html-file>');
+  }
+
+  const html = fs.readFileSync(target, 'utf8');
+  const rendered = renderAppConfig(html, env);
+
+  if (rendered !== html) {
+    fs.writeFileSync(target, rendered);
+  }
+
+  return target;
+}
+
+module.exports = { CONFIG_ELEMENT_ID, FLAG_ENV_PREFIX, renderAppConfig, toCamelCase };
+
+if (require.main === module) {
+  try {
+    process.stdout.write(
+      `render-app-config: rendered runtime configuration into ${main(process.argv, process.env)}\n`
+    );
+  } catch (error) {
+    process.stderr.write(`render-app-config: ${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/src/config/dependency-injection-config.ts
+++ b/src/config/dependency-injection-config.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 
 import { container } from 'tsyringe';
 
+import runtimeConfigRegistrar from '@/config/runtime/di';
 import type { ModuleRegistrar } from '@/config/types/module-registrar';
 import userModuleRegistrar from '@/modules/user/config/di';
 import errorRegistrar from '@/services/error/di';
@@ -11,6 +12,7 @@ import observabilityRegistrar from '@/services/observability/di';
 import errorUtilsRegistrar from '@/utils/error/di';
 
 const registrars: ModuleRegistrar[] = [
+  runtimeConfigRegistrar,
   errorUtilsRegistrar,
   errorRegistrar,
   errorReportingRegistrar,

--- a/src/config/env/README.md
+++ b/src/config/env/README.md
@@ -4,6 +4,13 @@ Single, typed, validated source of truth for the environment-derived configurati
 `src/` consumes. Replaces the scattered, contradictory raw `process.env` reads that used to
 live in `url-builder`, `get-graphql-url`, and the auth store (issue #112).
 
+This is the **build-time** layer: `REACT_APP_*` values are inlined into the bundle, so changing one
+requires a rebuild. Configuration an administrator can change **without** a rebuild lives in the
+sibling **runtime** layer, `@/config/runtime` (issue #145), which reuses the two-layer split below
+for the same paint-path reason. Where both define a setting (`graphqlUrl`, the REST base URL), the
+runtime value wins and the build-time value is the default. See
+[`../runtime/README.md`](../runtime/README.md).
+
 ## Why a two-layer module
 
 `REACT_APP_*` variables are inlined by RSBuild at **build time** (`loadEnv` +
@@ -53,8 +60,7 @@ _present but malformed_ value fails.
 
 `eslint.config.mjs` bans raw `process.env` reads in non-React application code
 (`src/**/*.ts`, the same scope as the no-free-functions gate #100) via `no-restricted-syntax`.
-`src/config/env/**` is the single exemption. Intentionally **out of this `.ts` scope** (and
-deferred, tracked with #145):
+`src/config/env/**` is the single exemption. Intentionally **out of this `.ts` scope**:
 
 - React components (`.tsx`) reading `NODE_ENV` — e.g. the error boundaries and
   `auth-error-boundary/index.tsx`. `.tsx` is exempt from the non-React `.ts` boundary the ban

--- a/src/config/runtime/README.md
+++ b/src/config/runtime/README.md
@@ -97,7 +97,11 @@ supplied. Note the REST fallback is `REACT_APP_MOCKOON_URL`, not `REACT_APP_API_
 
 A runtime URL that is not an absolute `http(s)` URL is treated as absent by the paint-path reader,
 so a malformed value falls back to the build-time default instead of reaching `fetch`. The zod
-layer rejects it outright (`z.httpUrl()`), matching what the container entrypoint enforces.
+layer rejects it outright (`z.url({ protocol: /^https?$/ })`), matching what the container
+entrypoint enforces. All three validators accept the same set, including single-label Docker
+hostnames such as `http://prod:3001` — note `z.httpUrl()` would **not**, because it additionally
+requires a dotted hostname, which would let a value pass container start and then fail in the
+browser.
 
 **Not covered:** `mainLanguage` / `fallbackLanguage` stay build-time. `src/i18n.js` initializes
 i18next at module evaluation and is CommonJS, and `src/config/i18n-config.js` is `require`d by

--- a/src/config/runtime/README.md
+++ b/src/config/runtime/README.md
@@ -1,0 +1,127 @@
+# Runtime configuration (`@/config/runtime`)
+
+Deployment-time configuration that an administrator can change **without a rebuild**, plus the
+typed feature-flag service that reads it (issue #145).
+
+`@/config/env` (issue #112) is the **build-time** layer: `REACT_APP_*` values are inlined into the
+JS bundle by RSBuild, so changing one requires a new build. This module is the **runtime** layer:
+its values live in the HTML shell, which the production container rewrites at start-up. Build-time
+values remain as defaults; runtime values win.
+
+## Where the configuration lives
+
+The configuration is an inline JSON block in the HTML shell, `public/index.html`:
+
+```json
+{ "flags": { "forgotPassword": false } }
+```
+
+It is carried by a `script` element with `id="app-runtime-config"` and
+`type="application/json"` — a data block, not executable code, so it stays valid under a strict
+Content-Security-Policy without a nonce.
+
+`serve.json` already sends `Cache-Control: no-cache` for `/` and `/index.html`, so a redeploy is
+never served from a stale cache.
+
+### Why inline and not a fetched `app-config.json`
+
+The auth pages are gated by a Lighthouse mobile performance floor that has no headroom
+(`lighthouse/lighthouserc.mobile.js`). A separate config request is **not** discoverable by the
+preload scanner — it can only start after `index.js` executes — so awaiting it before
+`root.render()` serializes a full round trip onto FCP and LCP. An inline block costs zero
+requests and zero added latency, and it is read synchronously, which also keeps the module-eval
+router construction in `src/routes/routes.tsx` working unchanged.
+
+## Why two layers
+
+Same reasoning as `@/config/env`, and measured on this codebase before choosing:
+
+| File                   | Deps  | Reads          | Use it from                            |
+| ---------------------- | ----- | -------------- | -------------------------------------- |
+| `app-config-source.ts` | none  | lazy, memoized | paint path / any zod-free code         |
+| `app-config.ts`        | `zod` | once, frozen   | container-resolved code wanting typing |
+| `app-config-schema.ts` | `zod` | —              | the zod contract (constraints)         |
+| `types/*.ts`           | none  | —              | the hand-authored interfaces           |
+
+Importing `zod` from the boot path was measured against a production build: the eager entrypoint
+grows from 373 kB to 436 kB raw (+62 kB) with `zod`, or to 418 kB (+45 kB) with `zod/mini`,
+against a hard 470 kB `raw.maxInitialEntrypointBytes` budget. Both fit the byte budget, but the
+extra parse and evaluation work lands on the critical path that the 0.84 mobile floor cannot
+absorb. So the split mirrors `raw-env.ts` / `env.ts` exactly.
+
+- **`appConfigSource`** (`@/config/runtime/app-config-source`) — dependency-free singleton and the
+  only place that touches the DOM block. It memoizes on the block's text, so repeated reads are
+  free and a test that rewrites the block is picked up. Import it **directly** on the paint path.
+- **`appConfig`** (`@/config/runtime/app-config`) — parses the same snapshot through the zod
+  schema **once** at module load, freezes it, and **fails fast** with an aggregated
+  (`z.prettifyError`) message. It is registered as `RUNTIME_TOKENS.AppConfig` and injected into
+  `GraphQLUrl`, which lives behind the dynamic-import DI composition root — so `zod` never reaches
+  the auth paint path.
+
+The `AppConfigValues` interface is hand-authored rather than `z.infer`, because a `types/` file
+may not import the runtime schema (dependency-cruiser `type-files-no-runtime-imports`, issue #88).
+The `private readonly values: AppConfigValues` assignment in `app-config.ts` is the compile-time
+check that the two stay in sync.
+
+## Where invalid configuration is caught
+
+Fail-fast happens at the earliest point that can act on it, not only in the browser:
+
+1. **Container start** — `scripts/docker-entrypoint.sh` runs `scripts/render-app-config.js`,
+   which rejects a non-`http(s)` URL, a flag value that is not exactly `true`/`false`, and an
+   `APP_CONFIG_FLAG_*` variable naming a flag that does not exist. The entrypoint exits non-zero,
+   so a misconfigured deployment never starts serving.
+2. **Browser boot** — `src/index.tsx` calls `appConfigSource.load()` before `createRoot`, so a
+   malformed or non-object JSON block throws immediately with a named error instead of silently
+   degrading to defaults.
+3. **Container-resolved code** — `appConfig` zod-validates the same snapshot when the DI graph
+   loads, and `tests/unit/config/runtime/app-config-defaults.test.ts` validates the **committed**
+   block in `public/index.html` against the schema, so the shipped default cannot drift from the
+   contract.
+
+## Settings
+
+| Key            | Environment variable                 | Consumed by                         |
+| -------------- | ------------------------------------ | ----------------------------------- |
+| `apiBaseUrl`   | `APP_CONFIG_API_BASE_URL`            | `@/utils/url-builder` (REST origin) |
+| `graphqlUrl`   | `APP_CONFIG_GRAPHQL_URL`             | `GraphQLUrl` (Apollo endpoint)      |
+| `flags.<name>` | `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` | `featureFlagService.isEnabled()`    |
+
+Both URL settings fall back to their build-time `REACT_APP_*` counterpart when unset, so existing
+deployments behave exactly as before until an `APP_CONFIG_*` value is supplied.
+
+**Not covered:** `mainLanguage` / `fallbackLanguage` stay build-time. `src/i18n.js` initializes
+i18next at module evaluation and is CommonJS, and `src/config/i18n-config.js` is `require`d by
+node tooling without a TypeScript loader, so making the language runtime-configurable is a
+restructuring of the i18n boot path rather than a config change. Tracked separately.
+
+## Feature flags
+
+`featureFlagService` (`@/config/runtime/feature-flag-service`) is a container-free class exported
+as a module singleton and registered as `RUNTIME_TOKENS.FeatureFlagService`, mirroring the
+observability render-path leaves (issue #115). Registering the instance as a value is what lets
+container-resolved classes inject it instead of value-importing it (issue #130), while the auth
+paint path can still read a flag without loading tsyringe.
+
+React components read a flag through `useFeatureFlag` (`@/hooks/use-feature-flag`):
+
+```ts
+const showForgotPassword = useFeatureFlag('forgotPassword');
+```
+
+The flag name is a `FeatureFlag` union member, so a typo is a compile error. Flag lifecycle —
+introduce, roll out, remove — is documented in `docs/feature-flags.md`.
+
+## Adding a setting
+
+1. Add the key to the JSON block in `public/index.html` (this block is the source of truth for
+   which flags exist — `render-app-config.js` rejects any flag it does not find there).
+2. Add the field to `app-config-schema.ts` and to the matching interface in `types/`.
+3. For a flag: add the name to the `FeatureFlag` union in `types/feature-flag.ts` and to
+   `FEATURE_FLAG_DEFAULTS` in `feature-flag-service.ts`.
+4. For a URL setting: add the `APP_CONFIG_*` variable to `URL_SETTINGS` in
+   `scripts/render-app-config.js`.
+5. Declare the environment variable in **both** `.env` and `.env.example`
+   (`make check-env-sync`), and pass it through the `prod` service in `docker-compose.test.yml`.
+6. Read it through `appConfigSource` (paint path) or `appConfig` (container-resolved code) — never
+   from the DOM directly.

--- a/src/config/runtime/README.md
+++ b/src/config/runtime/README.md
@@ -81,14 +81,23 @@ Fail-fast happens at the earliest point that can act on it, not only in the brow
 
 ## Settings
 
-| Key            | Environment variable                 | Consumed by                         |
-| -------------- | ------------------------------------ | ----------------------------------- |
-| `apiBaseUrl`   | `APP_CONFIG_API_BASE_URL`            | `@/utils/url-builder` (REST origin) |
-| `graphqlUrl`   | `APP_CONFIG_GRAPHQL_URL`             | `GraphQLUrl` (Apollo endpoint)      |
-| `flags.<name>` | `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` | `featureFlagService.isEnabled()`    |
+| Key            | Environment variable                 | Falls back to           |
+| -------------- | ------------------------------------ | ----------------------- |
+| `apiBaseUrl`   | `APP_CONFIG_API_BASE_URL`            | `REACT_APP_MOCKOON_URL` |
+| `graphqlUrl`   | `APP_CONFIG_GRAPHQL_URL`             | `REACT_APP_GRAPHQL_URL` |
+| `flags.<name>` | `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` | the declared default    |
 
-Both URL settings fall back to their build-time `REACT_APP_*` counterpart when unset, so existing
-deployments behave exactly as before until an `APP_CONFIG_*` value is supplied.
+`apiBaseUrl` is read by `@/utils/url-builder` (the REST origin), `graphqlUrl` is injected into
+`GraphQLUrl` (the Apollo endpoint), and flags are read through `featureFlagService`.
+
+Each URL setting falls back to the build-time variable its consumer already read before this
+module existed, so existing deployments behave exactly as before until an `APP_CONFIG_*` value is
+supplied. Note the REST fallback is `REACT_APP_MOCKOON_URL`, not `REACT_APP_API_BASE_URL` —
+`url-builder` has always used the former, and this change deliberately does not repoint it.
+
+A runtime URL that is not an absolute `http(s)` URL is treated as absent by the paint-path reader,
+so a malformed value falls back to the build-time default instead of reaching `fetch`. The zod
+layer rejects it outright (`z.httpUrl()`), matching what the container entrypoint enforces.
 
 **Not covered:** `mainLanguage` / `fallbackLanguage` stay build-time. `src/i18n.js` initializes
 i18next at module evaluation and is CommonJS, and `src/config/i18n-config.js` is `require`d by

--- a/src/config/runtime/app-config-schema.ts
+++ b/src/config/runtime/app-config-schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
 
+// `z.httpUrl()` rather than `z.url()`: both settings are HTTP endpoints, and the container
+// entrypoint already rejects every other scheme. Keeping the browser contract identical means a
+// block that reaches the document without passing through the renderer cannot smuggle in a
+// `mailto:` or `javascript:` value that only fails later inside the HTTP clients.
 const AppConfigSchema = z.strictObject({
-  apiBaseUrl: z.url().optional(),
-  graphqlUrl: z.url().optional(),
+  apiBaseUrl: z.httpUrl().optional(),
+  graphqlUrl: z.httpUrl().optional(),
   flags: z
     .strictObject({
       forgotPassword: z.boolean().optional(),

--- a/src/config/runtime/app-config-schema.ts
+++ b/src/config/runtime/app-config-schema.ts
@@ -1,12 +1,20 @@
 import { z } from 'zod';
 
-// `z.httpUrl()` rather than `z.url()`: both settings are HTTP endpoints, and the container
-// entrypoint already rejects every other scheme. Keeping the browser contract identical means a
-// block that reaches the document without passing through the renderer cannot smuggle in a
-// `mailto:` or `javascript:` value that only fails later inside the HTTP clients.
+// Protocol-constrained rather than bare `z.url()`: both settings are HTTP endpoints, and the
+// container entrypoint already rejects every other scheme, so a block that reaches the document
+// without passing through the renderer must not be able to smuggle in a `mailto:` or
+// `javascript:` value that only fails later inside the HTTP clients.
+//
+// NOT `z.httpUrl()`, which additionally requires a dotted hostname: it rejects
+// `http://localhost:4000/graphql` (the GraphQLUrl fallback) and `http://prod:3001` (the compose
+// service names the e2e and Lighthouse stacks use). This form matches `assertHttpUrl` in
+// scripts/render-app-config.js and `isHttpUrl` in app-config-source.ts exactly — all three layers
+// accept the same set, so validation can never disagree across them.
+const HttpUrl = z.url({ protocol: /^https?$/ });
+
 const AppConfigSchema = z.strictObject({
-  apiBaseUrl: z.httpUrl().optional(),
-  graphqlUrl: z.httpUrl().optional(),
+  apiBaseUrl: HttpUrl.optional(),
+  graphqlUrl: HttpUrl.optional(),
   flags: z
     .strictObject({
       forgotPassword: z.boolean().optional(),

--- a/src/config/runtime/app-config-schema.ts
+++ b/src/config/runtime/app-config-schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+const AppConfigSchema = z.strictObject({
+  apiBaseUrl: z.url().optional(),
+  graphqlUrl: z.url().optional(),
+  flags: z
+    .strictObject({
+      forgotPassword: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export default AppConfigSchema;

--- a/src/config/runtime/app-config-source.ts
+++ b/src/config/runtime/app-config-source.ts
@@ -28,6 +28,16 @@ class AppConfigSource {
     return typeof value === 'string' && value.trim() ? value.trim() : undefined;
   }
 
+  // Dependency-free counterpart of the `z.httpUrl()` contract in app-config-schema.ts. The paint
+  // path reads endpoints before the zod layer exists, so a value that is not an absolute http(s)
+  // URL is reported as absent and the caller falls back to its build-time default, rather than
+  // being handed to fetch as-is.
+  public url(key: string): string | undefined {
+    const value = this.text(key);
+
+    return value !== undefined && this.isHttpUrl(value) ? value : undefined;
+  }
+
   public flags(): Record<string, unknown> {
     const value = this.snapshot().flags;
 
@@ -61,6 +71,16 @@ class AppConfigSource {
 
   private isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private isHttpUrl(value: string): boolean {
+    try {
+      const { protocol } = new URL(value);
+
+      return protocol === 'http:' || protocol === 'https:';
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/src/config/runtime/app-config-source.ts
+++ b/src/config/runtime/app-config-source.ts
@@ -1,0 +1,69 @@
+export const APP_CONFIG_ELEMENT_ID = 'app-runtime-config';
+
+const ERROR_PREFIX = `The #${APP_CONFIG_ELEMENT_ID} runtime configuration block`;
+
+class AppConfigSource {
+  private cachedText: string | undefined;
+
+  private cachedValues: Record<string, unknown> = {};
+
+  public load(): Record<string, unknown> {
+    return this.snapshot();
+  }
+
+  public snapshot(): Record<string, unknown> {
+    const text = this.readText();
+
+    if (text !== this.cachedText) {
+      this.cachedValues = this.parse(text);
+      this.cachedText = text;
+    }
+
+    return this.cachedValues;
+  }
+
+  public text(key: string): string | undefined {
+    const value = this.snapshot()[key];
+
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  }
+
+  public flags(): Record<string, unknown> {
+    const value = this.snapshot().flags;
+
+    return this.isRecord(value) ? value : {};
+  }
+
+  private readText(): string {
+    const element =
+      typeof document === 'undefined' ? null : document.getElementById(APP_CONFIG_ELEMENT_ID);
+
+    return element?.textContent?.trim() ?? '';
+  }
+
+  private parse(text: string): Record<string, unknown> {
+    const parsed = text ? this.parseJson(text) : {};
+
+    if (!this.isRecord(parsed)) {
+      throw new Error(`${ERROR_PREFIX} must contain a JSON object.`);
+    }
+
+    return parsed;
+  }
+
+  private parseJson(text: string): unknown {
+    try {
+      return JSON.parse(text) as unknown;
+    } catch (cause) {
+      throw new Error(`${ERROR_PREFIX} does not contain valid JSON: ${String(cause)}`);
+    }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+}
+
+const appConfigSource = new AppConfigSource();
+
+export default appConfigSource;

--- a/src/config/runtime/app-config.ts
+++ b/src/config/runtime/app-config.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import AppConfigSchema from './app-config-schema';
+import appConfigSource from './app-config-source';
+import type { AppConfigReader, AppConfigValues } from './types/app-config';
+
+export class AppConfig implements AppConfigReader {
+  private readonly values: AppConfigValues;
+
+  constructor() {
+    const result = AppConfigSchema.safeParse(appConfigSource.snapshot());
+
+    if (!result.success) {
+      throw new Error(`Invalid runtime configuration:\n${z.prettifyError(result.error)}`);
+    }
+
+    this.values = Object.freeze(result.data);
+  }
+
+  public get(): AppConfigValues {
+    return this.values;
+  }
+
+  public apiBaseUrl(): string | undefined {
+    return this.values.apiBaseUrl;
+  }
+
+  public graphqlUrl(): string | undefined {
+    return this.values.graphqlUrl;
+  }
+}
+
+const appConfig = new AppConfig();
+
+export default appConfig;

--- a/src/config/runtime/app-config.ts
+++ b/src/config/runtime/app-config.ts
@@ -14,7 +14,7 @@ export class AppConfig implements AppConfigReader {
       throw new Error(`Invalid runtime configuration:\n${z.prettifyError(result.error)}`);
     }
 
-    this.values = Object.freeze(result.data);
+    this.values = this.freeze(result.data);
   }
 
   public get(): AppConfigValues {
@@ -27,6 +27,14 @@ export class AppConfig implements AppConfigReader {
 
   public graphqlUrl(): string | undefined {
     return this.values.graphqlUrl;
+  }
+
+  // Object.freeze is shallow, so the nested flag object has to be frozen separately for `get()`
+  // to actually honour the readonly contract its interface advertises.
+  private freeze(values: AppConfigValues): AppConfigValues {
+    const flags = values.flags === undefined ? {} : { flags: Object.freeze({ ...values.flags }) };
+
+    return Object.freeze({ ...values, ...flags });
   }
 }
 

--- a/src/config/runtime/di.ts
+++ b/src/config/runtime/di.ts
@@ -1,0 +1,21 @@
+import type { DependencyContainer } from 'tsyringe';
+
+import type { ModuleRegistrar } from '@/config/types/module-registrar';
+
+import appConfig from './app-config';
+import featureFlagService from './feature-flag-service';
+import RUNTIME_TOKENS from './tokens';
+
+class RuntimeConfigRegistrar implements ModuleRegistrar {
+  // Both bindings are container-free module singletons registered as values, mirroring the
+  // observability render-path leaves (issue #115). The auth page reads flags synchronously at
+  // paint time, so neither may pull tsyringe into the eager chunk; registering the existing
+  // instances is what lets container-resolved classes inject them instead of value-importing
+  // them at the call site (issue #130).
+  public register(container: DependencyContainer): void {
+    container.register(RUNTIME_TOKENS.AppConfig, { useValue: appConfig });
+    container.register(RUNTIME_TOKENS.FeatureFlagService, { useValue: featureFlagService });
+  }
+}
+
+export default new RuntimeConfigRegistrar();

--- a/src/config/runtime/feature-flag-service.ts
+++ b/src/config/runtime/feature-flag-service.ts
@@ -1,0 +1,28 @@
+import appConfigSource from './app-config-source';
+import type { FeatureFlag } from './types/feature-flag';
+
+const FEATURE_FLAG_DEFAULTS: Readonly<Record<FeatureFlag, boolean>> = Object.freeze({
+  forgotPassword: false,
+});
+
+export class FeatureFlagService {
+  public isEnabled(flag: FeatureFlag): boolean {
+    const value = appConfigSource.flags()[flag];
+
+    return typeof value === 'boolean' ? value : FEATURE_FLAG_DEFAULTS[flag];
+  }
+
+  public names(): FeatureFlag[] {
+    return Object.keys(FEATURE_FLAG_DEFAULTS) as FeatureFlag[];
+  }
+
+  public snapshot(): Record<FeatureFlag, boolean> {
+    const entries = this.names().map((flag) => [flag, this.isEnabled(flag)]);
+
+    return Object.fromEntries(entries) as Record<FeatureFlag, boolean>;
+  }
+}
+
+const featureFlagService = new FeatureFlagService();
+
+export default featureFlagService;

--- a/src/config/runtime/tokens.ts
+++ b/src/config/runtime/tokens.ts
@@ -1,0 +1,6 @@
+const RUNTIME_TOKENS = Object.freeze({
+  AppConfig: Symbol('AppConfig'),
+  FeatureFlagService: Symbol('FeatureFlagService'),
+} as const);
+
+export default RUNTIME_TOKENS;

--- a/src/config/runtime/types/app-config.ts
+++ b/src/config/runtime/types/app-config.ts
@@ -1,0 +1,13 @@
+import type { FeatureFlagValues } from './feature-flag';
+
+export interface AppConfigValues {
+  readonly apiBaseUrl?: string;
+  readonly graphqlUrl?: string;
+  readonly flags?: FeatureFlagValues;
+}
+
+export interface AppConfigReader {
+  get(): AppConfigValues;
+  apiBaseUrl(): string | undefined;
+  graphqlUrl(): string | undefined;
+}

--- a/src/config/runtime/types/feature-flag.ts
+++ b/src/config/runtime/types/feature-flag.ts
@@ -1,0 +1,5 @@
+export type FeatureFlag = 'forgotPassword';
+
+export interface FeatureFlagValues {
+  readonly forgotPassword?: boolean;
+}

--- a/src/hooks/use-feature-flag.ts
+++ b/src/hooks/use-feature-flag.ts
@@ -1,0 +1,10 @@
+import featureFlagService from '@/config/runtime/feature-flag-service';
+import type { FeatureFlag } from '@/config/runtime/types/feature-flag';
+
+// The runtime configuration is immutable for the lifetime of the document (it is rendered into
+// the HTML shell at container start), so this is a plain synchronous read rather than a
+// subscription. It deliberately stays container-free: the flag lookup happens on the auth paint
+// path, which must not load tsyringe or the DI graph (issue #145 — Lighthouse budget unchanged).
+export default function useFeatureFlag(flag: FeatureFlag): boolean {
+  return featureFlagService.isEnabled(flag);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,8 @@ import { createRoot } from 'react-dom/client';
 import '@/styles/fonts.css';
 
 import AppErrorBoundary from '@/components/error-boundary/app-error-boundary';
+import ErrorFallback from '@/components/error-boundary/error-fallback';
+import appConfigSource from '@/config/runtime/app-config-source';
 import AppProviders from '@/providers/app-providers';
 import observabilityCore from '@/services/observability/observability-core';
 
@@ -20,12 +22,34 @@ const root = createRoot(rootElement);
 
 observabilityCore.init();
 
-root.render(
-  <React.StrictMode>
-    <AppErrorBoundary reporter={observabilityCore}>
-      <AppProviders>
-        <App />
-      </AppProviders>
-    </AppErrorBoundary>
-  </React.StrictMode>
-);
+const reloadPage = (): void => {
+  window.location.reload();
+};
+
+// Parse the runtime configuration before rendering so a malformed deployment fails loudly here
+// instead of silently degrading to defaults (issue #145). This is a synchronous read of the
+// inline JSON block in the HTML shell — no fetch, no await, no paint-path cost. An unhandled
+// throw would leave an empty #root, which a screen reader cannot distinguish from "still
+// loading", so the failure is rendered through the shell's own accessible error fallback.
+let configError: Error | undefined;
+
+try {
+  appConfigSource.load();
+} catch (cause) {
+  configError = cause instanceof Error ? cause : new Error(String(cause));
+  observabilityCore.report(configError, { source: 'bootstrap:runtime-config' });
+}
+
+if (configError) {
+  root.render(<ErrorFallback error={configError} reset={reloadPage} />);
+} else {
+  root.render(
+    <React.StrictMode>
+      <AppErrorBoundary reporter={observabilityCore}>
+        <AppProviders>
+          <App />
+        </AppProviders>
+      </AppErrorBoundary>
+    </React.StrictMode>
+  );
+}

--- a/src/modules/user/features/auth/components/form-section/components/user-options/index.tsx
+++ b/src/modules/user/features/auth/components/form-section/components/user-options/index.tsx
@@ -2,12 +2,17 @@ import { Box, FormControlLabel, Checkbox } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import UILink from '@/components/ui-link';
+import useFeatureFlag from '@/hooks/use-feature-flag';
+import ROUTE_PATHS from '@/routes/route-paths';
+
 import { CheckBoxChecked, CheckBoxIcon } from './checkbox-icons';
 import styles from './styles';
 
 export default function UserOptions(): JSX.Element {
   const [isChecked, setIsChecked] = useState(false);
   const { t } = useTranslation();
+  const showForgotPassword = useFeatureFlag('forgotPassword');
 
   const handleCheckboxChange = useCallback((): void => {
     setIsChecked((prev) => !prev);
@@ -28,6 +33,12 @@ export default function UserOptions(): JSX.Element {
           />
         }
       />
+
+      {showForgotPassword && (
+        <UILink href={ROUTE_PATHS.passwordRecovery} sx={styles.forgotPasswordLink}>
+          {t('sign_in.form.forgot_password')}
+        </UILink>
+      )}
     </Box>
   );
 }

--- a/src/modules/user/features/auth/components/form-section/components/user-options/styles.ts
+++ b/src/modules/user/features/auth/components/form-section/components/user-options/styles.ts
@@ -1,11 +1,17 @@
 import breakpointsTheme from '@/components/ui-breakpoints';
-import { customColors } from '@/styles/colors';
+import { customColors, paletteColors } from '@/styles/colors';
 
 export default {
   authOptionsWrapper: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    // The row can carry a second item once the forgotPassword flag is on; wrapping keeps it
+    // within a 320px viewport under the WCAG 1.4.12 text-spacing overrides, and the column gap
+    // guarantees the 2.5.8 spacing exception the inline link relies on.
+    flexWrap: 'wrap',
+    columnGap: '1rem',
+    rowGap: '0.5rem',
     marginTop: '1rem',
 
     [`@media (min-width:${breakpointsTheme.breakpoints.values.md}px)`]: {
@@ -43,5 +49,39 @@ export default {
   rememberMeCheckbox: {
     padding: 0,
     marginRight: '0.8125rem',
+  },
+
+  forgotPasswordLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    minHeight: '1.5rem',
+
+    fontFamily: `Inter, sans-serif`,
+    fontWeight: 500,
+    fontSize: '0.875rem',
+    lineHeight: '1.2857',
+
+    // Literal token rather than the MUI theme: `renderWithTheme` replaces the theme instead of
+    // merging it, so `theme.palette.primary.main` inside UILink resolves to MUI's default blue.
+    color: paletteColors.primary.linkText,
+
+    // The underline must live here: ui-link/theme.ts sets `textDecoration: 'none'` in
+    // `styleOverrides.root`, which outranks the `underline` prop. Without it the link is
+    // distinguished from the adjacent label by colour alone (WCAG 1.4.1).
+    textDecoration: 'underline',
+    textDecorationThickness: '1px',
+    textUnderlineOffset: '0.2em',
+
+    '&:hover': {
+      color: paletteColors.primary.linkTextHover,
+      textDecorationThickness: '2px',
+    },
+
+    '&:focus-visible': {
+      outline: `2px solid ${customColors.text.primary}`,
+      outlineOffset: '2px',
+      borderRadius: '2px',
+      textDecorationThickness: '2px',
+    },
   },
 };

--- a/src/routes/route-paths.ts
+++ b/src/routes/route-paths.ts
@@ -2,6 +2,9 @@ const ROUTE_PATHS = {
   home: '/',
   signUp: '/sign-up',
   signIn: '/sign-in',
+  // Declared ahead of the flow it names: the `forgotPassword` feature flag (issue #145) gates the
+  // sign-in link that points here and stays off until the recovery route is implemented.
+  passwordRecovery: '/password-recovery',
   notFound: '*',
 } as const;
 

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -4,6 +4,10 @@ export const paletteColors = {
     hover: '#00A3FF',
     active: '#0399ED',
     linkHover: '#297FFF',
+    // Link text on the #FFFFFF form background: 5.04:1 and 7.60:1. WCAG 1.4.3 AA needs 4.5:1,
+    // which `main` (2.46:1), `linkHover` (3.77:1) and `active` (3.10:1) do not reach.
+    linkText: '#0074B5',
+    linkTextHover: '#00588A',
   },
   secondary: {
     main: '#FFC01E',

--- a/src/utils/get-graphql-url.ts
+++ b/src/utils/get-graphql-url.ts
@@ -1,16 +1,24 @@
-import { injectable } from 'tsyringe';
+import { inject, injectable } from 'tsyringe';
 
 import { env } from '@/config/env';
+import RUNTIME_TOKENS from '@/config/runtime/tokens';
+import type { AppConfigReader } from '@/config/runtime/types/app-config';
 
 @injectable()
 export default class GraphQLUrl {
   private readonly fallback = 'http://localhost:4000/graphql';
 
   private readonly productionMessage =
-    'REACT_APP_GRAPHQL_URL must be defined in production environment. Cannot default to localhost.';
+    'A GraphQL URL must be defined in production environment. Set graphqlUrl in the runtime ' +
+    'configuration (APP_CONFIG_GRAPHQL_URL) or REACT_APP_GRAPHQL_URL at build time. ' +
+    'Cannot default to localhost.';
+
+  constructor(@inject(RUNTIME_TOKENS.AppConfig) private readonly appConfig: AppConfigReader) {}
 
   public resolve(): string {
-    const url = env.graphqlUrl();
+    // Runtime configuration wins over the build-time value so one image can be promoted across
+    // environments without a rebuild (issue #145).
+    const url = this.appConfig.graphqlUrl() ?? env.graphqlUrl();
 
     if (env.isProduction() && !url) {
       throw new Error(this.productionMessage);

--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -1,8 +1,11 @@
 import rawEnv from '@/config/env/raw-env';
+import appConfigSource from '@/config/runtime/app-config-source';
 
 class UrlBuilder {
   public build(endpoint: string): string {
-    const baseUrl = rawEnv.mockoonUrl();
+    // Runtime configuration wins over the build-time default so the same image can be pointed at
+    // a different REST origin without a rebuild (issue #145).
+    const baseUrl = appConfigSource.text('apiBaseUrl') ?? rawEnv.mockoonUrl();
     const normalizedBase = baseUrl.replace(/\/+$/, '');
     const normalizedEndpoint = endpoint.replace(/^\/+/, '');
 

--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -5,7 +5,7 @@ class UrlBuilder {
   public build(endpoint: string): string {
     // Runtime configuration wins over the build-time default so the same image can be pointed at
     // a different REST origin without a rebuild (issue #145).
-    const baseUrl = appConfigSource.text('apiBaseUrl') ?? rawEnv.mockoonUrl();
+    const baseUrl = appConfigSource.url('apiBaseUrl') ?? rawEnv.mockoonUrl();
     const normalizedBase = baseUrl.replace(/\/+$/, '');
     const normalizedEndpoint = endpoint.replace(/^\/+/, '');
 

--- a/tests/bats/render_app_config.bats
+++ b/tests/bats/render_app_config.bats
@@ -15,8 +15,12 @@ STAGING_GRAPHQL_URL='https://staging.vilnacrm.example/graphql'
 PRODUCTION_API_BASE_URL='https://api.vilnacrm.example'
 PRODUCTION_GRAPHQL_URL='https://api.vilnacrm.example/graphql'
 
-STAGING_CONFIG='{"flags":{"forgotPassword":true},"graphqlUrl":"https://staging.vilnacrm.example/graphql"}'
-PRODUCTION_CONFIG='{"flags":{"forgotPassword":false},"apiBaseUrl":"https://api.vilnacrm.example","graphqlUrl":"https://api.vilnacrm.example/graphql"}'
+STAGING_CONFIG='{"flags":{"forgotPassword":true}'
+STAGING_CONFIG="$STAGING_CONFIG,\"graphqlUrl\":\"$STAGING_GRAPHQL_URL\"}"
+
+PRODUCTION_CONFIG='{"flags":{"forgotPassword":false}'
+PRODUCTION_CONFIG="$PRODUCTION_CONFIG,\"apiBaseUrl\":\"$PRODUCTION_API_BASE_URL\""
+PRODUCTION_CONFIG="$PRODUCTION_CONFIG,\"graphqlUrl\":\"$PRODUCTION_GRAPHQL_URL\"}"
 
 setup() {
   SHELL_SOURCE="$PROJECT_ROOT/public/index.html"
@@ -139,7 +143,8 @@ strip_config_block() {
   local artifact
   artifact="$(copy_artifact bad-scheme)"
 
-  run --separate-stderr env APP_CONFIG_API_BASE_URL='ftp://files.example/api' node "$RENDERER" "$artifact"
+  run --separate-stderr env APP_CONFIG_API_BASE_URL='ftp://files.example/api' \
+    node "$RENDERER" "$artifact"
 
   [ "$status" -ne 0 ]
   [[ "$stderr" == *"APP_CONFIG_API_BASE_URL must use http or https"* ]]
@@ -244,6 +249,7 @@ strip_config_block() {
     sh "$ENTRYPOINT" echo started
 
   [ "$status" -ne 0 ]
-  [[ "$stderr" == *"docker-entrypoint: renderer not found at $BATS_TEST_TMPDIR/absent-renderer.js"* ]]
+  local expected="docker-entrypoint: renderer not found at $BATS_TEST_TMPDIR/absent-renderer.js"
+  [[ "$stderr" == *"$expected"* ]]
   [[ "$output" != *"started"* ]]
 }

--- a/tests/bats/render_app_config.bats
+++ b/tests/bats/render_app_config.bats
@@ -1,0 +1,249 @@
+#!/usr/bin/env bats
+
+# Acceptance criterion 1 of issue #145 — "the same production build artifact runs against two
+# different configs without a rebuild" — proven end to end against the real committed HTML shell:
+# scripts/render-app-config.js (CLI surface) driven by scripts/docker-entrypoint.sh.
+#
+# Every case copies public/index.html into BATS_TEST_TMPDIR first, so the committed artifact is
+# never mutated and each environment renders from the identical bytes a built image would ship.
+
+bats_require_minimum_version 1.5.0
+
+load './test_helper.bash'
+
+STAGING_GRAPHQL_URL='https://staging.vilnacrm.example/graphql'
+PRODUCTION_API_BASE_URL='https://api.vilnacrm.example'
+PRODUCTION_GRAPHQL_URL='https://api.vilnacrm.example/graphql'
+
+STAGING_CONFIG='{"flags":{"forgotPassword":true},"graphqlUrl":"https://staging.vilnacrm.example/graphql"}'
+PRODUCTION_CONFIG='{"flags":{"forgotPassword":false},"apiBaseUrl":"https://api.vilnacrm.example","graphqlUrl":"https://api.vilnacrm.example/graphql"}'
+
+setup() {
+  SHELL_SOURCE="$PROJECT_ROOT/public/index.html"
+  RENDERER_SOURCE="$PROJECT_ROOT/scripts/render-app-config.js"
+  ENTRYPOINT="$PROJECT_ROOT/scripts/docker-entrypoint.sh"
+
+  RENDERER="$BATS_TEST_TMPDIR/scripts/render-app-config.js"
+  mkdir -p "$BATS_TEST_TMPDIR/scripts"
+  cp "$RENDERER_SOURCE" "$RENDERER"
+}
+
+# Copy the committed shell into the sandbox and echo the copy's path.
+copy_artifact() {
+  local target="$BATS_TEST_TMPDIR/$1.html"
+
+  cp "$SHELL_SOURCE" "$target"
+  printf '%s\n' "$target"
+}
+
+# The rendered runtime configuration JSON, without its surrounding <script> tags.
+config_block() {
+  sed -n 's|.*<script id="app-runtime-config"[^>]*>\(.*\)</script>.*|\1|p' "$1"
+}
+
+# Write $1 to "$BATS_TEST_TMPDIR/$2.rest" with the whole runtime configuration block removed —
+# handling both its committed (three-line) and rendered (single-line) shapes — so that what
+# surrounds the block can be diffed byte for byte.
+strip_config_block() {
+  awk '
+    /<script id="app-runtime-config"/ { in_block = 1 }
+    in_block { if ($0 ~ /<\/script>/) { in_block = 0 }; next }
+    { print }
+  ' "$1" > "$BATS_TEST_TMPDIR/$2.rest"
+}
+
+@test "one built artifact renders two different runtime configurations without a rebuild" {
+  local staging production
+  staging="$(copy_artifact staging)"
+  production="$(copy_artifact production)"
+
+  run --separate-stderr env \
+    APP_CONFIG_GRAPHQL_URL="$STAGING_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    node "$RENDERER" "$staging"
+  [ "$status" -eq 0 ]
+  assert_output_contains "$staging"
+
+  run --separate-stderr env \
+    APP_CONFIG_API_BASE_URL="$PRODUCTION_API_BASE_URL" \
+    APP_CONFIG_GRAPHQL_URL="$PRODUCTION_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=false \
+    node "$RENDERER" "$production"
+  [ "$status" -eq 0 ]
+
+  [ "$(config_block "$staging")" = "$STAGING_CONFIG" ]
+  [ "$(config_block "$production")" = "$PRODUCTION_CONFIG" ]
+  [ "$(config_block "$staging")" != "$(config_block "$production")" ]
+}
+
+@test "rendering changes nothing outside the runtime configuration block" {
+  local staging production
+  staging="$(copy_artifact staging)"
+  production="$(copy_artifact production)"
+
+  run env APP_CONFIG_GRAPHQL_URL="$STAGING_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    node "$RENDERER" "$staging"
+  [ "$status" -eq 0 ]
+
+  run env APP_CONFIG_API_BASE_URL="$PRODUCTION_API_BASE_URL" \
+    APP_CONFIG_GRAPHQL_URL="$PRODUCTION_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=false \
+    node "$RENDERER" "$production"
+  [ "$status" -eq 0 ]
+
+  strip_config_block "$SHELL_SOURCE" committed
+  strip_config_block "$staging" staging
+  strip_config_block "$production" production
+
+  diff "$BATS_TEST_TMPDIR/committed.rest" "$BATS_TEST_TMPDIR/staging.rest"
+  diff "$BATS_TEST_TMPDIR/committed.rest" "$BATS_TEST_TMPDIR/production.rest"
+  diff "$BATS_TEST_TMPDIR/staging.rest" "$BATS_TEST_TMPDIR/production.rest"
+
+  grep -q '<title>VilnaCRM</title>' "$staging"
+  grep -q '<div id="root"></div>' "$production"
+}
+
+@test "re-rendering an already rendered artifact with the same environment is a no-op" {
+  local artifact first
+  artifact="$(copy_artifact restart)"
+
+  run env APP_CONFIG_GRAPHQL_URL="$STAGING_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    node "$RENDERER" "$artifact"
+  [ "$status" -eq 0 ]
+  first="$(cat "$artifact")"
+
+  run env APP_CONFIG_GRAPHQL_URL="$STAGING_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    node "$RENDERER" "$artifact"
+  [ "$status" -eq 0 ]
+
+  [ "$first" = "$(cat "$artifact")" ]
+  [ "$(config_block "$artifact")" = "$STAGING_CONFIG" ]
+}
+
+@test "an invalid URL fails the renderer with a message on stderr" {
+  local artifact
+  artifact="$(copy_artifact invalid-url)"
+
+  run --separate-stderr env APP_CONFIG_GRAPHQL_URL='not-a-url' node "$RENDERER" "$artifact"
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"APP_CONFIG_GRAPHQL_URL must be an absolute URL"* ]]
+  [ -z "$output" ]
+  [ "$(config_block "$artifact")" = "" ]
+}
+
+@test "a non-http scheme fails the renderer with a message on stderr" {
+  local artifact
+  artifact="$(copy_artifact bad-scheme)"
+
+  run --separate-stderr env APP_CONFIG_API_BASE_URL='ftp://files.example/api' node "$RENDERER" "$artifact"
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"APP_CONFIG_API_BASE_URL must use http or https"* ]]
+}
+
+@test "an invalid flag boolean fails the renderer with a message on stderr" {
+  local artifact
+  artifact="$(copy_artifact invalid-boolean)"
+
+  run --separate-stderr env APP_CONFIG_FLAG_FORGOT_PASSWORD='yes' node "$RENDERER" "$artifact"
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *'APP_CONFIG_FLAG_FORGOT_PASSWORD must be exactly "true" or "false"'* ]]
+  [ -z "$output" ]
+}
+
+@test "an unknown feature flag fails the renderer and lists the known flags on stderr" {
+  local artifact
+  artifact="$(copy_artifact unknown-flag)"
+
+  run --separate-stderr env APP_CONFIG_FLAG_DARK_MODE='true' node "$RENDERER" "$artifact"
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *'names unknown feature flag "darkMode"'* ]]
+  [[ "$stderr" == *'Known flags: forgotPassword.'* ]]
+}
+
+@test "the renderer refuses to run without a target argument" {
+  run --separate-stderr node "$RENDERER"
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"usage: node scripts/render-app-config.js <html-file>"* ]]
+}
+
+@test "docker-entrypoint.sh renders the shell and then execs its command" {
+  local artifact
+  artifact="$(copy_artifact entrypoint)"
+
+  run --separate-stderr env \
+    APP_CONFIG_HTML="$artifact" \
+    APP_CONFIG_RENDERER="$RENDERER" \
+    APP_CONFIG_GRAPHQL_URL="$STAGING_GRAPHQL_URL" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    sh "$ENTRYPOINT" echo started
+
+  [ "$status" -eq 0 ]
+  assert_output_contains 'started'
+  [ "$(config_block "$artifact")" = "$STAGING_CONFIG" ]
+}
+
+@test "docker-entrypoint.sh derives both defaults from APP_ROOT" {
+  local root
+  root="$BATS_TEST_TMPDIR/app"
+  mkdir -p "$root/dist" "$root/scripts"
+  cp "$SHELL_SOURCE" "$root/dist/index.html"
+  cp "$RENDERER_SOURCE" "$root/scripts/render-app-config.js"
+
+  run --separate-stderr env \
+    APP_ROOT="$root" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=true \
+    sh "$ENTRYPOINT" echo started
+
+  [ "$status" -eq 0 ]
+  assert_output_contains 'started'
+  [ "$(config_block "$root/dist/index.html")" = '{"flags":{"forgotPassword":true}}' ]
+}
+
+@test "docker-entrypoint.sh fails before exec when the configuration is rejected" {
+  local artifact
+  artifact="$(copy_artifact entrypoint-reject)"
+
+  run --separate-stderr env \
+    APP_CONFIG_HTML="$artifact" \
+    APP_CONFIG_RENDERER="$RENDERER" \
+    APP_CONFIG_FLAG_FORGOT_PASSWORD=maybe \
+    sh "$ENTRYPOINT" echo started
+
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"started"* ]]
+  [[ "$stderr" == *'must be exactly "true" or "false"'* ]]
+  [ "$(config_block "$artifact")" = "" ]
+}
+
+@test "docker-entrypoint.sh fails when the HTML shell is missing" {
+  run --separate-stderr env \
+    APP_CONFIG_HTML="$BATS_TEST_TMPDIR/absent.html" \
+    APP_CONFIG_RENDERER="$RENDERER" \
+    sh "$ENTRYPOINT" echo started
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"docker-entrypoint: HTML shell not found at $BATS_TEST_TMPDIR/absent.html"* ]]
+  [[ "$output" != *"started"* ]]
+}
+
+@test "docker-entrypoint.sh fails when the renderer is missing" {
+  local artifact
+  artifact="$(copy_artifact entrypoint-no-renderer)"
+
+  run --separate-stderr env \
+    APP_CONFIG_HTML="$artifact" \
+    APP_CONFIG_RENDERER="$BATS_TEST_TMPDIR/absent-renderer.js" \
+    sh "$ENTRYPOINT" echo started
+
+  [ "$status" -ne 0 ]
+  [[ "$stderr" == *"docker-entrypoint: renderer not found at $BATS_TEST_TMPDIR/absent-renderer.js"* ]]
+  [[ "$output" != *"started"* ]]
+}

--- a/tests/builders/app-config.ts
+++ b/tests/builders/app-config.ts
@@ -1,0 +1,28 @@
+import { faker } from '@faker-js/faker';
+
+import type { AppConfigReader, AppConfigValues } from '@/config/runtime/types/app-config';
+import type { FeatureFlag } from '@/config/runtime/types/feature-flag';
+
+export function buildHttpUrl(path = ''): string {
+  return `${faker.internet.url({ appendSlash: false })}${path}`;
+}
+
+export function buildAppConfigValues(overrides: Partial<AppConfigValues> = {}): AppConfigValues {
+  return { ...overrides };
+}
+
+/**
+ * Stub of the `AppConfigReader` contract that `GraphQLUrl` injects. Defaults to "no runtime
+ * configuration supplied", which is the shape every existing build-time fallback path expects.
+ */
+export function buildAppConfigReader(values: AppConfigValues = {}): AppConfigReader {
+  return {
+    get: (): AppConfigValues => values,
+    apiBaseUrl: (): string | undefined => values.apiBaseUrl,
+    graphqlUrl: (): string | undefined => values.graphqlUrl,
+  };
+}
+
+export function buildFeatureFlagConfig(flags: Partial<Record<FeatureFlag, boolean>>): string {
+  return JSON.stringify({ flags });
+}

--- a/tests/builders/index.ts
+++ b/tests/builders/index.ts
@@ -1,4 +1,5 @@
 export * from './seed';
+export * from './app-config';
 export * from './user';
 export * from './credentials';
 export * from './auth';

--- a/tests/e2e/modules/user/features/auth/runtime-config.spec.ts
+++ b/tests/e2e/modules/user/features/auth/runtime-config.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+import { overrideRuntimeConfig } from '../../../../../utils/override-runtime-config';
+import { t } from '../../../../utils/initialize-localization';
+
+const SIGN_IN_URL = '/sign-in';
+
+const forgotPasswordLabel: string = t('sign_in.form.forgot_password');
+
+/**
+ * Acceptance criterion 1 of issue #145: the SAME production build artifact runs against two
+ * different configurations without a rebuild. Both cases below hit the identical served bundle;
+ * only the inline runtime-configuration block in the document differs, which is exactly what
+ * scripts/render-app-config.js rewrites at container start.
+ */
+test.describe('Runtime configuration and feature flags', () => {
+  test('serves the shipped default with the forgotPassword flag off', async ({ page }) => {
+    await page.goto(SIGN_IN_URL);
+
+    await expect(page.getByRole('checkbox')).toBeVisible();
+    await expect(page.getByRole('link', { name: forgotPasswordLabel })).toHaveCount(0);
+  });
+
+  test('serves the same artifact with the forgotPassword flag turned on', async ({ page }) => {
+    await overrideRuntimeConfig(page, { flags: { forgotPassword: true } });
+
+    await page.goto(SIGN_IN_URL);
+
+    const link = page.getByRole('link', { name: forgotPasswordLabel });
+    await expect(link).toHaveCount(1);
+    await expect(link).toHaveAttribute('href', '/password-recovery');
+
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('boots normally when the runtime configuration only carries endpoints', async ({ page }) => {
+    await overrideRuntimeConfig(page, { flags: {} });
+
+    await page.goto(SIGN_IN_URL);
+
+    await expect(page.getByRole('checkbox')).toBeVisible();
+    await expect(page.getByRole('link', { name: forgotPasswordLabel })).toHaveCount(0);
+
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+});

--- a/tests/e2e/modules/user/features/auth/runtime-config.spec.ts
+++ b/tests/e2e/modules/user/features/auth/runtime-config.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-import { overrideRuntimeConfig } from '../../../../../utils/override-runtime-config';
-import { t } from '../../../../utils/initialize-localization';
+import { t } from '@tests/e2e/utils/initialize-localization';
+import { overrideRuntimeConfig } from '@tests/utils/override-runtime-config';
 
 const SIGN_IN_URL = '/sign-in';
 

--- a/tests/integration/config/runtime.integration.test.ts
+++ b/tests/integration/config/runtime.integration.test.ts
@@ -135,6 +135,28 @@ describe('runtime configuration Integration', () => {
     expect(urlBuilder.build('/users')).toBe(`${apiBaseUrl}/users`);
   });
 
+  // The paint path reads endpoints before the zod layer loads, so a block that reached the
+  // document without passing through the container entrypoint must not hand a non-http(s) value
+  // to fetch — url-builder falls back to the build-time origin instead.
+  // 'not-a-url' fails to parse at all; 'javascript:alert(1)' parses but carries a scheme no HTTP
+  // client can use. Both must be treated as absent rather than handed to fetch.
+  it.each(['not-a-url', 'javascript:alert(1)'])(
+    'ignores the runtime api base url %s and keeps the build-time origin',
+    async (apiBaseUrl) => {
+      const buildTimeApi = buildHttpUrl();
+      process.env.REACT_APP_MOCKOON_URL = buildTimeApi;
+      renderRuntimeConfig(JSON.stringify({ apiBaseUrl }));
+
+      const { default: urlBuilder } = await import('@/utils/url-builder');
+
+      expect(urlBuilder.build('/users')).toBe(`${buildTimeApi}/users`);
+      // The same value is a hard failure once the validated layer loads.
+      await expect(import('@/config/dependency-injection-config')).rejects.toThrow(
+        /Invalid runtime configuration[\s\S]*apiBaseUrl/
+      );
+    }
+  );
+
   it('keeps the flag default when the rendered block omits the flag', async () => {
     renderRuntimeConfig(buildFeatureFlagConfig({}));
 

--- a/tests/integration/config/runtime.integration.test.ts
+++ b/tests/integration/config/runtime.integration.test.ts
@@ -1,0 +1,172 @@
+import '../setup';
+
+import type { DependencyContainer } from 'tsyringe';
+
+import type { AppConfig } from '@/config/runtime/app-config';
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+import type { FeatureFlagService } from '@/config/runtime/feature-flag-service';
+import type GraphQLUrl from '@/utils/get-graphql-url';
+import { buildAppConfigValues, buildFeatureFlagConfig, buildHttpUrl } from '@tests/builders';
+
+type RuntimeGraph = {
+  container: DependencyContainer;
+  tokens: { appConfig: symbol; featureFlagService: symbol; graphQlUrl: symbol };
+  singletons: { appConfig: AppConfig; featureFlagService: FeatureFlagService };
+};
+
+describe('runtime configuration Integration', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  const renderRuntimeConfig = (json: string): void => {
+    const block = document.createElement('script');
+    block.id = APP_CONFIG_ELEMENT_ID;
+    block.type = 'application/json';
+    block.textContent = json;
+    document.head.appendChild(block);
+  };
+
+  const loadRuntimeGraph = async (): Promise<RuntimeGraph> => {
+    const { default: container } = await import('@/config/dependency-injection-config');
+    const { default: RUNTIME_TOKENS } = await import('@/config/runtime/tokens');
+    const { default: AUTH_TOKENS } = await import('@/modules/user/config/tokens');
+    const { default: appConfig } = await import('@/config/runtime/app-config');
+    const { default: featureFlagService } = await import('@/config/runtime/feature-flag-service');
+
+    return {
+      container,
+      tokens: {
+        appConfig: RUNTIME_TOKENS.AppConfig,
+        featureFlagService: RUNTIME_TOKENS.FeatureFlagService,
+        graphQlUrl: AUTH_TOKENS.GraphQLUrl,
+      },
+      singletons: { appConfig, featureFlagService },
+    };
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    document.getElementById(APP_CONFIG_ELEMENT_ID)?.remove();
+  });
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV };
+    document.getElementById(APP_CONFIG_ELEMENT_ID)?.remove();
+  });
+
+  it('registers the runtime configuration singletons in the real container', async () => {
+    const { container, tokens, singletons } = await loadRuntimeGraph();
+
+    expect(container.resolve<AppConfig>(tokens.appConfig)).toBe(singletons.appConfig);
+    expect(container.resolve<AppConfig>(tokens.appConfig)).toBe(
+      container.resolve<AppConfig>(tokens.appConfig)
+    );
+    expect(container.resolve<FeatureFlagService>(tokens.featureFlagService)).toBe(
+      singletons.featureFlagService
+    );
+    expect(container.resolve<FeatureFlagService>(tokens.featureFlagService)).toBe(
+      container.resolve<FeatureFlagService>(tokens.featureFlagService)
+    );
+  });
+
+  it('exposes empty configuration and default flags when no block is rendered', async () => {
+    const { container, tokens } = await loadRuntimeGraph();
+    const { default: appConfigSource } = await import('@/config/runtime/app-config-source');
+    const { default: urlBuilder } = await import('@/utils/url-builder');
+    const appConfig = container.resolve<AppConfig>(tokens.appConfig);
+    const flags = container.resolve<FeatureFlagService>(tokens.featureFlagService);
+
+    expect(appConfigSource.load()).toEqual({});
+    expect(appConfig.get()).toEqual(buildAppConfigValues());
+    expect(appConfig.apiBaseUrl()).toBeUndefined();
+    expect(appConfig.graphqlUrl()).toBeUndefined();
+    expect(flags.names()).toEqual(['forgotPassword']);
+    expect(flags.isEnabled('forgotPassword')).toBe(false);
+    expect(flags.snapshot()).toEqual({ forgotPassword: false });
+    expect(urlBuilder.build('/users')).toBe(`${ORIGINAL_ENV.REACT_APP_MOCKOON_URL}/users`);
+  });
+
+  it('falls back to an empty configuration outside a DOM host', async () => {
+    const { default: appConfigSource } = await import('@/config/runtime/app-config-source');
+    const globals = globalThis as { document?: Document };
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'document'
+    ) as PropertyDescriptor;
+
+    delete globals.document;
+
+    try {
+      expect(appConfigSource.snapshot()).toEqual({});
+    } finally {
+      Object.defineProperty(globalThis, 'document', descriptor);
+    }
+  });
+
+  it('resolves the GraphQL url from the container using the build-time environment', async () => {
+    const buildTimeUrl = buildHttpUrl('/graphql');
+    process.env.REACT_APP_GRAPHQL_URL = buildTimeUrl;
+
+    const { container, tokens } = await loadRuntimeGraph();
+
+    expect(container.resolve<GraphQLUrl>(tokens.graphQlUrl).resolve()).toBe(buildTimeUrl);
+  });
+
+  it('lets a rendered block override the build-time urls and flag defaults', async () => {
+    const apiBaseUrl = buildHttpUrl();
+    const graphqlUrl = buildHttpUrl('/graphql');
+    process.env.REACT_APP_GRAPHQL_URL = buildHttpUrl('/build-time-graphql');
+    renderRuntimeConfig(
+      JSON.stringify(
+        buildAppConfigValues({ apiBaseUrl, graphqlUrl, flags: { forgotPassword: true } })
+      )
+    );
+
+    const { container, tokens } = await loadRuntimeGraph();
+    const { default: urlBuilder } = await import('@/utils/url-builder');
+    const appConfig = container.resolve<AppConfig>(tokens.appConfig);
+
+    expect(appConfig.get()).toEqual({ apiBaseUrl, graphqlUrl, flags: { forgotPassword: true } });
+    expect(appConfig.apiBaseUrl()).toBe(apiBaseUrl);
+    expect(container.resolve<GraphQLUrl>(tokens.graphQlUrl).resolve()).toBe(graphqlUrl);
+    expect(container.resolve<FeatureFlagService>(tokens.featureFlagService).snapshot()).toEqual({
+      forgotPassword: true,
+    });
+    expect(urlBuilder.build('/users')).toBe(`${apiBaseUrl}/users`);
+  });
+
+  it('keeps the flag default when the rendered block omits the flag', async () => {
+    renderRuntimeConfig(buildFeatureFlagConfig({}));
+
+    const { container, tokens } = await loadRuntimeGraph();
+
+    expect(container.resolve<AppConfig>(tokens.appConfig).get()).toEqual({ flags: {} });
+    expect(
+      container.resolve<FeatureFlagService>(tokens.featureFlagService).isEnabled('forgotPassword')
+    ).toBe(false);
+  });
+
+  it('fails fast when the rendered block violates the schema', async () => {
+    renderRuntimeConfig(JSON.stringify({ graphqlUrl: 'not-a-url' }));
+
+    await expect(import('@/config/dependency-injection-config')).rejects.toThrow(
+      /Invalid runtime configuration/
+    );
+  });
+
+  it('fails fast when the rendered block is not valid JSON', async () => {
+    renderRuntimeConfig('{ "flags": ');
+
+    await expect(import('@/config/dependency-injection-config')).rejects.toThrow(
+      /does not contain valid JSON/
+    );
+  });
+
+  it('fails fast when the rendered block is not a JSON object', async () => {
+    renderRuntimeConfig(JSON.stringify([{ apiBaseUrl: buildHttpUrl() }]));
+
+    await expect(import('@/config/dependency-injection-config')).rejects.toThrow(
+      /must contain a JSON object/
+    );
+  });
+});

--- a/tests/integration/mocks/server.ts
+++ b/tests/integration/mocks/server.ts
@@ -3,9 +3,16 @@ import { setupServer } from 'msw/node';
 
 import API_ENDPOINTS from '@/config/api-config';
 import GraphQLUrl from '@/utils/get-graphql-url';
-import { buildClientMutationId, buildGraphqlUser, buildLoginResponse } from '@tests/builders';
+import {
+  buildAppConfigReader,
+  buildClientMutationId,
+  buildGraphqlUser,
+  buildLoginResponse,
+} from '@tests/builders';
 
-export const GRAPHQL_URL = new GraphQLUrl().resolve();
+// No runtime configuration is rendered into the jsdom document, so the URL resolves from the
+// build-time environment exactly as it did before issue #145.
+export const GRAPHQL_URL = new GraphQLUrl(buildAppConfigReader()).resolve();
 
 export const defaultLoginResponse = buildLoginResponse();
 export const defaultGraphqlUser = buildGraphqlUser();

--- a/tests/integration/utils/get-graphql-url.integration.test.ts
+++ b/tests/integration/utils/get-graphql-url.integration.test.ts
@@ -1,3 +1,5 @@
+import { buildAppConfigReader, buildHttpUrl } from '@tests/builders';
+
 import '../setup';
 
 describe('getGraphQLUrl Integration', () => {
@@ -12,9 +14,9 @@ describe('getGraphQLUrl Integration', () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
-  const resolveUrl = async (): Promise<string> => {
+  const resolveUrl = async (graphqlUrl?: string): Promise<string> => {
     const { default: GraphQLUrl } = await import('@/utils/get-graphql-url');
-    return new GraphQLUrl().resolve();
+    return new GraphQLUrl(buildAppConfigReader({ graphqlUrl })).resolve();
   };
 
   it('returns the default localhost url when the env var is not set', async () => {
@@ -36,7 +38,7 @@ describe('getGraphQLUrl Integration', () => {
     process.env.NODE_ENV = 'production';
 
     await expect(resolveUrl()).rejects.toThrow(
-      /REACT_APP_GRAPHQL_URL must be defined in production/
+      /A GraphQL URL must be defined in production environment/
     );
   });
 
@@ -45,7 +47,15 @@ describe('getGraphQLUrl Integration', () => {
     process.env.NODE_ENV = 'production';
 
     await expect(resolveUrl()).rejects.toThrow(
-      /REACT_APP_GRAPHQL_URL must be defined in production/
+      /A GraphQL URL must be defined in production environment/
     );
+  });
+
+  it('prefers the runtime configuration url over the build-time one', async () => {
+    const runtimeUrl = buildHttpUrl('/graphql');
+    process.env.REACT_APP_GRAPHQL_URL = 'http://build-time.example.com/graphql';
+    process.env.NODE_ENV = 'production';
+
+    await expect(resolveUrl(runtimeUrl)).resolves.toBe(runtimeUrl);
   });
 });

--- a/tests/unit/config/runtime/app-config-defaults.test.ts
+++ b/tests/unit/config/runtime/app-config-defaults.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import AppConfigSchema from '@/config/runtime/app-config-schema';
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+import featureFlagService from '@/config/runtime/feature-flag-service';
+
+const BLOCK_PATTERN = new RegExp(
+  `<script id="${APP_CONFIG_ELEMENT_ID}" type="application/json">([\\s\\S]*?)</script>`
+);
+
+function readCommittedConfigBlock(): string {
+  const html = readFileSync(join(process.cwd(), 'public', 'index.html'), 'utf8');
+  const match = BLOCK_PATTERN.exec(html);
+
+  if (!match) {
+    throw new Error(`public/index.html is missing the #${APP_CONFIG_ELEMENT_ID} block.`);
+  }
+
+  return match[1];
+}
+
+describe('committed runtime configuration defaults (public/index.html)', () => {
+  const block = readCommittedConfigBlock();
+  const parsed: unknown = JSON.parse(block);
+
+  it('ships a JSON object that satisfies the runtime configuration schema', () => {
+    const result = AppConfigSchema.safeParse(parsed);
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('declares exactly the flags the feature-flag service knows about', () => {
+    const values = AppConfigSchema.parse(parsed);
+
+    expect(Object.keys(values.flags ?? {})).toEqual(featureFlagService.names());
+  });
+});

--- a/tests/unit/config/runtime/app-config-defaults.test.ts
+++ b/tests/unit/config/runtime/app-config-defaults.test.ts
@@ -34,6 +34,8 @@ describe('committed runtime configuration defaults (public/index.html)', () => {
   it('declares exactly the flags the feature-flag service knows about', () => {
     const values = AppConfigSchema.parse(parsed);
 
-    expect(Object.keys(values.flags ?? {})).toEqual(featureFlagService.names());
+    // Sorted on both sides: the contract is set equality, so declaring the same flags in a
+    // different order than FEATURE_FLAG_DEFAULTS is valid and must not fail here.
+    expect(Object.keys(values.flags ?? {}).sort()).toEqual([...featureFlagService.names()].sort());
   });
 });

--- a/tests/unit/config/runtime/app-config-source.test.ts
+++ b/tests/unit/config/runtime/app-config-source.test.ts
@@ -1,0 +1,188 @@
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+import { buildAppConfigValues, buildHttpUrl } from '@tests/builders';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
+
+type AppConfigSourceModule = typeof import('@/config/runtime/app-config-source');
+type AppConfigSourceSingleton = AppConfigSourceModule['default'];
+
+// The element id and both failure messages are a fixed contract shared with the HTML shell
+// (public/index.html) and the container entrypoint (scripts/render-app-config.js), so they are
+// spelled out here rather than rebuilt from the source's own template.
+const INVALID_JSON_PREFIX =
+  'The #app-runtime-config runtime configuration block does not contain valid JSON:';
+const NOT_AN_OBJECT_MESSAGE =
+  'The #app-runtime-config runtime configuration block must contain a JSON object.';
+
+async function loadSource(): Promise<AppConfigSourceSingleton> {
+  jest.resetModules();
+  const runtimeModule = await import('@/config/runtime/app-config-source');
+
+  return runtimeModule.default;
+}
+
+describe('appConfigSource', () => {
+  beforeEach(() => {
+    clearConfigBlock();
+  });
+
+  afterAll(() => {
+    clearConfigBlock();
+  });
+
+  it('publishes the element id the HTML shell and the renderer agree on', () => {
+    expect(APP_CONFIG_ELEMENT_ID).toBe('app-runtime-config');
+  });
+
+  describe('snapshot', () => {
+    it('is empty when the configuration block is absent from the document', async () => {
+      const source = await loadSource();
+
+      expect(source.snapshot()).toEqual({});
+    });
+
+    it('parses the JSON object carried by the configuration block', async () => {
+      const values = buildAppConfigValues({
+        apiBaseUrl: buildHttpUrl('/api'),
+        graphqlUrl: buildHttpUrl('/graphql'),
+      });
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.snapshot()).toEqual(values);
+    });
+
+    it('is empty when the configuration block holds only whitespace', async () => {
+      writeConfigBlock('   \n\t  ');
+
+      const source = await loadSource();
+
+      expect(source.snapshot()).toEqual({});
+    });
+
+    it('throws a named error when the configuration block is not valid JSON', async () => {
+      writeConfigBlock('{ "flags": ');
+
+      const source = await loadSource();
+
+      expect(() => source.snapshot()).toThrow(INVALID_JSON_PREFIX);
+    });
+
+    it.each([
+      ['an array', '[1, 2, 3]'],
+      ['a string', '"forgotPassword"'],
+      ['a number', '42'],
+      ['null', 'null'],
+    ])('throws when the configuration block contains %s', async (_label, json) => {
+      writeConfigBlock(json);
+
+      const source = await loadSource();
+
+      expect(() => source.snapshot()).toThrow(NOT_AN_OBJECT_MESSAGE);
+    });
+
+    it('parses again only when the configuration text changes', async () => {
+      const first = buildAppConfigValues({ apiBaseUrl: buildHttpUrl('/first') });
+      const second = buildAppConfigValues({ apiBaseUrl: buildHttpUrl('/second') });
+      const element = writeConfigBlock(JSON.stringify(first));
+
+      const source = await loadSource();
+      const parseSpy = jest.spyOn(JSON, 'parse');
+
+      try {
+        expect(source.snapshot()).toEqual(first);
+        expect(source.snapshot()).toEqual(first);
+        expect(source.snapshot()).toBe(source.snapshot());
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+
+        element.textContent = JSON.stringify(second);
+
+        expect(source.snapshot()).toEqual(second);
+        expect(parseSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        parseSpy.mockRestore();
+      }
+    });
+
+    it('reads nothing when there is no document to read from', async () => {
+      const values = buildAppConfigValues({ apiBaseUrl: buildHttpUrl('/api') });
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.snapshot()).toEqual(values);
+
+      const documentSpy = jest.spyOn(globalThis, 'document', 'get');
+      documentSpy.mockImplementation((): Document => undefined as unknown as Document);
+
+      let snapshot: Record<string, unknown> = { unread: true };
+
+      try {
+        snapshot = source.snapshot();
+      } finally {
+        documentSpy.mockRestore();
+      }
+
+      expect(snapshot).toEqual({});
+    });
+  });
+
+  describe('load', () => {
+    it('returns the same snapshot instance', async () => {
+      const values = buildAppConfigValues({ graphqlUrl: buildHttpUrl('/graphql') });
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.load()).toEqual(values);
+      expect(source.load()).toBe(source.snapshot());
+    });
+  });
+
+  describe('text', () => {
+    it('returns the trimmed string value of a key', async () => {
+      const apiBaseUrl = buildHttpUrl('/api');
+      writeConfigBlock(JSON.stringify({ apiBaseUrl: `  ${apiBaseUrl}  ` }));
+
+      const source = await loadSource();
+
+      expect(source.text('apiBaseUrl')).toBe(apiBaseUrl);
+    });
+
+    it.each([
+      ['is missing', {}],
+      ['is not a string', { apiBaseUrl: 42 }],
+      ['is an empty string', { apiBaseUrl: '' }],
+      ['is whitespace only', { apiBaseUrl: '   ' }],
+    ])('is undefined when the value %s', async (_label, values) => {
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.text('apiBaseUrl')).toBeUndefined();
+    });
+  });
+
+  describe('flags', () => {
+    it('returns the flags object when the configuration declares one', async () => {
+      writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));
+
+      const source = await loadSource();
+
+      expect(source.flags()).toEqual({ forgotPassword: true });
+    });
+
+    it.each([
+      ['absent', {}],
+      ['an array', { flags: [] }],
+      ['a string', { flags: 'forgotPassword' }],
+      ['null', { flags: null }],
+    ])('is empty when flags is %s', async (_label, values) => {
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.flags()).toEqual({});
+    });
+  });
+});

--- a/tests/unit/config/runtime/app-config-source.test.ts
+++ b/tests/unit/config/runtime/app-config-source.test.ts
@@ -163,6 +163,39 @@ describe('appConfigSource', () => {
     });
   });
 
+  // The paint path reads endpoints before the zod layer exists, so this accessor carries the same
+  // http(s)-only contract as `z.httpUrl()` in app-config-schema.ts and `assertHttpUrl` in the
+  // container entrypoint. Anything else is reported as absent so the caller falls back.
+  describe('url', () => {
+    it.each(['http://api.example', 'https://api.example/v1'])(
+      'returns the absolute http(s) URL %s',
+      async (apiBaseUrl) => {
+        writeConfigBlock(JSON.stringify({ apiBaseUrl: `  ${apiBaseUrl}  ` }));
+
+        const source = await loadSource();
+
+        expect(source.url('apiBaseUrl')).toBe(apiBaseUrl);
+      }
+    );
+
+    it.each([
+      ['is missing', {}],
+      ['is not a string', { apiBaseUrl: 42 }],
+      ['is whitespace only', { apiBaseUrl: '   ' }],
+      ['is not a URL at all', { apiBaseUrl: 'not-a-url' }],
+      ['is a relative path', { apiBaseUrl: '/api' }],
+      ['uses the mailto scheme', { apiBaseUrl: 'mailto:someone@example.com' }],
+      ['uses the ftp scheme', { apiBaseUrl: 'ftp://files.example/api' }],
+      ['uses the javascript scheme', { apiBaseUrl: 'javascript:alert(1)' }],
+    ])('is undefined when the value %s', async (_label, values) => {
+      writeConfigBlock(JSON.stringify(values));
+
+      const source = await loadSource();
+
+      expect(source.url('apiBaseUrl')).toBeUndefined();
+    });
+  });
+
   describe('flags', () => {
     it('returns the flags object when the configuration declares one', async () => {
       writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));

--- a/tests/unit/config/runtime/app-config-source.test.ts
+++ b/tests/unit/config/runtime/app-config-source.test.ts
@@ -164,19 +164,24 @@ describe('appConfigSource', () => {
   });
 
   // The paint path reads endpoints before the zod layer exists, so this accessor carries the same
-  // http(s)-only contract as `z.httpUrl()` in app-config-schema.ts and `assertHttpUrl` in the
+  // http(s)-only contract as the schema in app-config-schema.ts and `assertHttpUrl` in the
   // container entrypoint. Anything else is reported as absent so the caller falls back.
   describe('url', () => {
-    it.each(['http://api.example', 'https://api.example/v1'])(
-      'returns the absolute http(s) URL %s',
-      async (apiBaseUrl) => {
-        writeConfigBlock(JSON.stringify({ apiBaseUrl: `  ${apiBaseUrl}  ` }));
+    it.each([
+      'http://api.example',
+      'https://api.example/v1',
+      // Single-label and numeric hosts: the compose service names and localhost defaults this
+      // repo deploys with must stay acceptable at every layer.
+      'http://localhost:4000',
+      'http://prod:3001',
+      'http://127.0.0.1:8080',
+    ])('returns the absolute http(s) URL %s', async (apiBaseUrl) => {
+      writeConfigBlock(JSON.stringify({ apiBaseUrl: `  ${apiBaseUrl}  ` }));
 
-        const source = await loadSource();
+      const source = await loadSource();
 
-        expect(source.url('apiBaseUrl')).toBe(apiBaseUrl);
-      }
-    );
+      expect(source.url('apiBaseUrl')).toBe(apiBaseUrl);
+    });
 
     it.each([
       ['is missing', {}],

--- a/tests/unit/config/runtime/app-config.test.ts
+++ b/tests/unit/config/runtime/app-config.test.ts
@@ -44,11 +44,35 @@ describe('appConfig', () => {
     expect(Object.isFrozen(appConfig.get())).toBe(true);
   });
 
+  it('freezes the nested flags object, not just the top level', async () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));
+
+    const { default: appConfig } = await loadAppConfig();
+    const flags = appConfig.get().flags;
+
+    expect(Object.isFrozen(flags)).toBe(true);
+    expect(() => {
+      (flags as { forgotPassword: boolean }).forgotPassword = false;
+    }).toThrow(TypeError);
+    expect(appConfig.get().flags?.forgotPassword).toBe(true);
+  });
+
   it('fails fast and names the field when a URL is malformed', async () => {
     writeConfigBlock(JSON.stringify({ apiBaseUrl: 'not-a-url' }));
 
     await expect(loadAppConfig()).rejects.toThrow(/Invalid runtime configuration[\s\S]*apiBaseUrl/);
   });
+
+  it.each(['mailto:someone@example.com', 'ftp://files.example/api', 'javascript:alert(1)'])(
+    'rejects the non-http(s) URL %s, matching what the container entrypoint enforces',
+    async (apiBaseUrl) => {
+      writeConfigBlock(JSON.stringify({ apiBaseUrl }));
+
+      await expect(loadAppConfig()).rejects.toThrow(
+        /Invalid runtime configuration[\s\S]*apiBaseUrl/
+      );
+    }
+  );
 
   it('fails fast and names the key when the configuration carries an unknown setting', async () => {
     writeConfigBlock(JSON.stringify({ mainLanguage: 'uk' }));

--- a/tests/unit/config/runtime/app-config.test.ts
+++ b/tests/unit/config/runtime/app-config.test.ts
@@ -1,0 +1,84 @@
+import { buildAppConfigValues, buildHttpUrl } from '@tests/builders';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
+
+type AppConfigModule = typeof import('@/config/runtime/app-config');
+
+function loadAppConfig(): Promise<AppConfigModule> {
+  jest.resetModules();
+
+  return import('@/config/runtime/app-config');
+}
+
+describe('appConfig', () => {
+  beforeEach(() => {
+    clearConfigBlock();
+  });
+
+  afterAll(() => {
+    clearConfigBlock();
+  });
+
+  it('exposes and freezes a valid runtime configuration', async () => {
+    const values = buildAppConfigValues({
+      apiBaseUrl: buildHttpUrl('/api'),
+      graphqlUrl: buildHttpUrl('/graphql'),
+      flags: { forgotPassword: true },
+    });
+    writeConfigBlock(JSON.stringify(values));
+
+    const { default: appConfig, AppConfig } = await loadAppConfig();
+
+    expect(appConfig).toBeInstanceOf(AppConfig);
+    expect(appConfig.get()).toEqual(values);
+    expect(appConfig.apiBaseUrl()).toBe(values.apiBaseUrl);
+    expect(appConfig.graphqlUrl()).toBe(values.graphqlUrl);
+    expect(Object.isFrozen(appConfig.get())).toBe(true);
+  });
+
+  it('reads an empty configuration when the block is absent', async () => {
+    const { default: appConfig } = await loadAppConfig();
+
+    expect(appConfig.get()).toEqual({});
+    expect(appConfig.apiBaseUrl()).toBeUndefined();
+    expect(appConfig.graphqlUrl()).toBeUndefined();
+    expect(Object.isFrozen(appConfig.get())).toBe(true);
+  });
+
+  it('fails fast and names the field when a URL is malformed', async () => {
+    writeConfigBlock(JSON.stringify({ apiBaseUrl: 'not-a-url' }));
+
+    await expect(loadAppConfig()).rejects.toThrow(/Invalid runtime configuration[\s\S]*apiBaseUrl/);
+  });
+
+  it('fails fast and names the key when the configuration carries an unknown setting', async () => {
+    writeConfigBlock(JSON.stringify({ mainLanguage: 'uk' }));
+
+    await expect(loadAppConfig()).rejects.toThrow(
+      /Invalid runtime configuration[\s\S]*mainLanguage/
+    );
+  });
+
+  it('fails fast and names the flag when a flag value is not a boolean', async () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: 'yes' } }));
+
+    await expect(loadAppConfig()).rejects.toThrow(
+      /Invalid runtime configuration[\s\S]*forgotPassword/
+    );
+  });
+
+  it('aggregates every offending field into a single error', async () => {
+    writeConfigBlock(
+      JSON.stringify({ apiBaseUrl: 'not-a-url', graphqlUrl: 'also-not-a-url', unknownKey: 1 })
+    );
+
+    const error = await loadAppConfig().then(
+      () => null,
+      (thrown: unknown) => thrown as Error
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toMatch(/apiBaseUrl/);
+    expect(error?.message).toMatch(/graphqlUrl/);
+    expect(error?.message).toMatch(/unknownKey/);
+  });
+});

--- a/tests/unit/config/runtime/feature-flag-service.test.ts
+++ b/tests/unit/config/runtime/feature-flag-service.test.ts
@@ -1,0 +1,64 @@
+import { buildFeatureFlagConfig } from '@tests/builders';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
+
+type FeatureFlagModule = typeof import('@/config/runtime/feature-flag-service');
+
+function loadFeatureFlagService(): Promise<FeatureFlagModule> {
+  jest.resetModules();
+
+  return import('@/config/runtime/feature-flag-service');
+}
+
+describe('featureFlagService', () => {
+  beforeEach(() => {
+    clearConfigBlock();
+  });
+
+  afterAll(() => {
+    clearConfigBlock();
+  });
+
+  it('falls back to the compiled-in default when no runtime configuration is present', async () => {
+    const { default: featureFlagService, FeatureFlagService } = await loadFeatureFlagService();
+
+    expect(featureFlagService).toBeInstanceOf(FeatureFlagService);
+    expect(featureFlagService.isEnabled('forgotPassword')).toBe(false);
+    expect(featureFlagService.snapshot()).toEqual({ forgotPassword: false });
+  });
+
+  it('enables a flag the runtime configuration turns on', async () => {
+    writeConfigBlock(buildFeatureFlagConfig({ forgotPassword: true }));
+
+    const { default: featureFlagService } = await loadFeatureFlagService();
+
+    expect(featureFlagService.isEnabled('forgotPassword')).toBe(true);
+    expect(featureFlagService.snapshot()).toEqual({ forgotPassword: true });
+  });
+
+  it('disables a flag the runtime configuration turns off', async () => {
+    writeConfigBlock(buildFeatureFlagConfig({ forgotPassword: false }));
+
+    const { default: featureFlagService } = await loadFeatureFlagService();
+
+    expect(featureFlagService.isEnabled('forgotPassword')).toBe(false);
+    expect(featureFlagService.snapshot()).toEqual({ forgotPassword: false });
+  });
+
+  it.each([
+    ['the string "true"', 'true'],
+    ['the number 1', 1],
+    ['null', null],
+  ])('ignores %s and keeps the default, because it is not a boolean', async (_label, value) => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: value } }));
+
+    const { default: featureFlagService } = await loadFeatureFlagService();
+
+    expect(featureFlagService.isEnabled('forgotPassword')).toBe(false);
+  });
+
+  it('names every flag it knows about', async () => {
+    const { default: featureFlagService } = await loadFeatureFlagService();
+
+    expect(featureFlagService.names()).toEqual(['forgotPassword']);
+  });
+});

--- a/tests/unit/config/runtime/runtime-di.test.ts
+++ b/tests/unit/config/runtime/runtime-di.test.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+
+import { container } from 'tsyringe';
+
+// `container.clearInstances()` deletes value providers outright, and the runtime configuration
+// bindings are registered with `useValue` (they are container-free module singletons), so this
+// suite deliberately keeps the registrations that `dependency-injection-config` applied.
+describe('DI container — runtime configuration tokens', () => {
+  it('resolves RUNTIME_TOKENS.AppConfig to the app-config module singleton', async () => {
+    const [RUNTIME_TOKENS, appConfig] = await Promise.all([
+      import('@/config/runtime/tokens').then((m) => m.default),
+      import('@/config/runtime/app-config').then((m) => m.default),
+    ]);
+
+    await import('@/config/dependency-injection-config');
+
+    const resolved = container.resolve(RUNTIME_TOKENS.AppConfig);
+
+    expect(resolved).toBe(appConfig);
+    expect(container.resolve(RUNTIME_TOKENS.AppConfig)).toBe(resolved);
+  });
+
+  it('resolves RUNTIME_TOKENS.FeatureFlagService to the module singleton', async () => {
+    const [RUNTIME_TOKENS, featureFlagService] = await Promise.all([
+      import('@/config/runtime/tokens').then((m) => m.default),
+      import('@/config/runtime/feature-flag-service').then((m) => m.default),
+    ]);
+
+    await import('@/config/dependency-injection-config');
+
+    const resolved = container.resolve(RUNTIME_TOKENS.FeatureFlagService);
+
+    expect(resolved).toBe(featureFlagService);
+    expect(container.resolve(RUNTIME_TOKENS.FeatureFlagService)).toBe(resolved);
+  });
+
+  it('declares a distinct frozen symbol per runtime binding', async () => {
+    const RUNTIME_TOKENS = await import('@/config/runtime/tokens').then((m) => m.default);
+
+    expect(typeof RUNTIME_TOKENS.AppConfig).toBe('symbol');
+    expect(typeof RUNTIME_TOKENS.FeatureFlagService).toBe('symbol');
+    expect(RUNTIME_TOKENS.AppConfig).not.toBe(RUNTIME_TOKENS.FeatureFlagService);
+    expect(Object.isFrozen(RUNTIME_TOKENS)).toBe(true);
+  });
+});

--- a/tests/unit/hooks/use-feature-flag.test.ts
+++ b/tests/unit/hooks/use-feature-flag.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react';
+
+import useFeatureFlag from '@/hooks/use-feature-flag';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
+
+
+describe('useFeatureFlag', () => {
+  afterEach(() => {
+    clearConfigBlock();
+  });
+
+  it('reports a flag as disabled when no runtime configuration is rendered', () => {
+    const { result } = renderHook(() => useFeatureFlag('forgotPassword'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('reports a flag as enabled when the runtime configuration turns it on', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));
+
+    const { result } = renderHook(() => useFeatureFlag('forgotPassword'));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('reports a flag as disabled when the runtime configuration turns it off', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: false } }));
+
+    const { result } = renderHook(() => useFeatureFlag('forgotPassword'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to the declared default when the configured value is not a boolean', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: 'true' } }));
+
+    const { result } = renderHook(() => useFeatureFlag('forgotPassword'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('keeps the value stable across re-renders without re-subscribing', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));
+
+    const { result, rerender } = renderHook(() => useFeatureFlag('forgotPassword'));
+
+    expect(result.current).toBe(true);
+
+    rerender();
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/tests/unit/hooks/use-feature-flag.test.ts
+++ b/tests/unit/hooks/use-feature-flag.test.ts
@@ -3,7 +3,6 @@ import { renderHook } from '@testing-library/react';
 import useFeatureFlag from '@/hooks/use-feature-flag';
 import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
 
-
 describe('useFeatureFlag', () => {
   afterEach(() => {
     clearConfigBlock();

--- a/tests/unit/modules/user/features/auth/components/form-section/components/user-options.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section/components/user-options.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import UserOptions from '@auth/components/form-section/components/user-options';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
 
 jest.mock('react-i18next', () => ({
   useTranslation: (): { t: (key: string) => string } => ({
@@ -8,17 +9,39 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+const FORGOT_PASSWORD_LABEL = 'sign_in.form.forgot_password';
+
 describe('UserOptions', () => {
-  it('does not render a forgot-password control until a recovery flow exists', () => {
+  afterEach(() => {
+    clearConfigBlock();
+  });
+
+  it('does not render a forgot-password control while the flag is off by default', () => {
     render(<UserOptions />);
 
     expect(screen.getByText('sign_in.form.remember_me')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'sign_in.form.forgot_password' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'sign_in.form.forgot_password' })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: FORGOT_PASSWORD_LABEL })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: FORGOT_PASSWORD_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('keeps the forgot-password control hidden when the runtime flag is explicitly off', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: false } }));
+
+    render(<UserOptions />);
+
+    expect(screen.queryByRole('link', { name: FORGOT_PASSWORD_LABEL })).not.toBeInTheDocument();
+  });
+
+  it('renders the forgot-password link when the runtime flag is on', () => {
+    writeConfigBlock(JSON.stringify({ flags: { forgotPassword: true } }));
+
+    render(<UserOptions />);
+
+    const link = screen.getByRole('link', { name: FORGOT_PASSWORD_LABEL });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/password-recovery');
+    expect(screen.getByText('sign_in.form.remember_me')).toBeInTheDocument();
   });
 
   it('toggles the remember-me checkbox state on click', () => {

--- a/tests/unit/scripts/render-app-config.test.js
+++ b/tests/unit/scripts/render-app-config.test.js
@@ -1,0 +1,316 @@
+const fs = require('fs');
+const path = require('path');
+
+const { buildHttpUrl } = require('@tests/builders');
+
+const {
+  CONFIG_ELEMENT_ID,
+  FLAG_ENV_PREFIX,
+  renderAppConfig,
+  toCamelCase,
+} = require('../../../scripts/render-app-config');
+
+const projectRoot = path.resolve(__dirname, '../../..');
+
+const API_BASE_URL_VAR = 'APP_CONFIG_API_BASE_URL';
+const GRAPHQL_URL_VAR = 'APP_CONFIG_GRAPHQL_URL';
+const FORGOT_PASSWORD_VAR = `${FLAG_ENV_PREFIX}FORGOT_PASSWORD`;
+const UNKNOWN_FLAG_VAR = `${FLAG_ENV_PREFIX}DARK_MODE`;
+
+const blockPattern = () =>
+  new RegExp(`(<script[^>]*\\bid="${CONFIG_ELEMENT_ID}"[^>]*>)([\\s\\S]*?)(</script>)`);
+
+const shell = (body, openTag = `<script id="${CONFIG_ELEMENT_ID}" type="application/json">`) =>
+  [
+    '<!doctype html>',
+    '<html lang="en">',
+    '  <head>',
+    '    <title>VilnaCRM</title>',
+    `    ${openTag}`,
+    `      ${body}`,
+    '    </script>',
+    '  </head>',
+    '  <body><div id="root"></div></body>',
+    '</html>',
+  ].join('\n');
+
+const defaultShell = () => shell('{ "flags": { "forgotPassword": false } }');
+
+const readBlockBody = (html) => {
+  const match = blockPattern().exec(html);
+
+  if (!match) {
+    throw new Error('the rendered HTML no longer contains a runtime configuration block');
+  }
+
+  return match[2];
+};
+
+const readBlockConfig = (html) => JSON.parse(readBlockBody(html));
+
+const stripBlockBody = (html) =>
+  html.replace(blockPattern(), (_full, open, _body, close) => `${open}${close}`);
+
+describe('scripts/render-app-config.js', () => {
+  describe('renderAppConfig — block rewriting', () => {
+    it('replaces the committed block with compact JSON', () => {
+      const rendered = renderAppConfig(defaultShell(), {});
+
+      expect(readBlockBody(rendered)).toBe('{"flags":{"forgotPassword":false}}');
+    });
+
+    it('leaves every byte outside the block untouched', () => {
+      const html = defaultShell();
+      const rendered = renderAppConfig(html, { [GRAPHQL_URL_VAR]: buildHttpUrl('/graphql') });
+
+      expect(stripBlockBody(rendered)).toBe(stripBlockBody(html));
+    });
+
+    it('matches the block regardless of attribute order', () => {
+      const html = shell(
+        '{ "flags": { "forgotPassword": false } }',
+        `<script type="application/json" id="${CONFIG_ELEMENT_ID}">`
+      );
+
+      const rendered = renderAppConfig(html, { [FORGOT_PASSWORD_VAR]: 'true' });
+
+      expect(readBlockConfig(rendered)).toEqual({ flags: { forgotPassword: true } });
+    });
+
+    it('throws when the HTML shell has no runtime configuration block', () => {
+      expect(() => renderAppConfig('<!doctype html><html><head></head></html>', {})).toThrow(
+        /no <script id="app-runtime-config"> block found/
+      );
+    });
+  });
+
+  describe('renderAppConfig — existing block contents', () => {
+    it('throws when the block does not contain valid JSON', () => {
+      expect(() => renderAppConfig(shell('{ not json }'), {})).toThrow(
+        /does not contain valid JSON/
+      );
+    });
+
+    it.each([
+      ['an array', '[]'],
+      ['null', 'null'],
+      ['a number', '42'],
+      ['a string', '"nope"'],
+    ])('throws when the block contains %s instead of a JSON object', (_label, body) => {
+      expect(() => renderAppConfig(shell(body), {})).toThrow(/must contain a JSON object/);
+    });
+
+    it('normalises a block with no flags key to an empty flags object', () => {
+      const rendered = renderAppConfig(shell('{}'), {});
+
+      expect(readBlockBody(rendered)).toBe('{"flags":{}}');
+    });
+
+    it('normalises a non-object flags value to an empty flags object', () => {
+      const rendered = renderAppConfig(shell('{ "flags": "nope" }'), {});
+
+      expect(readBlockBody(rendered)).toBe('{"flags":{}}');
+    });
+  });
+
+  describe('renderAppConfig — URL settings', () => {
+    it('applies both URL settings', () => {
+      const apiBaseUrl = buildHttpUrl('/api');
+      const graphqlUrl = buildHttpUrl('/graphql');
+
+      const rendered = renderAppConfig(defaultShell(), {
+        [API_BASE_URL_VAR]: apiBaseUrl,
+        [GRAPHQL_URL_VAR]: graphqlUrl,
+      });
+
+      expect(readBlockConfig(rendered)).toEqual({
+        flags: { forgotPassword: false },
+        apiBaseUrl,
+        graphqlUrl,
+      });
+    });
+
+    it('trims surrounding whitespace from a URL setting', () => {
+      const graphqlUrl = buildHttpUrl('/graphql');
+
+      const rendered = renderAppConfig(defaultShell(), {
+        [GRAPHQL_URL_VAR]: `  ${graphqlUrl}\n`,
+      });
+
+      expect(readBlockConfig(rendered).graphqlUrl).toBe(graphqlUrl);
+    });
+
+    it('ignores URL settings that are unset', () => {
+      const rendered = renderAppConfig(defaultShell(), {});
+
+      expect(readBlockConfig(rendered)).not.toHaveProperty('apiBaseUrl');
+      expect(readBlockConfig(rendered)).not.toHaveProperty('graphqlUrl');
+    });
+
+    it('ignores a whitespace-only URL setting', () => {
+      const rendered = renderAppConfig(defaultShell(), { [API_BASE_URL_VAR]: '   \t ' });
+
+      expect(readBlockConfig(rendered)).not.toHaveProperty('apiBaseUrl');
+    });
+
+    it.each([
+      ['a bare host', 'example.com/graphql'],
+      ['a relative path', '/graphql'],
+      ['empty-looking punctuation', '://'],
+    ])('rejects %s as a URL setting', (_label, value) => {
+      expect(() => renderAppConfig(defaultShell(), { [GRAPHQL_URL_VAR]: value })).toThrow(
+        /must be an absolute URL/
+      );
+    });
+
+    it.each([
+      ['ftp', 'ftp://files.example.com/graphql'],
+      ['javascript', 'javascript:alert(1)'],
+      ['file', 'file:///etc/passwd'],
+    ])('rejects the %s scheme as a URL setting', (_label, value) => {
+      expect(() => renderAppConfig(defaultShell(), { [API_BASE_URL_VAR]: value })).toThrow(
+        /must use http or https/
+      );
+    });
+
+    it('names the offending variable in a URL rejection', () => {
+      expect(() => renderAppConfig(defaultShell(), { [GRAPHQL_URL_VAR]: 'nope' })).toThrow(
+        new RegExp(`^${GRAPHQL_URL_VAR} must be an absolute URL, got "nope"\\.$`)
+      );
+    });
+  });
+
+  describe('renderAppConfig — feature flags', () => {
+    it.each([
+      ['true', true],
+      ['false', false],
+    ])('applies the flag value %s', (raw, expected) => {
+      const rendered = renderAppConfig(defaultShell(), { [FORGOT_PASSWORD_VAR]: raw });
+
+      expect(readBlockConfig(rendered).flags.forgotPassword).toBe(expected);
+    });
+
+    it.each([['TRUE'], ['1'], ['yes'], ['on'], ['False ']])('rejects %p as a flag value', (raw) => {
+      expect(() => renderAppConfig(defaultShell(), { [FORGOT_PASSWORD_VAR]: raw })).toThrow(
+        /must be exactly "true" or "false"/
+      );
+    });
+
+    it('keeps the committed default when a flag variable is empty', () => {
+      const rendered = renderAppConfig(defaultShell(), { [FORGOT_PASSWORD_VAR]: '   ' });
+
+      expect(readBlockConfig(rendered).flags.forgotPassword).toBe(false);
+    });
+
+    it('rejects a flag variable naming a flag the committed block does not declare', () => {
+      expect(() => renderAppConfig(defaultShell(), { [UNKNOWN_FLAG_VAR]: 'true' })).toThrow(
+        /names unknown feature flag "darkMode"/
+      );
+    });
+
+    it('lists the known flags when rejecting an unknown flag', () => {
+      const html = shell('{ "flags": { "forgotPassword": false, "auditLog": true } }');
+
+      expect(() => renderAppConfig(html, { [UNKNOWN_FLAG_VAR]: 'true' })).toThrow(
+        /Known flags: auditLog, forgotPassword\./
+      );
+    });
+
+    it('reports "(none)" when the committed block declares no flags at all', () => {
+      expect(() => renderAppConfig(shell('{}'), { [UNKNOWN_FLAG_VAR]: 'false' })).toThrow(
+        /Known flags: \(none\)\./
+      );
+    });
+
+    it('ignores environment variables outside the flag prefix', () => {
+      const rendered = renderAppConfig(defaultShell(), {
+        PATH: '/usr/bin',
+        NODE_ENV: 'production',
+        APP_CONFIG_NOT_A_FLAG: 'true',
+      });
+
+      expect(readBlockConfig(rendered)).toEqual({ flags: { forgotPassword: false } });
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it.each([
+      ['FORGOT_PASSWORD', 'forgotPassword'],
+      ['NEW_CHECKOUT_V2_BETA', 'newCheckoutV2Beta'],
+      ['FLAG_2FA', 'flag2fa'],
+      ['SINGLE', 'single'],
+    ])('converts %s to %s', (input, expected) => {
+      expect(toCamelCase(input)).toBe(expected);
+    });
+  });
+
+  describe('renderAppConfig — injection and replacement safety', () => {
+    it('escapes "<" so a value cannot terminate the script block', () => {
+      const hostile = `${buildHttpUrl()}/</script><script>alert(1)</script>`;
+
+      const rendered = renderAppConfig(defaultShell(), { [API_BASE_URL_VAR]: hostile });
+      const body = readBlockBody(rendered);
+
+      expect(body).not.toContain('<');
+      expect(body).toContain('\\u003c/script>\\u003cscript>');
+      expect(JSON.parse(body).apiBaseUrl).toBe(hostile);
+    });
+
+    it('leaves exactly one closing script tag for the block', () => {
+      const hostile = `${buildHttpUrl()}/</script>`;
+
+      const rendered = renderAppConfig(defaultShell(), { [GRAPHQL_URL_VAR]: hostile });
+
+      expect(rendered.match(/<\/script>/g)).toHaveLength(1);
+    });
+
+    it('preserves regex replacement tokens in a value verbatim', () => {
+      const tricky = `${buildHttpUrl()}/?a=$&b=$1c=$$d=$'`;
+
+      const rendered = renderAppConfig(defaultShell(), { [API_BASE_URL_VAR]: tricky });
+
+      expect(rendered).toContain('$&');
+      expect(JSON.parse(readBlockBody(rendered)).apiBaseUrl).toBe(tricky);
+    });
+  });
+
+  describe('renderAppConfig — idempotence', () => {
+    it('is idempotent for the same environment', () => {
+      const env = {
+        [API_BASE_URL_VAR]: `${buildHttpUrl()}/?next=</script>&token=$&`,
+        [GRAPHQL_URL_VAR]: buildHttpUrl('/graphql'),
+        [FORGOT_PASSWORD_VAR]: 'true',
+      };
+
+      const once = renderAppConfig(defaultShell(), env);
+      const twice = renderAppConfig(once, env);
+
+      expect(twice).toBe(once);
+    });
+  });
+
+  describe('renderAppConfig — the committed public/index.html shell', () => {
+    const committedShell = () =>
+      fs.readFileSync(path.join(projectRoot, 'public', 'index.html'), 'utf8');
+
+    it('renders the real shell without a rebuild', () => {
+      const graphqlUrl = buildHttpUrl('/graphql');
+      const html = committedShell();
+
+      const rendered = renderAppConfig(html, {
+        [GRAPHQL_URL_VAR]: graphqlUrl,
+        [FORGOT_PASSWORD_VAR]: 'true',
+      });
+
+      expect(readBlockConfig(rendered)).toEqual({
+        flags: { forgotPassword: true },
+        graphqlUrl,
+      });
+      expect(stripBlockBody(rendered)).toBe(stripBlockBody(html));
+    });
+
+    it('declares forgotPassword as the committed default so the flag variable is accepted', () => {
+      expect(readBlockConfig(committedShell())).toEqual({ flags: { forgotPassword: false } });
+    });
+  });
+});

--- a/tests/unit/tooling/performance-serving.test.ts
+++ b/tests/unit/tooling/performance-serving.test.ts
@@ -35,6 +35,47 @@ describe('performance serving config', () => {
     expect(dockerfile).toContain('"/app/serve.json"');
   });
 
+  it('renders runtime configuration at container start without changing the serve command', () => {
+    const dockerfile = readFile('Dockerfile');
+
+    // The ENTRYPOINT renders APP_CONFIG_* into the built HTML shell, then execs CMD (issue #145).
+    expect(dockerfile).toContain(
+      'COPY --chown=node:node scripts/docker-entrypoint.sh scripts/render-app-config.js ./scripts/'
+    );
+    expect(dockerfile).toContain('ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]');
+
+    // The serve command itself must stay byte-identical: the entrypoint wraps it, never
+    // replaces it, so the production image keeps serving `dist` with the explicit serve config.
+    expect(dockerfile).toContain(
+      'CMD ["serve", "-s", "dist", "-l", "tcp://0.0.0.0:3001", "-c", "/app/serve.json"]'
+    );
+  });
+
+  it('reads runtime configuration at boot synchronously, free of fetch, zod and tsyringe', () => {
+    // Issue #145. The runtime config lives inline in the HTML shell precisely so that reading it
+    // costs nothing on the critical path. Two regressions this pins against, both of which would
+    // blow the auth-page Lighthouse mobile budget (lighthouse/lighthouserc.mobile.js):
+    //   * an `await fetch('/app-config.json')` before render() is invisible to the preload
+    //     scanner, so it serializes a full round trip onto FCP and LCP;
+    //   * importing `@/config/runtime/app-config` (zod), or the tsyringe composition root, from
+    //     the entry module drags both into the eager entrypoint chunk — the exact cost the
+    //     deferred-DI auth store was built to avoid.
+    const entrySource = readFile('src/index.tsx');
+    // Comments legitimately discuss `await` and `fetch`; the gate is about executable code.
+    const entryCode = entrySource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+    expect(entrySource).toContain(
+      "import appConfigSource from '@/config/runtime/app-config-source';"
+    );
+    expect(entrySource).toContain('appConfigSource.load()');
+
+    expect(entryCode).not.toMatch(/\bawait\b/);
+    expect(entryCode).not.toContain('fetch(');
+    expect(entryCode).not.toContain("'@/config/dependency-injection-config'");
+    expect(entryCode).not.toContain("'@/config/runtime/app-config'");
+    expect(entryCode).not.toContain("from 'zod'");
+  });
+
   it('does not inject preload hints for every async chunk into the HTML shell', () => {
     const rsbuildConfigSource = readFile('rsbuild.config.ts');
 

--- a/tests/unit/tooling/public-index.test.ts
+++ b/tests/unit/tooling/public-index.test.ts
@@ -7,6 +7,21 @@ const publicDir = path.resolve(__dirname, '..', '..', '..', 'public');
 const readPublicJson = <T>(filename: string): T =>
   JSON.parse(fs.readFileSync(path.join(publicDir, filename), 'utf-8')) as T;
 
+const RUNTIME_CONFIG_BLOCK = /<script[^>]*\bid="app-runtime-config"[^>]*>([\s\S]*?)<\/script>/;
+
+const readRuntimeConfigJson = (indexHtml: string): string => {
+  const match = RUNTIME_CONFIG_BLOCK.exec(indexHtml);
+
+  if (!match) {
+    throw new Error(
+      'public/index.html is missing the <script id="app-runtime-config"> block that ' +
+        'src/config/runtime/app-config-source.ts reads synchronously at boot (issue #145).'
+    );
+  }
+
+  return match[1];
+};
+
 describe('public index shell', () => {
   it('does not load the Inter font stylesheet from a third-party host', () => {
     const indexHtml = readPublicIndex();
@@ -30,6 +45,25 @@ describe('public index shell', () => {
     expect(indexHtml).toContain('href="/favicon-32x32.png"');
     expect(indexHtml).toContain('href="/apple-touch-icon.png"');
     expect(indexHtml).toContain('href="/safari-pinned-tab.svg"');
+  });
+
+  it('ships the inline runtime configuration block the app reads at boot', () => {
+    const indexHtml = readPublicIndex();
+
+    expect(indexHtml).toContain('id="app-runtime-config"');
+    expect(indexHtml).toContain('type="application/json"');
+
+    const parsed = JSON.parse(readRuntimeConfigJson(indexHtml)) as unknown;
+
+    expect(typeof parsed).toBe('object');
+    expect(parsed).not.toBeNull();
+    expect(Array.isArray(parsed)).toBe(false);
+
+    const { flags } = parsed as { flags?: unknown };
+
+    expect(typeof flags).toBe('object');
+    expect(flags).not.toBeNull();
+    expect(Array.isArray(flags)).toBe(false);
   });
 
   it('ships a single manifest file with install metadata', () => {

--- a/tests/unit/tooling/runtime-config-contract.test.ts
+++ b/tests/unit/tooling/runtime-config-contract.test.ts
@@ -1,0 +1,144 @@
+// @jest-environment @stryker-mutator/jest-runner/jest-env/node
+
+import fs from 'fs';
+import path from 'path';
+
+import AppConfigSchema from '@/config/runtime/app-config-schema';
+import featureFlagService from '@/config/runtime/feature-flag-service';
+
+import { FLAG_ENV_PREFIX, renderAppConfig, toCamelCase } from '../../../scripts/render-app-config';
+
+const projectRoot = path.resolve(__dirname, '..', '..', '..');
+
+const readFile = (relativePath: string): string =>
+  fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
+
+const SHELL = 'public/index.html';
+const SCHEMA = 'src/config/runtime/app-config-schema.ts';
+const UNION = 'src/config/runtime/types/feature-flag.ts';
+const RENDERER = 'scripts/render-app-config.js';
+const DOCS = 'docs/feature-flags.md';
+
+const CONFIG_BLOCK = /<script[^>]*\bid="app-runtime-config"[^>]*>([\s\S]*?)<\/script>/;
+
+const parseConfigBlock = (html: string): { flags?: Record<string, unknown> } => {
+  const match = CONFIG_BLOCK.exec(html);
+
+  if (!match) {
+    throw new Error(
+      `${SHELL} has no <script id="app-runtime-config"> block. The runtime configuration ` +
+        'contract (issue #145) starts there — restore the block before changing anything else.'
+    );
+  }
+
+  return JSON.parse(match[1]) as { flags?: Record<string, unknown> };
+};
+
+const shellFlagNames = (): string[] =>
+  Object.keys(parseConfigBlock(readFile(SHELL)).flags ?? {}).sort();
+
+const schemaFlagNames = (): string[] =>
+  Object.keys(AppConfigSchema.shape.flags.unwrap().shape).sort();
+
+const unionFlagNames = (): string[] => {
+  const declaration = /export type FeatureFlag\s*=\s*([^;]+);/.exec(readFile(UNION));
+
+  if (!declaration) {
+    throw new Error(
+      `${UNION} no longer declares "export type FeatureFlag = ...". That union is what makes an ` +
+        'unknown flag name a compile error, so it cannot be removed or renamed.'
+    );
+  }
+
+  return Array.from(declaration[1].matchAll(/'([^']+)'/g), (match) => match[1]).sort();
+};
+
+const registeredFlagNames = (): string[] => [...featureFlagService.names()].sort();
+
+const appConfigEnvKeys = (relativePath: string): string[] =>
+  readFile(relativePath)
+    .split('\n')
+    .map((line) => /^(APP_CONFIG_[A-Z0-9_]*)=/.exec(line.trim()))
+    .filter((match): match is RegExpExecArray => match !== null)
+    .map((match) => match[1])
+    .sort();
+
+const urlSettings = (): Array<{ envVar: string; key: string }> => {
+  const block = /const URL_SETTINGS = \[([\s\S]*?)\];/.exec(readFile(RENDERER));
+
+  if (!block) {
+    throw new Error(
+      `${RENDERER} no longer declares a URL_SETTINGS array. It is the list of APP_CONFIG_* URL ` +
+        'variables the container entrypoint renders into the HTML shell.'
+    );
+  }
+
+  return Array.from(block[1].matchAll(/envVar:\s*'([^']+)',\s*key:\s*'([^']+)'/g), (match) => ({
+    envVar: match[1],
+    key: match[2],
+  }));
+};
+
+// A feature flag is declared in four places that no compiler or bundler ties together:
+// the committed JSON block in the HTML shell, the zod schema, the FeatureFlag union, and
+// FEATURE_FLAG_DEFAULTS. Adding a flag to three of them ships a flag that silently cannot be
+// turned on (or one the container entrypoint rejects at start-up). This suite is the tie.
+describe('runtime configuration contract', () => {
+  it('declares the same flags in the HTML shell, the zod schema and the flag service', () => {
+    const registered = registeredFlagNames();
+
+    expect(registered.length).toBeGreaterThan(0);
+    expect({ [SHELL]: shellFlagNames(), [SCHEMA]: schemaFlagNames() }).toEqual({
+      [SHELL]: registered,
+      [SCHEMA]: registered,
+    });
+  });
+
+  it('keeps the FeatureFlag union in step with FEATURE_FLAG_DEFAULTS', () => {
+    expect({ [UNION]: unionFlagNames() }).toEqual({ [UNION]: registeredFlagNames() });
+  });
+
+  it('maps every APP_CONFIG_FLAG_* variable declared in .env onto a registered flag', () => {
+    const shellHtml = readFile(SHELL);
+    const flagEnvKeys = appConfigEnvKeys('.env').filter((key) => key.startsWith(FLAG_ENV_PREFIX));
+    const namedFlags = flagEnvKeys
+      .map((envVar) => toCamelCase(envVar.slice(FLAG_ENV_PREFIX.length)))
+      .sort();
+
+    // Bijection: every declared variable names a real flag, and every flag is operable.
+    expect(namedFlags).toEqual(registeredFlagNames());
+
+    for (const envVar of flagEnvKeys) {
+      // The renderer rejects a variable naming a flag absent from the committed block, so this
+      // reproduces the check that fails container start rather than degrading silently.
+      expect(() => renderAppConfig(shellHtml, { [envVar]: 'true' })).not.toThrow();
+    }
+  });
+
+  it('declares the same APP_CONFIG_* keys in .env and .env.example', () => {
+    const declared = appConfigEnvKeys('.env');
+
+    expect(declared.length).toBeGreaterThan(0);
+    expect(appConfigEnvKeys('.env.example')).toEqual(declared);
+  });
+
+  it('declares every URL setting the renderer reads in .env, matching the schema keys', () => {
+    const settings = urlSettings();
+    const declared = appConfigEnvKeys('.env');
+    const schemaKeys = Object.keys(AppConfigSchema.shape)
+      .filter((key) => key !== 'flags')
+      .sort();
+
+    expect(settings.length).toBeGreaterThan(0);
+    // An undeclared variable is invisible to docker-compose and to `make check-env-sync`.
+    expect(settings.filter((setting) => !declared.includes(setting.envVar))).toEqual([]);
+    // A renderer key the schema does not know would be rejected by the strictObject at boot.
+    expect(settings.map((setting) => setting.key).sort()).toEqual(schemaKeys);
+  });
+
+  it('documents every registered feature flag in the feature-flag guide', () => {
+    const guide = readFile(DOCS);
+
+    expect(registeredFlagNames().filter((flag) => !guide.includes(flag))).toEqual([]);
+  });
+});

--- a/tests/unit/tooling/runtime-config-contract.test.ts
+++ b/tests/unit/tooling/runtime-config-contract.test.ts
@@ -160,6 +160,39 @@ describe('runtime configuration contract', () => {
     expect(registeredFlagNames().filter((flag) => !guide.includes(flag))).toEqual([]);
   });
 
+  // Three independent validators decide whether a runtime URL is acceptable: the zod schema in
+  // the browser, `assertHttpUrl` in the container entrypoint, and `isHttpUrl` on the paint path.
+  // If they disagree, a value can pass container start and then blow up in the browser (or the
+  // reverse). This pins that they accept exactly the same set — including the single-label Docker
+  // hostnames this repo actually deploys with, which `z.httpUrl()` silently rejects.
+  it.each([
+    ['http://localhost:4000/graphql', true],
+    ['http://prod:3001', true],
+    ['http://mockoon:8080/api', true],
+    ['http://127.0.0.1:8080', true],
+    ['https://api.example.com/graphql', true],
+    ['mailto:someone@example.com', false],
+    ['ftp://files.example/api', false],
+    ['javascript:alert(1)', false],
+    ['not-a-url', false],
+    ['/api', false],
+  ])('accepts %s in the schema and the renderer alike (%s)', (url, accepted) => {
+    const schemaAccepts = AppConfigSchema.safeParse({ graphqlUrl: url }).success;
+    const rendererAccepts = ((): boolean => {
+      try {
+        renderAppConfig(readFile(SHELL), { APP_CONFIG_GRAPHQL_URL: url });
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+
+    expect({ schemaAccepts, rendererAccepts }).toEqual({
+      schemaAccepts: accepted,
+      rendererAccepts: accepted,
+    });
+  });
+
   // The sign-in control `forgotPassword` gates links to ROUTE_PATHS.passwordRecovery. Shipping
   // that flag enabled before the route is registered would send an already-locked-out user to the
   // not-found page, so this makes the rollout precondition in docs/feature-flags.md a build gate

--- a/tests/unit/tooling/runtime-config-contract.test.ts
+++ b/tests/unit/tooling/runtime-config-contract.test.ts
@@ -19,7 +19,12 @@ const UNION = 'src/config/runtime/types/feature-flag.ts';
 const RENDERER = 'scripts/render-app-config.js';
 const DOCS = 'docs/feature-flags.md';
 
-const CONFIG_BLOCK = /<script[^>]*\bid="app-runtime-config"[^>]*>([\s\S]*?)<\/script>/;
+// Both the id AND the JSON type are part of the contract: a block that loses `application/json`
+// would become an executable script, so matching the id alone would let that regression pass.
+const CONFIG_BLOCK = new RegExp(
+  '<script(?=[^>]*\\sid="app-runtime-config")' +
+    '(?=[^>]*\\stype="application/json")[^>]*>([\\s\\S]*?)</script>'
+);
 
 const parseConfigBlock = (html: string): { flags?: Record<string, unknown> } => {
   const match = CONFIG_BLOCK.exec(html);
@@ -78,6 +83,19 @@ const urlSettings = (): Array<{ envVar: string; key: string }> => {
     key: match[2],
   }));
 };
+
+const ROUTE_CONTRACTS = [
+  'src/routes/app-routes.ts',
+  'src/modules/user/features/auth/routes/index.ts',
+];
+
+const isRouteRegistered = (routePathKey: string): boolean =>
+  ROUTE_CONTRACTS.map(readFile).some((source) =>
+    new RegExp(`path:\\s*ROUTE_PATHS\\.${routePathKey}\\b`).test(source)
+  );
+
+const shippedFlagDefault = (flag: string): unknown =>
+  (parseConfigBlock(readFile(SHELL)).flags ?? {})[flag];
 
 // A feature flag is declared in four places that no compiler or bundler ties together:
 // the committed JSON block in the HTML shell, the zod schema, the FeatureFlag union, and
@@ -140,5 +158,20 @@ describe('runtime configuration contract', () => {
     const guide = readFile(DOCS);
 
     expect(registeredFlagNames().filter((flag) => !guide.includes(flag))).toEqual([]);
+  });
+
+  // The sign-in control `forgotPassword` gates links to ROUTE_PATHS.passwordRecovery. Shipping
+  // that flag enabled before the route is registered would send an already-locked-out user to the
+  // not-found page, so this makes the rollout precondition in docs/feature-flags.md a build gate
+  // rather than a promise: the shipped default and the route registration have to move together.
+  it('never ships forgotPassword enabled while its recovery route is unregistered', () => {
+    // Guard the probe itself: a registered route must read as registered, an absent one must not.
+    expect(isRouteRegistered('signIn')).toBe(true);
+    expect(isRouteRegistered('notARealRouteKey')).toBe(false);
+
+    const enabledWithoutRoute =
+      shippedFlagDefault('forgotPassword') === true && !isRouteRegistered('passwordRecovery');
+
+    expect(enabledWithoutRoute).toBe(false);
   });
 });

--- a/tests/unit/utils/get-graphql-url.test.ts
+++ b/tests/unit/utils/get-graphql-url.test.ts
@@ -1,3 +1,6 @@
+import type { AppConfigReader } from '@/config/runtime/types/app-config';
+import { buildAppConfigReader, buildHttpUrl } from '@tests/builders';
+
 describe('getGraphQLUrl', () => {
   const ORIGINAL_ENV = { ...process.env };
 
@@ -10,9 +13,11 @@ describe('getGraphQLUrl', () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
-  const resolveUrl = async (): Promise<string> => {
+  const resolveUrl = async (
+    appConfig: AppConfigReader = buildAppConfigReader()
+  ): Promise<string> => {
     const { default: GraphQLUrl } = await import('@/utils/get-graphql-url');
-    return new GraphQLUrl().resolve();
+    return new GraphQLUrl(appConfig).resolve();
   };
 
   it('returns the configured url trimmed when provided', async () => {
@@ -40,7 +45,7 @@ describe('getGraphQLUrl', () => {
     process.env.NODE_ENV = 'production';
 
     await expect(resolveUrl()).rejects.toThrow(
-      /REACT_APP_GRAPHQL_URL must be defined in production/
+      /A GraphQL URL must be defined in production environment/
     );
   });
 
@@ -49,7 +54,37 @@ describe('getGraphQLUrl', () => {
     process.env.NODE_ENV = 'production';
 
     await expect(resolveUrl()).rejects.toThrow(
-      /REACT_APP_GRAPHQL_URL must be defined in production/
+      /A GraphQL URL must be defined in production environment/
     );
+  });
+
+  describe('runtime configuration (issue #145)', () => {
+    it('prefers the injected runtime url over the build-time one', async () => {
+      const runtimeUrl = buildHttpUrl('/graphql');
+      process.env.REACT_APP_GRAPHQL_URL = 'http://build-time.example.com/graphql';
+
+      await expect(resolveUrl(buildAppConfigReader({ graphqlUrl: runtimeUrl }))).resolves.toBe(
+        runtimeUrl
+      );
+    });
+
+    it('satisfies the production requirement from the runtime url alone', async () => {
+      const runtimeUrl = buildHttpUrl('/graphql');
+      delete process.env.REACT_APP_GRAPHQL_URL;
+      process.env.NODE_ENV = 'production';
+
+      await expect(resolveUrl(buildAppConfigReader({ graphqlUrl: runtimeUrl }))).resolves.toBe(
+        runtimeUrl
+      );
+    });
+
+    it('uses the injected reader rather than the module singleton', async () => {
+      const runtimeUrl = buildHttpUrl('/graphql');
+      const appConfig = buildAppConfigReader({ graphqlUrl: runtimeUrl });
+      const graphqlUrl = jest.spyOn(appConfig, 'graphqlUrl');
+
+      await expect(resolveUrl(appConfig)).resolves.toBe(runtimeUrl);
+      expect(graphqlUrl).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tests/unit/utils/override-runtime-config.test.ts
+++ b/tests/unit/utils/override-runtime-config.test.ts
@@ -1,0 +1,115 @@
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+import { buildHttpUrl } from '@tests/builders';
+
+import { overrideRuntimeConfig } from '../../utils/override-runtime-config';
+
+type PageRouteTarget = Parameters<typeof overrideRuntimeConfig>[0];
+type RouteHandler = (route: unknown) => Promise<void>;
+type RegisteredHandler = { handler: RouteHandler; route: jest.Mock };
+type FakeRoute = {
+  request: () => { resourceType: () => string };
+  fetch: () => Promise<{ text: () => Promise<string> }>;
+  fulfill: jest.Mock;
+  continue: jest.Mock;
+};
+
+const SHELL = [
+  '<html><head>',
+  `<script id="${APP_CONFIG_ELEMENT_ID}" type="application/json">`,
+  '{ "flags": { "forgotPassword": false } }',
+  '</script>',
+  '</head><body></body></html>',
+].join('');
+
+const registerHandler = async (
+  config: Parameters<typeof overrideRuntimeConfig>[1]
+): Promise<RegisteredHandler> => {
+  const route = jest.fn().mockResolvedValue(undefined);
+  const page = { route: route as PageRouteTarget['route'] };
+
+  await overrideRuntimeConfig(page, config);
+
+  const [, handler] = route.mock.calls[0] as [unknown, RouteHandler];
+
+  return { handler, route };
+};
+
+const documentRoute = (body: string, fulfill: jest.Mock): FakeRoute => ({
+  request: (): { resourceType: () => string } => ({ resourceType: (): string => 'document' }),
+  fetch: async (): Promise<{ text: () => Promise<string> }> => ({
+    text: async (): Promise<string> => body,
+  }),
+  fulfill,
+  continue: jest.fn(),
+});
+
+const renderedConfig = (html: string): unknown => {
+  const match = new RegExp(`id="${APP_CONFIG_ELEMENT_ID}"[^>]*>([\\s\\S]*?)</script>`).exec(html);
+
+  return JSON.parse(match?.[1] ?? 'null') as unknown;
+};
+
+describe('overrideRuntimeConfig', () => {
+  it('registers exactly one route handler', async () => {
+    const { route } = await registerHandler({});
+
+    expect(route).toHaveBeenCalledTimes(1);
+    expect(route.mock.calls[0][0]).toBe('**/*');
+  });
+
+  it('replaces the runtime configuration block in the served document', async () => {
+    const graphqlUrl = buildHttpUrl('/graphql');
+    const fulfill = jest.fn().mockResolvedValue(undefined);
+    const { handler } = await registerHandler({ graphqlUrl, flags: { forgotPassword: true } });
+
+    await handler(documentRoute(SHELL, fulfill));
+
+    expect(fulfill).toHaveBeenCalledTimes(1);
+    const [options] = fulfill.mock.calls[0] as [{ body: string }];
+
+    expect(renderedConfig(options.body)).toEqual({
+      graphqlUrl,
+      flags: { forgotPassword: true },
+    });
+    expect(options.body).toContain('<html><head>');
+    expect(options.body).toContain('</body></html>');
+  });
+
+  it('escapes a value that would otherwise terminate the script block', async () => {
+    const fulfill = jest.fn().mockResolvedValue(undefined);
+    const { handler } = await registerHandler({ apiBaseUrl: 'http://x/</script><b>' });
+
+    await handler(documentRoute(SHELL, fulfill));
+
+    const [options] = fulfill.mock.calls[0] as [{ body: string }];
+
+    expect(options.body).not.toContain('http://x/</script>');
+    expect(renderedConfig(options.body)).toEqual({ apiBaseUrl: 'http://x/</script><b>' });
+  });
+
+  it('passes non-document requests through untouched', async () => {
+    const { handler } = await registerHandler({});
+    const continueRoute = jest.fn().mockResolvedValue(undefined);
+    const mockRoute = {
+      request: (): { resourceType: () => string } => ({ resourceType: (): string => 'script' }),
+      fetch: jest.fn(),
+      fulfill: jest.fn(),
+      continue: continueRoute,
+    };
+
+    await handler(mockRoute);
+
+    expect(continueRoute).toHaveBeenCalledTimes(1);
+    expect(mockRoute.fulfill).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly when the served document ships no configuration block', async () => {
+    const fulfill = jest.fn().mockResolvedValue(undefined);
+    const { handler } = await registerHandler({});
+
+    await expect(handler(documentRoute('<html><head></head></html>', fulfill))).rejects.toThrow(
+      new RegExp(`has no #${APP_CONFIG_ELEMENT_ID} block to override`)
+    );
+    expect(fulfill).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/url-builder.test.ts
+++ b/tests/unit/utils/url-builder.test.ts
@@ -1,10 +1,34 @@
 import urlBuilder from '@/utils/url-builder';
+import { clearConfigBlock, writeConfigBlock } from '@tests/utils/config-block';
 
 describe('urlBuilder', () => {
   const originalEnv = process.env.REACT_APP_MOCKOON_URL;
 
   afterEach(() => {
     process.env.REACT_APP_MOCKOON_URL = originalEnv;
+    clearConfigBlock();
+  });
+
+  describe('runtime configuration (issue #145)', () => {
+    it('prefers the runtime apiBaseUrl over the build-time one', () => {
+      process.env.REACT_APP_MOCKOON_URL = 'https://build-time.example.com';
+      writeConfigBlock(JSON.stringify({ apiBaseUrl: 'https://runtime.example.com' }));
+
+      expect(urlBuilder.build('users')).toBe('https://runtime.example.com/users');
+    });
+
+    it('falls back to the build-time origin when the runtime value is blank', () => {
+      process.env.REACT_APP_MOCKOON_URL = 'https://build-time.example.com';
+      writeConfigBlock(JSON.stringify({ apiBaseUrl: '   ' }));
+
+      expect(urlBuilder.build('users')).toBe('https://build-time.example.com/users');
+    });
+
+    it('falls back to the build-time origin when no runtime block is rendered', () => {
+      process.env.REACT_APP_MOCKOON_URL = 'https://build-time.example.com';
+
+      expect(urlBuilder.build('users')).toBe('https://build-time.example.com/users');
+    });
   });
 
   describe('with base URL configured', () => {

--- a/tests/unit/utils/url-builder.test.ts
+++ b/tests/unit/utils/url-builder.test.ts
@@ -24,6 +24,16 @@ describe('urlBuilder', () => {
       expect(urlBuilder.build('users')).toBe('https://build-time.example.com/users');
     });
 
+    it.each(['not-a-url', '/api', 'mailto:someone@example.com', 'javascript:alert(1)'])(
+      'falls back to the build-time origin rather than passing %s to fetch',
+      (apiBaseUrl) => {
+        process.env.REACT_APP_MOCKOON_URL = 'https://build-time.example.com';
+        writeConfigBlock(JSON.stringify({ apiBaseUrl }));
+
+        expect(urlBuilder.build('users')).toBe('https://build-time.example.com/users');
+      }
+    );
+
     it('falls back to the build-time origin when no runtime block is rendered', () => {
       process.env.REACT_APP_MOCKOON_URL = 'https://build-time.example.com';
 

--- a/tests/utils/config-block.ts
+++ b/tests/utils/config-block.ts
@@ -1,0 +1,23 @@
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+
+/**
+ * Test-side counterpart of the inline `<script id="app-runtime-config">` block that
+ * `public/index.html` ships and `scripts/render-app-config.js` rewrites at container start.
+ * The runtime config layer is the only code that reads it, so every suite under
+ * `tests/unit/config/runtime` drives it through these two helpers.
+ */
+export function clearConfigBlock(): void {
+  document.getElementById(APP_CONFIG_ELEMENT_ID)?.remove();
+}
+
+export function writeConfigBlock(text: string): HTMLScriptElement {
+  clearConfigBlock();
+
+  const element = document.createElement('script');
+  element.id = APP_CONFIG_ELEMENT_ID;
+  element.type = 'application/json';
+  element.textContent = text;
+  document.head.appendChild(element);
+
+  return element;
+}

--- a/tests/utils/override-runtime-config.ts
+++ b/tests/utils/override-runtime-config.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test';
+
+import { APP_CONFIG_ELEMENT_ID } from '@/config/runtime/app-config-source';
+import type { AppConfigValues } from '@/config/runtime/types/app-config';
+
+type PageRouteTarget = Pick<Page, 'route'>;
+
+const BLOCK_PATTERN = new RegExp(
+  `(<script[^>]*\\bid="${APP_CONFIG_ELEMENT_ID}"[^>]*>)[\\s\\S]*?(</script>)`
+);
+
+/**
+ * Serves the SAME production artifact with a different runtime configuration by rewriting the
+ * inline app-config block in the document response — the browser-side twin of what
+ * scripts/render-app-config.js does at container start (issue #145).
+ *
+ * This is what lets an e2e spec prove "one build, many configs" against a running production
+ * container it cannot write files into.
+ */
+export async function overrideRuntimeConfig(
+  page: PageRouteTarget,
+  config: AppConfigValues
+): Promise<void> {
+  // Escaping `<` keeps a configured value from terminating the script block early.
+  const json = JSON.stringify(config).replace(/</g, '\\u003c');
+
+  await page.route('**/*', async (route) => {
+    if (route.request().resourceType() !== 'document') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    const body = await response.text();
+
+    if (!BLOCK_PATTERN.test(body)) {
+      throw new Error(
+        `The served document has no #${APP_CONFIG_ELEMENT_ID} block to override. ` +
+          'The production HTML shell must ship one (public/index.html).'
+      );
+    }
+
+    await route.fulfill({
+      response,
+      body: body.replace(BLOCK_PATTERN, (_match, open, close) => `${open}${json}${close}`),
+    });
+  });
+}


### PR DESCRIPTION
Closes #145

## Problem

Every setting — API endpoints, GraphQL URL, languages — was inlined into the JS bundle at build
time by RSBuild `source.define`. Consequences: an administrator could not change anything without
a rebuild, the same tested `dist/` could not be promoted from staging to production, and there was
no feature-flag mechanism at all, so the only lever for disabling a feature was a git revert.

## What this adds

A **runtime** configuration layer (`@/config/runtime`) alongside the existing **build-time** layer
(`@/config/env`, #112). Build-time values stay as defaults; runtime values win.

The configuration is an inline JSON block in the HTML shell, carried by a `script` element with
`id="app-runtime-config"` and `type="application/json"`. The production container `ENTRYPOINT`
rewrites it from `APP_CONFIG_*` environment variables at start-up:

```bash
APP_CONFIG_GRAPHQL_URL=https://api.example.com/graphql \
APP_CONFIG_FLAG_FORGOT_PASSWORD=false \
docker compose -f docker-compose.yml -f docker-compose.test.yml up -d --force-recreate prod
```

| Setting        | Variable                             | Consumer                  |
| -------------- | ------------------------------------ | ------------------------- |
| `apiBaseUrl`   | `APP_CONFIG_API_BASE_URL`            | `@/utils/url-builder`     |
| `graphqlUrl`   | `APP_CONFIG_GRAPHQL_URL`             | `GraphQLUrl` (injected)   |
| `flags.<name>` | `APP_CONFIG_FLAG_<UPPER_SNAKE_NAME>` | `featureFlagService`      |

## Design decisions, and why

**Inline block rather than a fetched `app-config.json`.** The issue offered both. A config request
is invisible to the preload scanner — it can only start after `index.js` executes — so awaiting it
before `root.render()` serializes a full round trip onto FCP and LCP. The mobile Lighthouse floor
is `0.84` with `aggregationMethod: 'median-run'`, and the in-file comment records that the #104
app shell already consumed the remaining headroom. The inline block costs zero requests, is read
synchronously (which also keeps the module-eval router construction in `src/routes/routes.tsx`
working unchanged), and `index.html` is already served `no-cache`.

**Two layers, dependency-free + zod, mirroring `@/config/env`.** This was measured against real
production builds rather than assumed:

| Boot-path validation | Eager entrypoint (raw) | Δ | Budget |
| -------------------- | ---------------------- | --- | ------ |
| none (this PR)       | 373 kB                 | —   | 470 kB |
| `zod`                | 436 kB                 | +62 kB | 470 kB |
| `zod/mini`           | 418 kB                 | +45 kB | 470 kB |

Both variants fit the byte budget, but the extra parse/eval lands on the auth critical path that
the 0.84 floor cannot absorb. So `app-config-source.ts` is dependency-free and paint-safe, and
`app-config.ts` (zod, frozen, fail-fast) sits behind the DI composition root where zod already
lives. Measured entrypoint on this branch: **121.5 kB gzip, all budgets satisfied.**

**Fail-fast happens at the earliest point that can act on it** — which is the deployment, not the
browser:

1. **Container start.** `scripts/render-app-config.js` rejects a non-`http(s)` URL, a flag value
   that is not exactly `true`/`false`, and an `APP_CONFIG_FLAG_*` variable naming a flag that does
   not exist; the entrypoint exits non-zero, so a misconfigured deployment never serves.
2. **Browser boot.** `appConfigSource.load()` runs before `createRoot`, and a malformed block is
   rendered through the shell's own accessible `ErrorFallback` (focus-managed `h1`, `role="alert"`,
   retry button) instead of leaving an empty `#root` — which a screen reader cannot distinguish
   from "still loading".
3. **Container-resolved code.** `appConfig` zod-validates with `z.prettifyError`, and a unit test
   validates the **committed** block in `public/index.html` against the schema.

**`FeatureFlagService` is registered with `useValue`, not decorated `@injectable()`.** It is a
container-free module singleton, exactly like the observability render-path leaves (#115): the
auth page must read a flag without pulling tsyringe into the eager chunk, and registering the
instance under `RUNTIME_TOKENS.FeatureFlagService` is what lets container-resolved classes inject
it rather than value-import it (#130). `GraphQLUrl` now injects `RUNTIME_TOKENS.AppConfig` through
an `AppConfigReader` interface, which is the real consumer of the validated layer.

**Anti-drift.** A flag is declared in four places (the `FeatureFlag` union, `FEATURE_FLAG_DEFAULTS`,
the zod schema, the committed HTML block) plus `.env`/`.env.example`.
`tests/unit/tooling/runtime-config-contract.test.ts` fails the build when any of them disagree, and
the renderer treats the committed block as the source of truth for which flags exist, so it needs
no duplicated registry.

## Acceptance criteria

- [x] **Same artifact, two configs, no rebuild.** Verified three ways: against the real production
      image (built once, run twice with different `APP_CONFIG_*`, two different rendered blocks —
      and two invalid configs exiting `1` without serving); in `tests/bats/render_app_config.bats`;
      and in `tests/e2e/.../runtime-config.spec.ts`, which serves the identical bundle with the
      flag off and on.
- [x] **Config schema zod-validated; invalid config fails fast with a clear error.** Three layers
      above. Deviation worth reviewing explicitly: zod validation runs in the container-resolved
      layer rather than in the eager boot chunk, for the measured reason in the table above; the
      boot layer still fails fast on a malformed block, and the entrypoint fails the deployment.
- [x] **`FeatureFlagService` behind a DI token, 100% covered, no static/free functions.** 100%
      branches/functions/lines/statements across all three Jest suites.
- [x] **Auth-page Lighthouse budget unchanged.** No new request, no new eager dependency;
      entrypoint 121.5 kB gzip against a 161.1 kB budget, all budgets satisfied.
- [x] **Flag lifecycle documented; example flag gates a non-critical UI element.**
      `docs/feature-flags.md` covers introduce → roll out → remove. `forgotPassword` defaults to
      **off**, so the shipped DOM is byte-identical and no visual baseline moves.

## Accessibility

The UI change went through the `accessibility-lead` team review. Findings caused by this change
are fixed here: the link carries its own `textDecoration` (UILink's theme sets
`textDecoration: 'none'` in `styleOverrides.root`, which outranks the `underline` prop), a
`4.5:1`-conformant colour as a token rather than `primary.main` (`renderWithTheme` *replaces*
rather than merges the theme, so `theme.palette.primary.main` inside `UILink` does not resolve to
the brand colour), a `10.23:1` focus ring matching the `ui-button` precedent rather than the
footer's, and `flexWrap` + gaps so the two-item row reflows at 320px. No live region is added —
the value is constant for the document lifetime.

The review also surfaced **pre-existing** issues that predate this change and are **not** fixed
here, to keep the diff scoped. Each deserves its own issue:

- `FormField` renders `label for="email"` but `UIFormInputField` never passes a matching `id`, so
  the accessible name falls back to the placeholder — WCAG 1.3.1 and 2.5.3 (Level A), and in
  Ukrainian the visible label is not contained in the accessible name.
- `html lang="en"` while the app runs in Ukrainian (3.1.1, Level A). Known to invalidate the
  Firefox visual baselines, so it needs its own PR plus a baseline regeneration.
- The remember-me checkbox border and checkmark are both `1.49:1` (1.4.11) and it has no
  perceivable focus indicator (2.4.7). Both need a design-token decision.
- "Remember me" is local `useState` only — it is never submitted. Functional, not WCAG.

## Verification

All run on the host (the dev container's `node_modules` volume is stale):

| Gate | Result |
| ---- | ------ |
| `eslint .` | 0 errors |
| `tsc` | clean |
| `prettier --check` | clean |
| `markdownlint` | clean |
| `depcruise` | no violations (747 modules) |
| `jscpd` | 0 clones |
| `lint-metrics` (rust-code-analysis) | all hard checks pass |
| `check-env-sync`, `check-lockfile-registries` | pass |
| `shellcheck` (v0.10.0, `--severity=warning`) | clean |
| unit (`TEST_ENV=client`) | 157 suites / 1661 tests, **100%** coverage |
| integration | 40 suites / 416 tests, **100%** coverage |
| apollo server | 5 suites / 118 tests |
| `bats -r tests/bats` | 84/84 |
| production build + `bundle-size-report.mjs` | all gzip budgets satisfied |
| production image | 63.4 MiB against a 236.5 MiB limit |

## Review round

Sixteen threads from qlty, qodo, CodeRabbit and cubic — all answered and resolved. Three reviewers
independently found the same real defect, which is the one worth calling out:

- **URL scheme mismatch.** `z.url()` accepts `mailto:` / `ftp:` / `javascript:` while the container
  entrypoint rejects everything but http(s). Now `z.httpUrl()` — and the same hole was closed one
  layer earlier, which none of the reviews reached: `url-builder` reads the dependency-free source
  before the zod layer exists, so `appConfigSource` gained a `url(key)` accessor carrying the
  identical contract. An invalid value falls back to the build-time origin instead of reaching
  `fetch`.
- **Shallow `Object.freeze`** — the nested `flags` object stayed mutable, so `get()` did not honour
  the `readonly` interface it advertises. Fixed, with assertions that mutation throws.
- **`/password-recovery` is unregistered** (CodeRabbit Major, cubic P2). Rather than implement the
  route here or drop the worked example, the rollout precondition became a build gate:
  `runtime-config-contract.test.ts` fails if the committed `forgotPassword` default is ever `true`
  while no route contract registers `ROUTE_PATHS.passwordRecovery`. The probe is itself guarded so
  it cannot pass vacuously.

Two were pushed back on with reasoning:

- The eslint override was **narrowed** from the whole `testing-library` rule set to the single rule
  that misfires (`prefer-screen-queries` reads Playwright's destructured `page` as a `render()`
  result, and suggests a `screen` API that does not exist there). Everything else stays on.
- `import '../setup'` in the integration spec was **kept** — it is the same-area convention every
  integration test in the repo uses, and changing only the new file would make it the outlier.

The rest were mechanical: bats lines over 100 chars, an order-sensitive flag assertion, an id-only
config-block regex, Prettier on one file, and a README claim that both URLs fall back to their
`REACT_APP_*` counterpart when the REST fallback is actually `REACT_APP_MOCKOON_URL`.

## Notes for review

- `eslint.config.mjs` gains one override: the RTL rule set is scoped away from `tests/e2e/**` and
  `tests/visual/**`. `testing-library/prefer-screen-queries` misreads Playwright's destructured
  `page` fixture as a `render()` result, so it fired on exactly the semantic `page.getByRole(...)`
  queries the testing convention in `CLAUDE.md` mandates. This is a scoping fix, not a suppression
  — there are no `eslint-disable` comments anywhere in this branch.
- `.dependency-cruiser.js` gains `^src/config/runtime/di[.]ts$` to `DI_COMPOSITION_ROOTS` so the
  new composition root is protected by `no-di-config-import-outside-composition-root` like the
  others.
- `ROUTE_PATHS.passwordRecovery` is declared ahead of the route it names. That is deliberate and is
  why the flag defaults to off — enabling it before the recovery flow exists would send an
  already-locked-out user to the 404 page. `docs/feature-flags.md` makes that the flag's rollout
  precondition.
- Languages stay build-time. `src/i18n.js` initializes i18next at module evaluation and
  `src/config/i18n-config.js` is `require`d by node tooling without a TypeScript loader, so making
  the language runtime-configurable is an i18n boot-path restructuring rather than a config change.
  Called out in `src/config/runtime/README.md`.
