### PR TITLE
test(#192): fail Jest on unexpected console.error/console.warn

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -49,6 +49,8 @@ module.exports = {
           '^src/index[.]tsx$', // app entrypoint
           '^codegen[.]ts$', // graphql-codegen config (consumed by the CLI, not imported)
           '^tests/load/utils/test-data[.]js$', // ad-hoc load-test data generator
+          // console-gate fixtures: run by a child Jest process, never imported (issue #192)
+          '^tests/fixtures/console-gate/.*[.]fixture[.](?:ts|tsx)$',
           '^storybook-static/', // generated Storybook output
           '^coverage/', // generated coverage reports
           '^test-results/', // generated Playwright/Jest test artifacts
@@ -553,11 +555,12 @@ module.exports = {
       name: 'tests-top-level-allowed-folders',
       comment:
         'Tests root may only contain allowed folders: apollo-server, builders, ' +
-        'e2e, integration, load, memory-leak, mutation, unit, utils, visual.',
+        'console-gate, e2e, fixtures, i18n, integration, load, memory-leak, mutation, ' +
+        'unit, utils, visual.',
       severity: 'error',
       from: {
         path:
-          '^tests/(?!(?:apollo-server|builders|e2e|integration|' +
+          '^tests/(?!(?:apollo-server|builders|console-gate|e2e|fixtures|i18n|integration|' +
           'load|memory-leak|mutation|unit|utils|visual)/)[^/]+/',
       },
       to: {},

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,61 @@ Test structure:
 - Server tests: `tests/apollo-server/server.test.ts`
 - Test environment controlled by `TEST_ENV` variable
 
+### Unexpected console output fails the suite (issue #192)
+
+`jest-fail-on-console` is installed by `installConsoleGate()`
+([`tests/console-gate/install.ts`](tests/console-gate/install.ts)) in **every** Jest setup file, so
+an unexpected `console.error` or `console.warn` **fails the emitting test**:
+
+| Setup file                     | Suite                      | Gated levels |
+| ------------------------------ | -------------------------- | ------------ |
+| `jest.setup.ts`                | unit (jsdom)               | error + warn |
+| `tests/integration/setup.ts`   | integration                | error + warn |
+| `tests/mutation/setup.ts`      | Stryker (unit+integration) | error + warn |
+| `tests/apollo-server/setup.ts` | apollo server (node)       | error only   |
+
+The server environment is error-only: it runs no React, and its intentional `console.error` paths
+are already spied in `format-error.test.ts` / `shutdown-functions.test.ts`. `console.log` / `info` /
+`debug` are **never** gated — the apollo-server shutdown path logs on purpose and level-gating them
+adds noise without defect coverage.
+
+**Why it matters.** ESLint's `no-console` gates code that _writes_ `console.*`; it cannot see output
+_emitted by_ React, MUI, react-router, or i18next at render time. This gate closes that channel —
+`act()` warnings from un-awaited state updates, missing list `key`s, invalid DOM nesting, and
+i18next `missingKey` output now fail instead of scrolling past in a green log.
+
+**When a test legitimately triggers logging** (it exercises an error path the application logs on),
+spy on it _and assert it_, scoped to that one test — never a file-wide `beforeEach`, which would
+swallow genuinely unexpected output in the file's other tests:
+
+```ts
+const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+  issueCount: 2,
+});
+```
+
+**When the warning is an `act()` warning, it is a real latent bug** — the test asserts against a
+tree that is still settling. Await the update (`await waitFor(...)`, `await screen.findBy…`, or
+`act(() => …)`); do not spy it away.
+
+**Allowlist.** [`tests/console-gate/allowlist.ts`](tests/console-gate/allowlist.ts) is the only
+escape hatch and is deliberately hostile to growth —
+[`tests/unit/tooling/console-gate.test.ts`](tests/unit/tooling/console-gate.test.ts) fails the build
+unless every entry is `^`-anchored, carries a substantive `reason`, and declares an `expiresWith`
+dependency major that the pinned version has **not** yet reached. An entry therefore cannot outlive
+its cause: the dependency bump that fixes the message turns the allowlist red until the entry is
+deleted. The single current entry covers the `ReactDOMTestUtils.act` deprecation that the pinned
+`@testing-library/react` 13.4 emits on every render; it expires at major 16.
+
+**No suppression:** satisfy the gate by fixing the emitting path or by spying **and asserting** the
+expected output — never by broadening an allowlist pattern, never by dropping the gate from a setup
+file. [`tests/unit/tooling/console-gate-fixtures.test.ts`](tests/unit/tooling/console-gate-fixtures.test.ts)
+runs a child Jest against seeded fixtures in `tests/fixtures/console-gate/` and pins that the gate
+really fails on unexpected `error`/`warn`, really passes a spied-and-asserted call, and really
+ignores `log`/`info`/`debug`.
+
 ### E2E & Visual Tests
 
 Uses Playwright inside Docker containers:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,34 @@ When you change or add a public target:
 - preserve the canonical entrypoints contributors and CI already rely on, or document the migration
   explicitly in the same change
 
+### Unexpected console output fails Jest
+
+Every Jest setup file installs `jest-fail-on-console`, so a `console.error` or `console.warn`
+emitted while a test runs **fails that test** (the apollo-server node suite gates `error` only;
+`log` / `info` / `debug` are never gated). This catches the runtime warnings ESLint cannot see —
+React `act()` warnings, missing list `key`s, invalid DOM nesting, i18next `missingKey` — which
+otherwise scroll past in a green log.
+
+If your test legitimately drives a path the application logs on, spy on it **and assert it**,
+scoped to that single test:
+
+```ts
+const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+  issueCount: 2,
+});
+```
+
+Do not put that spy in a file-wide `beforeEach` — it would swallow genuinely unexpected output in
+the file's other tests. If the message is an `act()` warning, it is a real bug in the test: await
+the update instead of spying it away.
+
+`tests/console-gate/allowlist.ts` is the only escape hatch, and
+`tests/unit/tooling/console-gate.test.ts` rejects any entry that is not `^`-anchored, lacks a
+substantive reason, or has outlived the dependency major it declares it expires with. Adding to it
+is reviewed as a defect suppression, exactly like an `eslint-disable`.
+
 ### Dockerfile build performance
 
 If your change touches a configured Dockerfile path (or the gate's own config),

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-fail-on-console": "^3.3.4",
         "jscpd": "^4.2.5",
         "jsdoc": "^4.0.4",
         "jsdom": "^20.0.3",
@@ -2353,6 +2354,8 @@
     "jest-environment-jsdom": ["jest-environment-jsdom@29.7.0", "", { "dependencies": { "@jest/environment": "^29.7.0", "@jest/fake-timers": "^29.7.0", "@jest/types": "^29.6.3", "@types/jsdom": "^20.0.0", "@types/node": "*", "jest-mock": "^29.7.0", "jest-util": "^29.7.0", "jsdom": "^20.0.0" }, "peerDependencies": { "canvas": "^2.5.0" }, "optionalPeers": ["canvas"] }, "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA=="],
 
     "jest-environment-node": ["jest-environment-node@29.7.0", "", { "dependencies": { "@jest/environment": "^29.7.0", "@jest/fake-timers": "^29.7.0", "@jest/types": "^29.6.3", "@types/node": "*", "jest-mock": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw=="],
+
+    "jest-fail-on-console": ["jest-fail-on-console@3.3.4", "", { "peerDependencies": { "@jest/globals": ">=27.5.1" } }, "sha512-ckcABlg7ZLy83RRVOE1YvJMF1thgVPozVp+DjnE36Z1CaIbTrSeSR2AU4de/SEpfFgp2qK62EHXfm47N74zMuw=="],
 
     "jest-get-type": ["jest-get-type@29.6.3", "", {}, "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw=="],
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,9 +1,12 @@
 import 'reflect-metadata';
 import '@testing-library/jest-dom';
+import '@testing-library/react';
 
 import { seedFaker } from './tests/builders/seed';
+import { installConsoleGate } from './tests/console-gate/install';
 
 seedFaker();
+installConsoleGate();
 
 // jsdom does not provide a global fetch. Apollo Client's HttpLink requires one to
 // exist at construction time; individual tests that exercise network code stub it.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fail-on-console": "^3.3.4",
     "jscpd": "^4.2.5",
     "jsdoc": "^4.0.4",
     "jsdom": "^20.0.3",

--- a/tests/apollo-server/setup.ts
+++ b/tests/apollo-server/setup.ts
@@ -1,3 +1,5 @@
 import { seedFaker } from '@tests/builders/seed';
+import { installConsoleGate } from '@tests/console-gate/install';
 
 seedFaker();
+installConsoleGate({ failOnWarn: false });

--- a/tests/builders/seed.ts
+++ b/tests/builders/seed.ts
@@ -12,7 +12,9 @@ export function seedFaker(seed: number = resolveFakerSeed()): number {
   faker.seed(seed);
   if (!process.env.FAKER_SEED_REPORTED) {
     process.env.FAKER_SEED_REPORTED = '1';
-    console.warn(`[faker] deterministic seed=${seed} (override with FAKER_SEED=<integer>)`);
+    process.stdout.write(
+      `[faker] deterministic seed=${seed} (override with FAKER_SEED=<integer>)\n`
+    );
   }
   return seed;
 }

--- a/tests/console-gate/README.md
+++ b/tests/console-gate/README.md
@@ -1,0 +1,85 @@
+# Console gate
+
+Fails a Jest test when it emits unexpected `console.error` or `console.warn` output (issue #192).
+
+## Why
+
+ESLint's `no-console` gates code that *writes* `console.*` calls. It cannot see output *emitted by*
+React, MUI, react-router, or i18next while a component renders. That channel carried real defects
+past every green build: `act()` warnings from un-awaited state updates, missing list `key` props,
+invalid DOM nesting, duplicate providers, and i18next `missingKey` output — the last of which is a
+user-visible localization defect in a `uk`/`en` product. Because the 100% coverage threshold forces
+essentially the whole component tree through Jest, this gate observes far more surface than a
+browser-level console check can, and it sees development-mode warnings that production builds strip.
+
+## Wiring
+
+`installConsoleGate()` is called from every Jest setup file. It is idempotent, so
+`tests/mutation/setup.ts` re-entering through `tests/integration/setup.ts` installs the gate once.
+
+| Setup file                     | Suite                              | Gated levels |
+| ------------------------------ | ---------------------------------- | ------------ |
+| `jest.setup.ts`                | unit (jsdom)                       | error + warn |
+| `tests/integration/setup.ts`   | integration                        | error + warn |
+| `tests/mutation/setup.ts`      | Stryker (unit + integration union) | error + warn |
+| `tests/apollo-server/setup.ts` | apollo server (node)               | error only   |
+
+The node server suite runs no React, and its intentional `console.error` paths are already spied in
+`format-error.test.ts` and `shutdown-functions.test.ts`. `console.log` / `info` / `debug` are never
+gated — the apollo-server shutdown path logs on purpose, and gating those levels adds noise without
+defect coverage.
+
+Because Stryker reuses this Jest wiring, mutants that surface a React warning are now killed. That
+can only raise the mutation score; no Stryker threshold changes.
+
+## Satisfying the gate
+
+**The path legitimately logs.** Spy on it *and assert it*, scoped to the single test that needs it:
+
+```ts
+it('returns error when the response is null', () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  const result = mapper.map(null);
+
+  expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+    issueCount: 1,
+  });
+  expect(result.ok).toBe(false);
+});
+```
+
+A file-wide `beforeEach` spy is not acceptable: it swallows genuinely unexpected output in the
+file's other tests. A bare `mockImplementation()` with no assertion is silencing, not testing.
+
+**The message is an `act()` warning.** It is a real latent bug — the test asserts against a React
+tree that is still settling. Await the update (`await waitFor(...)`, `await screen.findBy…`, or wrap
+the trigger in `act(...)`). Do not spy it away.
+
+**A library emits it unconditionally and nothing in this repository can stop it.** Only then add an
+allowlist entry, and expect it to be reviewed as a defect suppression.
+
+## Allowlist
+
+`allowlist.ts` entries are validated by `tests/unit/tooling/console-gate.test.ts`, which fails the
+build unless every entry:
+
+- has a `^`-anchored `pattern`, so it cannot swallow unrelated output;
+- carries a substantive `reason`;
+- declares an `expiresWith` package major that the version pinned in `package.json` has **not** yet
+  reached.
+
+The last rule is what stops the allowlist from rotting: the dependency bump that fixes the message
+turns this test red until the stale entry is deleted. An entry cannot outlive its cause.
+
+## Proof the gate fires
+
+`tests/unit/tooling/console-gate-fixtures.test.ts` runs a child Jest process against the seeded
+fixtures in `tests/fixtures/console-gate/` and pins that the gate:
+
+- fails a test that emits an unexpected `console.error`;
+- fails a test that emits an unexpected `console.warn`;
+- passes a test that spies on and asserts its expected output;
+- passes an allowlisted message and the ungated `log` / `info` / `debug` levels.
+
+The fixtures are named `*.fixture.ts`, not `*.test.ts`, so no runner discovers them directly.

--- a/tests/console-gate/README.md
+++ b/tests/console-gate/README.md
@@ -4,7 +4,7 @@ Fails a Jest test when it emits unexpected `console.error` or `console.warn` out
 
 ## Why
 
-ESLint's `no-console` gates code that *writes* `console.*` calls. It cannot see output *emitted by*
+ESLint's `no-console` gates code that _writes_ `console.*` calls. It cannot see output _emitted by_
 React, MUI, react-router, or i18next while a component renders. That channel carried real defects
 past every green build: `act()` warnings from un-awaited state updates, missing list `key` props,
 invalid DOM nesting, duplicate providers, and i18next `missingKey` output — the last of which is a
@@ -34,7 +34,7 @@ can only raise the mutation score; no Stryker threshold changes.
 
 ## Satisfying the gate
 
-**The path legitimately logs.** Spy on it *and assert it*, scoped to the single test that needs it:
+**The path legitimately logs.** Spy on it _and assert it_, scoped to the single test that needs it:
 
 ```ts
 it('returns error when the response is null', () => {
@@ -64,7 +64,8 @@ allowlist entry, and expect it to be reviewed as a defect suppression.
 `allowlist.ts` entries are validated by `tests/unit/tooling/console-gate.test.ts`, which fails the
 build unless every entry:
 
-- has a `^`-anchored `pattern`, so it cannot swallow unrelated output;
+- has a `pattern` anchored at **both** ends (`^` … `$`), so an entry matches the complete message
+  and cannot swallow unrelated output appended to it;
 - carries a substantive `reason`;
 - declares an `expiresWith` package major that the version pinned in `package.json` has **not** yet
   reached.
@@ -79,7 +80,12 @@ fixtures in `tests/fixtures/console-gate/` and pins that the gate:
 
 - fails a test that emits an unexpected `console.error`;
 - fails a test that emits an unexpected `console.warn`;
+- fails a test whose output is emitted during testing-library cleanup, after the test body returned;
 - passes a test that spies on and asserts its expected output;
-- passes an allowlisted message and the ungated `log` / `info` / `debug` levels.
+- re-arms after a test leaves its `console` spy unrestored, so one spied test cannot silently
+  disable the gate for the rest of its file (the library re-installs its patch in its own
+  `beforeEach`, so no `mockRestore()` is required);
+- passes an allowlisted message and the ungated `log` / `info` levels.
 
-The fixtures are named `*.fixture.ts`, not `*.test.ts`, so no runner discovers them directly.
+The fixtures are named `*.fixture.ts` / `*.fixture.tsx`, not `*.test.ts` / `*.test.tsx`, so no
+runner discovers them directly.

--- a/tests/console-gate/README.md
+++ b/tests/console-gate/README.md
@@ -64,14 +64,19 @@ allowlist entry, and expect it to be reviewed as a defect suppression.
 `allowlist.ts` entries are validated by `tests/unit/tooling/console-gate.test.ts`, which fails the
 build unless every entry:
 
-- has a `pattern` anchored at **both** ends (`^` … `$`), so an entry matches the complete message
-  and cannot swallow unrelated output appended to it;
+- has a `pattern` anchored at **both** ends (`^` … `$`), and carries neither the `g` nor the `y`
+  flag (a stateful pattern would skip messages);
 - carries a substantive `reason`;
 - declares an `expiresWith` package major that the version pinned in `package.json` has **not** yet
   reached.
 
 The last rule is what stops the allowlist from rotting: the dependency bump that fixes the message
 turns this test red until the stale entry is deleted. An entry cannot outlive its cause.
+
+The whole-message boundary is enforced in `install.ts`, not by those style rules. `isConsoleAllowedBy`
+allows a message only when the pattern matches it **in full** (`match[0] === message`), so an entry
+cannot allow a message that merely contains an allowed fragment — not even when the anchors are
+written in a way that binds to only one branch of an alternation, such as `/^allowed|swallowed$/`.
 
 ## Proof the gate fires
 

--- a/tests/console-gate/allowlist.ts
+++ b/tests/console-gate/allowlist.ts
@@ -1,0 +1,15 @@
+import type { ConsoleAllowlistEntry } from './types/console-allowlist-entry';
+
+const CONSOLE_ALLOWLIST: ConsoleAllowlistEntry[] = [
+  {
+    pattern: /^Warning: `ReactDOMTestUtils\.act` is deprecated in favor of `React\.act`\./,
+    reason: [
+      '@testing-library/react 13.4 renders through the deprecated react-dom/test-utils act(),',
+      'so React 18.3 emits this once per spec that renders a component.',
+      'Nothing here can stop it; @testing-library/react 16 renders through React.act instead.',
+    ].join(' '),
+    expiresWith: { packageName: '@testing-library/react', removedInMajor: 16 },
+  },
+];
+
+export default CONSOLE_ALLOWLIST;

--- a/tests/console-gate/allowlist.ts
+++ b/tests/console-gate/allowlist.ts
@@ -1,8 +1,16 @@
 import type { ConsoleAllowlistEntry } from './types/console-allowlist-entry';
 
+const RTL_ACT_DEPRECATION = new RegExp(
+  [
+    '^Warning: `ReactDOMTestUtils\\.act` is deprecated in favor of `React\\.act`\\.',
+    'Import `act` from `react` instead of `react-dom/test-utils`\\.',
+    'See https://react\\.dev/warnings/react-dom-test-utils for more info\\.$',
+  ].join(' ')
+);
+
 const CONSOLE_ALLOWLIST: ConsoleAllowlistEntry[] = [
   {
-    pattern: /^Warning: `ReactDOMTestUtils\.act` is deprecated in favor of `React\.act`\./,
+    pattern: RTL_ACT_DEPRECATION,
     reason: [
       '@testing-library/react 13.4 renders through the deprecated react-dom/test-utils act(),',
       'so React 18.3 emits this once per spec that renders a component.',

--- a/tests/console-gate/install.ts
+++ b/tests/console-gate/install.ts
@@ -1,11 +1,22 @@
 import failOnConsole from 'jest-fail-on-console';
 
 import CONSOLE_ALLOWLIST from './allowlist';
+import type { ConsoleAllowlistEntry } from './types/console-allowlist-entry';
 
 let installed = false;
 
+export function isConsoleAllowedBy(message: string, entries: ConsoleAllowlistEntry[]): boolean {
+  return entries.some((entry) => {
+    const match = new RegExp(entry.pattern.source, entry.pattern.flags.replace(/[gy]/g, '')).exec(
+      message
+    );
+
+    return match !== null && match[0] === message;
+  });
+}
+
 export function isConsoleAllowed(message: string): boolean {
-  return CONSOLE_ALLOWLIST.some((entry) => entry.pattern.test(message));
+  return isConsoleAllowedBy(message, CONSOLE_ALLOWLIST);
 }
 
 export function installConsoleGate({ failOnWarn = true }: { failOnWarn?: boolean } = {}): void {

--- a/tests/console-gate/install.ts
+++ b/tests/console-gate/install.ts
@@ -1,0 +1,24 @@
+import failOnConsole from 'jest-fail-on-console';
+
+import CONSOLE_ALLOWLIST from './allowlist';
+
+let installed = false;
+
+export function isConsoleAllowed(message: string): boolean {
+  return CONSOLE_ALLOWLIST.some((entry) => entry.pattern.test(message));
+}
+
+export function installConsoleGate({ failOnWarn = true }: { failOnWarn?: boolean } = {}): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  failOnConsole({
+    shouldFailOnError: true,
+    shouldFailOnWarn: failOnWarn,
+    allowMessage: isConsoleAllowed,
+  });
+}
+
+export default installConsoleGate;

--- a/tests/console-gate/types/console-allowlist-entry.ts
+++ b/tests/console-gate/types/console-allowlist-entry.ts
@@ -1,0 +1,10 @@
+export interface ConsoleAllowlistExpiry {
+  packageName: string;
+  removedInMajor: number;
+}
+
+export interface ConsoleAllowlistEntry {
+  pattern: RegExp;
+  reason: string;
+  expiresWith: ConsoleAllowlistExpiry;
+}

--- a/tests/fixtures/console-gate/allowlisted-message.fixture.ts
+++ b/tests/fixtures/console-gate/allowlisted-message.fixture.ts
@@ -1,0 +1,21 @@
+const runtimeConsole = Reflect.get(globalThis, 'console') as Console;
+
+const RTL_ACT_DEPRECATION = [
+  'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
+  'Import `act` from `react` instead of `react-dom/test-utils`.',
+].join(' ');
+
+describe('console gate fixture', () => {
+  it('passes when the message is on the allowlist', () => {
+    console.error(RTL_ACT_DEPRECATION);
+
+    expect(true).toBe(true);
+  });
+
+  it('passes when the level is outside the gated error and warn scope', () => {
+    runtimeConsole.log('an intentional log line');
+    runtimeConsole.info('an intentional info line');
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/console-gate/allowlisted-message.fixture.ts
+++ b/tests/fixtures/console-gate/allowlisted-message.fixture.ts
@@ -3,6 +3,7 @@ const runtimeConsole = Reflect.get(globalThis, 'console') as Console;
 const RTL_ACT_DEPRECATION = [
   'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
   'Import `act` from `react` instead of `react-dom/test-utils`.',
+  'See https://react.dev/warnings/react-dom-test-utils for more info.',
 ].join(' ');
 
 describe('console gate fixture', () => {

--- a/tests/fixtures/console-gate/emits-console-error.fixture.ts
+++ b/tests/fixtures/console-gate/emits-console-error.fixture.ts
@@ -1,0 +1,7 @@
+describe('console gate fixture', () => {
+  it('emits an unexpected console.error', () => {
+    console.error('seeded console-gate defect: unexpected error output');
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/console-gate/emits-console-warn.fixture.ts
+++ b/tests/fixtures/console-gate/emits-console-warn.fixture.ts
@@ -1,0 +1,7 @@
+describe('console gate fixture', () => {
+  it('emits an unexpected console.warn', () => {
+    console.warn('seeded console-gate defect: unexpected warn output');
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/console-gate/spied-console-error.fixture.ts
+++ b/tests/fixtures/console-gate/spied-console-error.fixture.ts
@@ -1,0 +1,9 @@
+describe('console gate fixture', () => {
+  it('passes when the expected error is spied on and asserted', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    console.error('an expected, asserted error');
+
+    expect(consoleError).toHaveBeenCalledWith('an expected, asserted error');
+  });
+});

--- a/tests/fixtures/console-gate/unrestored-spy.fixture.ts
+++ b/tests/fixtures/console-gate/unrestored-spy.fixture.ts
@@ -1,0 +1,15 @@
+describe('console gate fixture', () => {
+  it('installs a console.error spy and never restores it', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    console.error('an expected, asserted error');
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it('is still gated in the next test of the same file', () => {
+    console.error('seeded console-gate defect: emitted after an unrestored spy');
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/console-gate/warns-during-cleanup.fixture.tsx
+++ b/tests/fixtures/console-gate/warns-during-cleanup.fixture.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { useEffect } from 'react';
+
+function WarnOnUnmount(): JSX.Element {
+  useEffect((): (() => void) => {
+    return (): void => {
+      console.warn('seeded console-gate defect: warn emitted during testing-library cleanup');
+    };
+  }, []);
+
+  return <div>mounted</div>;
+}
+
+describe('console gate fixture', () => {
+  it('emits a warn from the unmount path that runs after the test body', () => {
+    render(<WarnOnUnmount />);
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/i18n/test-i18n.ts
+++ b/tests/i18n/test-i18n.ts
@@ -1,0 +1,18 @@
+import i18n, { i18n as I18nType } from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import enTranslations from '@/i18n/localization.json';
+
+export const testI18n: I18nType = i18n.createInstance();
+
+testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: {
+    en: { translation: enTranslations.en.translation },
+  },
+  interpolation: { escapeValue: false },
+  initImmediate: false,
+});
+
+export default testI18n;

--- a/tests/integration/components/skeletons/auth-skeleton.integration.test.tsx
+++ b/tests/integration/components/skeletons/auth-skeleton.integration.test.tsx
@@ -12,7 +12,7 @@ const AUTH_SKELETON_REGION_NAME = localization.en.translation.auth.loadingForm;
 const renderAuthSkeleton = (disableAnimation = false): ReturnType<typeof render> =>
   render(
     <I18nextProvider i18n={testI18n}>
-      <AuthSkeleton disableAnimation={disableAnimation} />
+      {disableAnimation ? <AuthSkeleton disableAnimation /> : <AuthSkeleton />}
     </I18nextProvider>
   );
 

--- a/tests/integration/components/skeletons/auth-skeleton.integration.test.tsx
+++ b/tests/integration/components/skeletons/auth-skeleton.integration.test.tsx
@@ -1,8 +1,20 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { I18nextProvider } from 'react-i18next';
 
 import AuthSkeleton from '@/components/skeletons/auth-skeleton';
+import localization from '@/i18n/localization.json';
+import testI18n from '@tests/i18n/test-i18n';
+
+const AUTH_SKELETON_REGION_NAME = localization.en.translation.auth.loadingForm;
+
+const renderAuthSkeleton = (disableAnimation = false): ReturnType<typeof render> =>
+  render(
+    <I18nextProvider i18n={testI18n}>
+      <AuthSkeleton disableAnimation={disableAnimation} />
+    </I18nextProvider>
+  );
 
 function getGenericSkeletonElements(): HTMLElement[] {
   return screen.getAllByRole('generic', { hidden: true }) as HTMLElement[];
@@ -55,15 +67,15 @@ describe('AuthSkeleton Integration Tests', () => {
 
   it('renders all skeleton elements', () => {
     expect(React).toBeDefined();
-    render(<AuthSkeleton />);
+    renderAuthSkeleton();
     assertAuthSkeletonElements();
   });
 
   it('renders the full skeleton tree when animation is disabled', () => {
-    render(<AuthSkeleton disableAnimation />);
+    renderAuthSkeleton(true);
 
     assertAuthSkeletonElements();
-    expect(screen.getByRole('region')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: AUTH_SKELETON_REGION_NAME })).toBeInTheDocument();
   });
 
   viewportCases.forEach(({ label, width }) => {
@@ -78,8 +90,8 @@ describe('AuthSkeleton Integration Tests', () => {
       });
 
       it(`should render skeleton structure on ${label} viewport`, () => {
-        render(<AuthSkeleton />);
-        const section = screen.getByRole('region');
+        renderAuthSkeleton();
+        const section = screen.getByRole('region', { name: AUTH_SKELETON_REGION_NAME });
         expect(section).toBeInTheDocument();
       });
     });
@@ -97,8 +109,8 @@ describe('AuthSkeleton Integration Tests', () => {
           });
           window.dispatchEvent(new Event('resize'));
 
-          const { unmount } = render(<AuthSkeleton />);
-          const section = screen.getByRole('region');
+          const { unmount } = renderAuthSkeleton();
+          const section = screen.getByRole('region', { name: AUTH_SKELETON_REGION_NAME });
           expect(section).toBeInTheDocument();
           unmount();
         });
@@ -115,7 +127,7 @@ describe('AuthSkeleton Integration Tests', () => {
           });
           window.dispatchEvent(new Event('resize'));
 
-          const { unmount } = render(<AuthSkeleton />);
+          const { unmount } = renderAuthSkeleton();
           const buttons = screen.queryAllByRole('button');
           const links = screen.queryAllByRole('link');
           expect(buttons).toHaveLength(0);

--- a/tests/integration/modules/user/features/auth/login-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/login-api.integration.test.ts
@@ -168,11 +168,15 @@ describe('LoginAPI Integration', () => {
     });
 
     it('should handle network errors', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
       server.use(rest.post(API_ENDPOINTS.LOGIN, (_, res) => res.networkError('Failed to fetch')));
 
       await expect(loginAPI.login(buildCredentials())).rejects.toThrow(
         'Network error. Please check your connection.'
       );
+
+      expect(consoleError).toHaveBeenCalledWith(`POST ${API_ENDPOINTS.LOGIN} net::ERR_FAILED`);
     });
   });
 

--- a/tests/integration/modules/user/features/auth/login-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/login-api.integration.test.ts
@@ -176,7 +176,10 @@ describe('LoginAPI Integration', () => {
         'Network error. Please check your connection.'
       );
 
-      expect(consoleError).toHaveBeenCalledWith(`POST ${API_ENDPOINTS.LOGIN} net::ERR_FAILED`);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(`POST ${API_ENDPOINTS.LOGIN}`)
+      );
     });
   });
 

--- a/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
@@ -161,7 +161,8 @@ describe('RegistrationAPI Integration', () => {
 
       await expect(registrationAPI.register(credentials)).rejects.toBeInstanceOf(ApiError);
 
-      expect(consoleError).toHaveBeenCalledWith(`POST ${GRAPHQL_URL} net::ERR_FAILED`);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(`POST ${GRAPHQL_URL}`));
     });
   });
 

--- a/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/registration-api.integration.test.ts
@@ -17,6 +17,8 @@ type ApolloClientLike = import('@apollo/client').ApolloClient<
   import('@apollo/client').NormalizedCacheObject
 >;
 
+type EmptyResponseCase = [label: string, body: Record<string, unknown>, missingFields: string[]];
+
 const credentials = buildUser();
 const { email, fullName, password } = credentials;
 
@@ -81,15 +83,32 @@ describe('RegistrationAPI Integration', () => {
   });
 
   describe('empty responses', () => {
-    it.each([
-      ['data is null', { data: null }],
-      ['createUser is null', { data: { createUser: null } }],
-      ['user is null', { data: { createUser: { user: null } } }],
-    ])('resolves to undefined when %s', async (_label, body) => {
-      server.use(rest.post(GRAPHQL_URL, (_req, res, ctx) => res(ctx.status(200), ctx.json(body))));
+    const emptyResponseCases: EmptyResponseCase[] = [
+      ['data is null', { data: null }, ['createUser']],
+      ['createUser is null', { data: { createUser: null } }, []],
+      ['user is null', { data: { createUser: { user: null } } }, ['clientMutationId']],
+    ];
 
-      await expect(registrationAPI.register(credentials)).resolves.toBeUndefined();
-    });
+    it.each(emptyResponseCases)(
+      'resolves to undefined when %s',
+      async (_label, body, missingCacheFields) => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        server.use(
+          rest.post(GRAPHQL_URL, (_req, res, ctx) => res(ctx.status(200), ctx.json(body)))
+        );
+
+        await expect(registrationAPI.register(credentials)).resolves.toBeUndefined();
+
+        expect(consoleError).toHaveBeenCalledTimes(missingCacheFields.length);
+        missingCacheFields.forEach((field, index) => {
+          const [message] = consoleError.mock.calls[index] as [string];
+
+          expect(message).toContain('https://go.apollo.dev/c/err#');
+          expect(decodeURIComponent(message)).toContain(`"${field}"`);
+        });
+      }
+    );
   });
 
   describe('error handling', () => {
@@ -136,9 +155,13 @@ describe('RegistrationAPI Integration', () => {
     });
 
     it('throws an ApiError on a network failure', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
       server.use(rest.post(GRAPHQL_URL, (_req, res) => res.networkError('Failed to fetch')));
 
       await expect(registrationAPI.register(credentials)).rejects.toBeInstanceOf(ApiError);
+
+      expect(consoleError).toHaveBeenCalledWith(`POST ${GRAPHQL_URL} net::ERR_FAILED`);
     });
   });
 

--- a/tests/integration/modules/user/features/auth/stores/auth-store-composition.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/auth-store-composition.integration.test.ts
@@ -1,6 +1,6 @@
 import '../../../../../setup';
 
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { AuthStateVar, authActions, useAuthState, useAuthToken } from '@auth/stores';
 import { buildCredentials, buildUser } from '@tests/builders';
@@ -11,7 +11,9 @@ describe('auth stores composition root integration', () => {
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   afterEach(() => {
     server.resetHandlers();
-    AuthStateVar.reset();
+    act(() => {
+      AuthStateVar.reset();
+    });
   });
   afterAll(() => server.close());
 

--- a/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
@@ -155,8 +155,9 @@ describe('Auth Store Integration', () => {
 
       await authActions.loginUser(buildCredentials());
 
+      expect(consoleError).toHaveBeenCalledTimes(1);
       expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining(`POST ${API_ENDPOINTS.LOGIN} net::ERR_FAILED`)
+        expect.stringContaining(`POST ${API_ENDPOINTS.LOGIN}`)
       );
 
       const state = AuthStateVar.get();
@@ -360,6 +361,7 @@ describe('Auth Store Integration', () => {
 
       await authActions.registerUser(registrationCredentials);
 
+      expect(consoleError).toHaveBeenCalledTimes(1);
       expect(consoleError).toHaveBeenCalledWith(
         expect.stringContaining('https://go.apollo.dev/c/err')
       );
@@ -379,10 +381,12 @@ describe('Auth Store Integration', () => {
 
       await authActions.registerUser(registrationCredentials);
 
-      expect(consoleError).toHaveBeenCalledWith(
+      expect(consoleError).toHaveBeenCalledTimes(2);
+      expect(consoleError).toHaveBeenNthCalledWith(
+        1,
         expect.stringContaining('https://go.apollo.dev/c/err')
       );
-      expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+      expect(consoleError).toHaveBeenNthCalledWith(2, 'Registration response validation failed', {
         issueCount: 1,
       });
 
@@ -425,9 +429,8 @@ describe('Auth Store Integration', () => {
 
       await authActions.registerUser(registrationCredentials);
 
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining(`POST ${GRAPHQL_URL} net::ERR_FAILED`)
-      );
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(`POST ${GRAPHQL_URL}`));
 
       const state = AuthStateVar.get();
       expect(state.registerLoading).toBe(false);

--- a/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/auth-store.integration.test.ts
@@ -150,9 +150,14 @@ describe('Auth Store Integration', () => {
     });
 
     it('should set error state on network failure', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       server.use(rest.post(API_ENDPOINTS.LOGIN, (_, res) => res.networkError('Failed to fetch')));
 
       await authActions.loginUser(buildCredentials());
+
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(`POST ${API_ENDPOINTS.LOGIN} net::ERR_FAILED`)
+      );
 
       const state = AuthStateVar.get();
       expect(state.loginLoading).toBe(false);
@@ -339,6 +344,7 @@ describe('Auth Store Integration', () => {
     });
 
     it('should handle validation error from API response', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       server.use(
         rest.post(GRAPHQL_URL, (_, res, ctx) =>
           res(
@@ -354,12 +360,17 @@ describe('Auth Store Integration', () => {
 
       await authActions.registerUser(registrationCredentials);
 
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('https://go.apollo.dev/c/err')
+      );
+
       const state = AuthStateVar.get();
       expect(state.registerLoading).toBe(false);
       expect(state.registerError).toBeTruthy();
     });
 
     it('surfaces a register error when the payload contains no user', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       server.use(
         rest.post(GRAPHQL_URL, (_, res, ctx) =>
           res(ctx.status(200), ctx.json({ data: { createUser: { user: null } } }))
@@ -367,6 +378,13 @@ describe('Auth Store Integration', () => {
       );
 
       await authActions.registerUser(registrationCredentials);
+
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('https://go.apollo.dev/c/err')
+      );
+      expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+        issueCount: 1,
+      });
 
       const state = AuthStateVar.get();
       expect(state.registerLoading).toBe(false);
@@ -402,9 +420,14 @@ describe('Auth Store Integration', () => {
     });
 
     it('should handle network failure', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       server.use(rest.post(GRAPHQL_URL, (_, res) => res.networkError('Failed to fetch')));
 
       await authActions.registerUser(registrationCredentials);
+
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(`POST ${GRAPHQL_URL} net::ERR_FAILED`)
+      );
 
       const state = AuthStateVar.get();
       expect(state.registerLoading).toBe(false);

--- a/tests/integration/modules/user/features/auth/stores/deferred-auth-actions.integration.test.ts
+++ b/tests/integration/modules/user/features/auth/stores/deferred-auth-actions.integration.test.ts
@@ -17,11 +17,17 @@ describe('deferred auth actions integration', () => {
   it('surfaces a retryable error when the DI graph fails to load, then recovers', async () => {
     const credentials = buildCredentials();
     const registration = buildUser();
+    const chunkLoadFailure = new Error('chunk load failed');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const resolveSpy = jest.spyOn(container, 'resolve').mockImplementation(() => {
-      throw new Error('chunk load failed');
+      throw chunkLoadFailure;
     });
 
     await authActions.loginUser(credentials);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Auth module failed to load; surfacing retryable error to the user.',
+      chunkLoadFailure
+    );
     expect(AuthStateVar.get()).toMatchObject({
       loginLoading: false,
       loginError: { kind: 'network', retryable: true },
@@ -33,9 +39,12 @@ describe('deferred auth actions integration', () => {
       registerError: { kind: 'network', retryable: true },
     });
 
+    expect(consoleError).toHaveBeenCalledTimes(2);
+
     resolveSpy.mockRestore();
 
     await authActions.loginUser(credentials);
     expect(AuthStateVar.get().token).toBe(defaultLoginResponse.token);
+    expect(consoleError).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/integration/services/error-handler.integration.test.ts
+++ b/tests/integration/services/error-handler.integration.test.ts
@@ -82,7 +82,12 @@ describe('ErrorHandler Coverage Tests', () => {
   });
 
   it('should safely no-op when no logger is configured', () => {
-    expect(() => errorHandler.handle(new Error('No console available'))).not.toThrow();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('No console available');
+
+    expect(() => errorHandler.handle(error)).not.toThrow();
+
+    expect(consoleError).toHaveBeenCalledWith('[ErrorHandler]', error);
   });
 
   it('exposes instance methods for auth-error mapping and error handling', () => {

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,8 +1,11 @@
 import 'reflect-metadata';
+import '@testing-library/react';
 
 import { seedFaker } from '@tests/builders/seed';
+import { installConsoleGate } from '@tests/console-gate/install';
 
 seedFaker();
+installConsoleGate();
 
 const mockoonPort = process.env.MOCKOON_PORT || '8080';
 process.env.REACT_APP_MOCKOON_URL = `http://localhost:${mockoonPort}`;

--- a/tests/mutation/setup.ts
+++ b/tests/mutation/setup.ts
@@ -1,9 +1,12 @@
 import 'reflect-metadata';
 import '@testing-library/jest-dom';
+import '@testing-library/react';
 
 import { seedFaker } from '@tests/builders/seed';
+import { installConsoleGate } from '@tests/console-gate/install';
 
 seedFaker();
+installConsoleGate();
 
 const { testPath } = expect.getState();
 const isIntegrationSuite = typeof testPath === 'string' && testPath.includes('/tests/integration/');

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -22,9 +22,9 @@ jest.mock('react-router-dom', () => {
     __esModule: true,
     ...actual,
     createBrowserRouter: (routes: unknown): unknown => routes,
-    RouterProvider: ({ router }: { router: unknown }): ReactElement => {
+    RouterProvider: ({ router, future }: { router: unknown; future?: unknown }): ReactElement => {
       const memoryRouter = actual.createMemoryRouter(router, { initialEntries: [mockCurrentPath] });
-      return <actual.RouterProvider router={memoryRouter} />;
+      return <actual.RouterProvider router={memoryRouter} future={future} />;
     },
   };
 });

--- a/tests/unit/components/protected-route.test.tsx
+++ b/tests/unit/components/protected-route.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import ProtectedRoute from '@auth/components/protected-route';
 import { AuthStateVar } from '@auth/stores';
+import ROUTER_FUTURE_FLAGS from '@tests/unit/utils/router-future-flags';
 
 function seedToken(token: string | null): void {
   act(() => {
@@ -14,7 +15,7 @@ function seedToken(token: string | null): void {
 const renderWithRouter = (token: string | null): ReturnType<typeof render> => {
   seedToken(token);
   return render(
-    <MemoryRouter initialEntries={['/']}>
+    <MemoryRouter initialEntries={['/']} future={ROUTER_FUTURE_FLAGS}>
       <Routes>
         <Route element={<ProtectedRoute />}>
           <Route path="/" element={<div>dashboard</div>} />

--- a/tests/unit/components/route-fallback/route-fallback.test.tsx
+++ b/tests/unit/components/route-fallback/route-fallback.test.tsx
@@ -16,7 +16,9 @@ jest.mock('react-i18next', () => ({
 describe('RouteFallback', () => {
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 
@@ -34,6 +36,10 @@ describe('RouteFallback', () => {
 
   it('keeps the spinner decorative and out of the eager MUI graph', () => {
     render(<RouteFallback />);
+
+    act(() => {
+      jest.advanceTimersByTime(ANNOUNCE_DELAY_MS);
+    });
 
     // The grey-pill spinner is a dependency-free CSS ring marked aria-hidden, so the only
     // a11y-exposed node is the single status region.

--- a/tests/unit/components/skeletons/auth-skeleton.typography.test.tsx
+++ b/tests/unit/components/skeletons/auth-skeleton.typography.test.tsx
@@ -1,8 +1,11 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
 
 import AuthSkeleton from '@/components/skeletons/auth-skeleton';
 import UISkeletonText from '@/components/skeletons/ui-skeleton-text';
 import breakpointsTheme from '@/components/ui-breakpoints';
+import localization from '@/i18n/localization.json';
+import testI18n from '@tests/i18n/test-i18n';
 
 jest.mock('@/components/skeletons/ui-skeleton-text', () => ({
   __esModule: true,
@@ -11,7 +14,15 @@ jest.mock('@/components/skeletons/ui-skeleton-text', () => ({
 
 describe('AuthSkeleton typography parity', () => {
   it('matches top text skeleton sizes to auth form typography', () => {
-    render(<AuthSkeleton />);
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <AuthSkeleton />
+      </I18nextProvider>
+    );
+
+    expect(
+      screen.getByRole('region', { name: localization.en.translation.auth.loadingForm })
+    ).toBeInTheDocument();
 
     const calls = (UISkeletonText as unknown as jest.Mock).mock.calls.map(([props]) => props);
     const titleSkeleton = calls.find((props) => props.id === 'auth-skeleton-title');

--- a/tests/unit/modules/user/features/auth/components/auth-error-boundary.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/auth-error-boundary.test.tsx
@@ -33,6 +33,7 @@ describe('AuthErrorBoundary', () => {
   });
 
   it('delegates caught errors to onError when provided', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const error = new Error('delegated error');
     const info = { componentStack: '\n    at ThrowingChild' } as React.ErrorInfo;
     const onError = jest.fn();
@@ -41,9 +42,11 @@ describe('AuthErrorBoundary', () => {
     boundary.componentDidCatch(error, info);
 
     expect(onError).toHaveBeenCalledWith(error, info);
+    expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
   it('forwards caught errors to the auth error reporter', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const reportSpy = jest.spyOn(authErrorReporter, 'report').mockImplementation(() => {});
     const error = new Error('captured error');
     const info = { componentStack: '\n    at ThrowingChild' } as ErrorInfo;
@@ -52,16 +55,20 @@ describe('AuthErrorBoundary', () => {
     boundary.componentDidCatch(error, info);
 
     expect(reportSpy).toHaveBeenCalledWith(error, info);
+    expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
   it('does not rethrow when the reporter fails', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.spyOn(authErrorReporter, 'report').mockImplementation(() => {
       throw new Error('capture failed');
     });
     const info = { componentStack: '\n    at ThrowingChild' } as ErrorInfo;
+    const error = new Error('boom');
     const boundary = new AuthErrorBoundary({ children: <SafeChild /> });
 
-    expect(() => boundary.componentDidCatch(new Error('boom'), info)).not.toThrow();
+    expect(() => boundary.componentDidCatch(error, info)).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
   it('does not try to access console in production mode', () => {
@@ -100,31 +107,43 @@ describe('AuthErrorBoundary', () => {
   });
 
   it('renders a custom fallback node when provided', () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('fallback node error');
 
     render(
       <AuthErrorBoundary fallback={<span>Custom fallback node</span>}>
-        <ThrowingChild error={new Error('fallback node error')} />
+        <ThrowingChild error={error} />
       </AuthErrorBoundary>
     );
 
     expect(screen.getByText('Custom fallback node')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'AuthErrorBoundary caught an error:',
+      error,
+      expect.objectContaining({ componentStack: expect.any(String) })
+    );
     consoleErrorSpy.mockRestore();
   });
 
   it('renders development error details when NODE_ENV is development', () => {
     process.env.NODE_ENV = 'development';
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('development details');
 
     render(
       <AuthErrorBoundary>
-        <ThrowingChild error={new Error('development details')} />
+        <ThrowingChild error={error} />
       </AuthErrorBoundary>
     );
 
     expect(screen.getByText('Something went wrong. Please try again later.')).toBeInTheDocument();
     expect(screen.getByText('Error Details')).toBeInTheDocument();
     expect(screen.getByText('development details')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'AuthErrorBoundary caught an error:',
+      error,
+      expect.objectContaining({ componentStack: expect.any(String) })
+    );
     consoleErrorSpy.mockRestore();
   });
 

--- a/tests/unit/modules/user/features/auth/components/auth-error-boundary.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/auth-error-boundary.test.tsx
@@ -42,6 +42,7 @@ describe('AuthErrorBoundary', () => {
     boundary.componentDidCatch(error, info);
 
     expect(onError).toHaveBeenCalledWith(error, info);
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
@@ -55,6 +56,7 @@ describe('AuthErrorBoundary', () => {
     boundary.componentDidCatch(error, info);
 
     expect(reportSpy).toHaveBeenCalledWith(error, info);
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
@@ -68,6 +70,7 @@ describe('AuthErrorBoundary', () => {
     const boundary = new AuthErrorBoundary({ children: <SafeChild /> });
 
     expect(() => boundary.componentDidCatch(error, info)).not.toThrow();
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('AuthErrorBoundary caught an error:', error, info);
   });
 
@@ -122,6 +125,11 @@ describe('AuthErrorBoundary', () => {
       error,
       expect.objectContaining({ componentStack: expect.any(String) })
     );
+    expect(
+      consoleErrorSpy.mock.calls.filter(
+        ([message]) => message === 'AuthErrorBoundary caught an error:'
+      )
+    ).toHaveLength(1);
     consoleErrorSpy.mockRestore();
   });
 
@@ -144,6 +152,11 @@ describe('AuthErrorBoundary', () => {
       error,
       expect.objectContaining({ componentStack: expect.any(String) })
     );
+    expect(
+      consoleErrorSpy.mock.calls.filter(
+        ([message]) => message === 'AuthErrorBoundary caught an error:'
+      )
+    ).toHaveLength(1);
     consoleErrorSpy.mockRestore();
   });
 

--- a/tests/unit/modules/user/features/auth/components/auth-page-layout/index.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/auth-page-layout/index.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
+import { I18nextProvider } from 'react-i18next';
 
+import localization from '@/i18n/localization.json';
 import AuthPageLayout from '@/modules/user/features/auth/components/auth-page-layout';
+import testI18n from '@tests/i18n/test-i18n';
 
 jest.mock('@/styles/theme', () => ({
   __esModule: true,
@@ -64,16 +67,25 @@ describe('AuthPageLayout', () => {
   });
 
   it('renders the AuthErrorBoundary fallback when the child throws (AC3)', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
     render(
-      <AuthPageLayout>
-        <ThrowingChild />
-      </AuthPageLayout>
+      <I18nextProvider i18n={testI18n}>
+        <AuthPageLayout>
+          <ThrowingChild />
+        </AuthPageLayout>
+      </I18nextProvider>
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        localization.en.translation.auth.error.default
+      );
     });
+    expect(consoleError).toHaveBeenCalledWith(
+      'AuthErrorBoundary caught an error:',
+      expect.objectContaining({ message: 'test chunk-load error' }),
+      expect.objectContaining({ componentStack: expect.any(String) })
+    );
   });
 });

--- a/tests/unit/modules/user/features/auth/components/auth-page-layout/index.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/auth-page-layout/index.test.tsx
@@ -87,5 +87,10 @@ describe('AuthPageLayout', () => {
       expect.objectContaining({ message: 'test chunk-load error' }),
       expect.objectContaining({ componentStack: expect.any(String) })
     );
+    expect(
+      consoleError.mock.calls.filter(
+        ([message]) => message === 'AuthErrorBoundary caught an error:'
+      )
+    ).toHaveLength(1);
   });
 });

--- a/tests/unit/modules/user/features/auth/components/form-section/auth-forms/registration-notification.test.tsx
+++ b/tests/unit/modules/user/features/auth/components/form-section/auth-forms/registration-notification.test.tsx
@@ -185,7 +185,9 @@ describe('RegistrationNotification', () => {
     fireEvent.click(backButton);
     fireEvent.click(backButton);
 
-    jest.advanceTimersByTime(BACK_CLOSE_ANIMATION_MS);
+    act(() => {
+      jest.advanceTimersByTime(BACK_CLOSE_ANIMATION_MS);
+    });
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/modules/user/features/auth/stores/deferred-auth-actions.test.ts
+++ b/tests/unit/modules/user/features/auth/stores/deferred-auth-actions.test.ts
@@ -25,6 +25,7 @@ const makeActions = (): { login: jest.Mock; register: jest.Mock } => ({
 
 const credentials = { email: 'a@b.c', password: 'p' };
 const registration = { fullName: 'A', email: 'a@b.c', password: 'p' };
+const loadFailureLog = 'Auth module failed to load; surfacing retryable error to the user.';
 
 describe('deferred auth actions composition root', () => {
   // clearMocks resets call history per test; mockReset additionally drops any staged
@@ -70,12 +71,16 @@ describe('deferred auth actions composition root', () => {
 
   it('stores a retryable login error when the deferred graph fails to load', async () => {
     const { authActions, AuthStateVar } = await loadBarrel();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const loadError = new Error('chunk load failed');
     resolveMock.mockImplementation(() => {
-      throw new Error('chunk load failed');
+      throw loadError;
     });
 
     await authActions.loginUser(credentials);
 
+    expect(consoleError).toHaveBeenCalledWith(loadFailureLog, loadError);
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(AuthStateVar.get()).toMatchObject({
       loginLoading: false,
       loginError: { kind: 'network', retryable: true },
@@ -84,12 +89,16 @@ describe('deferred auth actions composition root', () => {
 
   it('stores a retryable register error when the deferred graph fails to load', async () => {
     const { authActions, AuthStateVar } = await loadBarrel();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const loadError = new Error('chunk load failed');
     resolveMock.mockImplementation(() => {
-      throw new Error('chunk load failed');
+      throw loadError;
     });
 
     await authActions.registerUser(registration);
 
+    expect(consoleError).toHaveBeenCalledWith(loadFailureLog, loadError);
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(AuthStateVar.get()).toMatchObject({
       registerLoading: false,
       registerError: { kind: 'network', retryable: true },
@@ -99,17 +108,21 @@ describe('deferred auth actions composition root', () => {
   it('retries the load after a failure instead of caching the rejection', async () => {
     const { authActions, AuthStateVar } = await loadBarrel();
     const actions = makeActions();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const loadError = new Error('chunk load failed');
     resolveMock
       .mockImplementationOnce(() => {
-        throw new Error('chunk load failed');
+        throw loadError;
       })
       .mockReturnValue(actions);
 
     await authActions.loginUser(credentials);
     expect(AuthStateVar.get().loginError).not.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(loadFailureLog, loadError);
 
     await authActions.loginUser(credentials);
     expect(actions.login).toHaveBeenCalledWith(credentials, undefined);
     expect(resolveMock).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/modules/user/store/registration-response-mapper.test.ts
+++ b/tests/unit/modules/user/store/registration-response-mapper.test.ts
@@ -18,8 +18,13 @@ describe('RegistrationResponseMapper', () => {
   });
 
   it('returns error when response fields have wrong types', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
     const result = mapper.map({ fullName: 123, email: 456 });
 
+    expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+      issueCount: 2,
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.displayMessage).toBeTruthy();
@@ -28,8 +33,13 @@ describe('RegistrationResponseMapper', () => {
   });
 
   it('returns error when the response is null', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
     const result = mapper.map(null);
 
+    expect(consoleError).toHaveBeenCalledWith('Registration response validation failed', {
+      issueCount: 1,
+    });
     expect(result.ok).toBe(false);
   });
 });

--- a/tests/unit/routes/routes.test.tsx
+++ b/tests/unit/routes/routes.test.tsx
@@ -6,6 +6,9 @@ import { render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
 import type { ReactElement } from 'react';
 
+import router from '@/routes/routes';
+import ROUTER_FUTURE_FLAGS from '@tests/unit/utils/router-future-flags';
+
 let mockCurrentPath = '/sign-up';
 
 jest.mock('react-i18next', () => ({
@@ -21,9 +24,9 @@ jest.mock('react-router-dom', () => {
     __esModule: true,
     ...actual,
     createBrowserRouter: (routes: unknown): unknown => routes,
-    RouterProvider: ({ router }: { router: unknown }): ReactElement => {
+    RouterProvider: ({ router, future }: { router: unknown; future?: unknown }): ReactElement => {
       const mem = actual.createMemoryRouter(router, { initialEntries: [mockCurrentPath] });
-      return <actual.RouterProvider router={mem} />;
+      return <actual.RouterProvider router={mem} future={future} />;
     },
   };
 });
@@ -75,8 +78,6 @@ jest.mock('@auth/routes/sign-in', () => ({
   default: (): ReactElement => <div>sign in page</div>,
 }));
 
-import router from '@/routes/routes';
-
 describe('routes', () => {
   const RouterProvider =
     jest.requireActual<typeof import('react-router-dom')>('react-router-dom').RouterProvider;
@@ -86,7 +87,7 @@ describe('routes', () => {
     const { RouterProvider: MockedRP } = jest.requireMock('react-router-dom');
     render(
       <Suspense fallback={null}>
-        <MockedRP router={router} />
+        <MockedRP router={router} future={ROUTER_FUTURE_FLAGS} />
       </Suspense>
     );
   };

--- a/tests/unit/scripts/localization-generator.test.js
+++ b/tests/unit/scripts/localization-generator.test.js
@@ -221,6 +221,15 @@ describe('LocalizationGenerator', () => {
     });
 
     it('should handle invalid JSON gracefully', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const invalidJson = 'invalid json content';
+      let parseMessage = '';
+      try {
+        JSON.parse(invalidJson);
+      } catch (error) {
+        parseMessage = error.message;
+      }
+
       mockFs.existsSync.mockReturnValue(true);
       mockFs.readdirSync.mockReturnValue([
         { name: 'en.json', isFile: () => true },
@@ -231,11 +240,15 @@ describe('LocalizationGenerator', () => {
         if (filePath.endsWith('en.json')) {
           return JSON.stringify({ valid: 'json' });
         }
-        return 'invalid json content';
+        return invalidJson;
       });
 
       const result = generator.getLocalizationFromFolder('test/i18n');
 
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Skipping invalid JSON: ${path.join('test/i18n', 'de.json')} - ${parseMessage}`
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         en: { translation: { valid: 'json' } },
       });

--- a/tests/unit/services/https-client/fetch-https-client.test.ts
+++ b/tests/unit/services/https-client/fetch-https-client.test.ts
@@ -39,15 +39,20 @@ const createStatusOnlyResponse = (status: number): Response =>
     headers: new Headers(),
   }) as unknown as Response;
 
-const createErrorResponse = (status: number, statusText: string, url: string): Response =>
-  ({
+const createErrorResponse = (status: number, statusText: string, url: string): Response => {
+  const response = {
     ok: false,
     status,
     statusText,
     url,
     headers: new Headers(),
-    json: async () => ({}),
-  }) as unknown as Response;
+    json: async (): Promise<unknown> => ({}),
+    text: async (): Promise<string> => '',
+    clone: (): unknown => response,
+  };
+
+  return response as unknown as Response;
+};
 
 const createClient = (
   requestConfigBuilder: HttpRequestConfigBuilder = new HttpRequestConfigBuilder(),
@@ -580,53 +585,25 @@ describe('FetchHttpsClient', () => {
 
   describe('error handling', () => {
     it('should throw HttpError on 400 Bad Request', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 400,
-        statusText: 'Bad Request',
-        url: '/api/test',
-        headers: new Headers(),
-        json: async () => ({}),
-      });
+      mockFetch.mockResolvedValue(createErrorResponse(400, 'Bad Request', '/api/test'));
 
       await expect(client.get('/api/test', { schema: passthrough })).rejects.toThrow(HttpError);
     });
 
     it('should throw HttpError on 401 Unauthorized', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized',
-        url: '/api/test',
-        headers: new Headers(),
-        json: async () => ({}),
-      });
+      mockFetch.mockResolvedValue(createErrorResponse(401, 'Unauthorized', '/api/test'));
 
       await expect(client.get('/api/test', { schema: passthrough })).rejects.toThrow(HttpError);
     });
 
     it('should throw HttpError on 403 Forbidden', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 403,
-        statusText: 'Forbidden',
-        url: '/api/test',
-        headers: new Headers(),
-        json: async () => ({}),
-      });
+      mockFetch.mockResolvedValue(createErrorResponse(403, 'Forbidden', '/api/test'));
 
       await expect(client.get('/api/test', { schema: passthrough })).rejects.toThrow(HttpError);
     });
 
     it('should throw HttpError on 500 Internal Server Error', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-        url: '/api/test',
-        headers: new Headers(),
-        json: async () => ({}),
-      });
+      mockFetch.mockResolvedValue(createErrorResponse(500, 'Internal Server Error', '/api/test'));
 
       await expect(client.get('/api/test', { schema: passthrough })).rejects.toThrow(HttpError);
     });

--- a/tests/unit/services/https-client/http-error-response-parser.test.ts
+++ b/tests/unit/services/https-client/http-error-response-parser.test.ts
@@ -4,7 +4,18 @@ import { HttpError } from '@/services/https-client/http-error';
 import HttpErrorResponseParser from '@/services/https-client/http-error-response-parser';
 
 function makeResponse(ok: boolean, status: number, statusText = ''): Response {
-  return { ok, status, statusText, url: '/test', headers: new Headers() } as Response;
+  const response = {
+    ok,
+    status,
+    statusText,
+    url: '/test',
+    headers: new Headers(),
+    json: async (): Promise<unknown> => ({}),
+    text: async (): Promise<string> => '',
+    clone: (): unknown => response,
+  };
+
+  return response as unknown as Response;
 }
 
 describe('HttpErrorResponseParser', () => {
@@ -20,13 +31,8 @@ describe('HttpErrorResponseParser', () => {
 
   it('throws HttpError for a non-ok response', async () => {
     const parser = new HttpErrorResponseParser();
-    const response = {
-      ok: false,
-      status: 400,
-      statusText: 'Bad Request',
-      url: '/test',
-      headers: new Headers(),
-    } as Response;
+    const response = makeResponse(false, 400, 'Bad Request');
+
     await expect(parser.assertOk(response)).rejects.toThrow(HttpError);
   });
 

--- a/tests/unit/tooling/console-gate-fixtures.test.ts
+++ b/tests/unit/tooling/console-gate-fixtures.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import baseConfig from '../../../jest.config';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const JEST_BIN = path.join(repoRoot, 'node_modules', 'jest', 'bin', 'jest.js');
+const FIXTURE_DIR = '<rootDir>/tests/fixtures/console-gate';
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');
+
+interface FixtureRunResult {
+  status: 'passed' | 'failed';
+  message: string;
+}
+
+const runFixtureSuite = (): Map<string, FixtureRunResult> => {
+  const childConfig = {
+    ...baseConfig,
+    rootDir: repoRoot,
+    roots: [FIXTURE_DIR],
+    testMatch: [`${FIXTURE_DIR}/**/*.fixture.{ts,tsx}`],
+    collectCoverage: false,
+    coverageThreshold: undefined,
+  };
+
+  const result = spawnSync(
+    process.execPath,
+    [JEST_BIN, '--config', JSON.stringify(childConfig), '--ci', '--json'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      env: { ...process.env, TEST_ENV: 'client', CI: 'true' },
+      maxBuffer: 32 * 1024 * 1024,
+    }
+  );
+
+  const jsonStart = result.stdout.indexOf('{');
+  if (jsonStart < 0) {
+    throw new Error(`fixture jest run produced no JSON report:\n${result.stderr}`);
+  }
+
+  const report = JSON.parse(result.stdout.slice(jsonStart)) as {
+    testResults: { name: string; status: string; message: string }[];
+  };
+
+  return new Map(
+    report.testResults.map((suite) => [
+      path.basename(suite.name),
+      { status: suite.status as FixtureRunResult['status'], message: stripAnsi(suite.message) },
+    ])
+  );
+};
+
+describe('console gate seeded defects', () => {
+  let fixtures: Map<string, FixtureRunResult>;
+
+  beforeAll(() => {
+    fixtures = runFixtureSuite();
+  }, 300_000);
+
+  const fixtureResult = (name: string): FixtureRunResult => {
+    const result = fixtures.get(name);
+    if (!result) {
+      throw new Error(`fixture ${name} was not discovered by the child jest run`);
+    }
+    return result;
+  };
+
+  it('discovers every fixture', () => {
+    expect([...fixtures.keys()].sort()).toEqual([
+      'allowlisted-message.fixture.ts',
+      'emits-console-error.fixture.ts',
+      'emits-console-warn.fixture.ts',
+      'spied-console-error.fixture.ts',
+      'warns-during-cleanup.fixture.tsx',
+    ]);
+  });
+
+  it('fails a test that emits an unexpected console.error', () => {
+    const result = fixtureResult('emits-console-error.fixture.ts');
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('Expected test not to call console.error()');
+    expect(result.message).toContain('seeded console-gate defect: unexpected error output');
+  });
+
+  it('fails a test that emits an unexpected console.warn', () => {
+    const result = fixtureResult('emits-console-warn.fixture.ts');
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('Expected test not to call console.warn()');
+    expect(result.message).toContain('seeded console-gate defect: unexpected warn output');
+  });
+
+  it('fails a test whose output is emitted during testing-library cleanup', () => {
+    const result = fixtureResult('warns-during-cleanup.fixture.tsx');
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('Expected test not to call console.warn()');
+    expect(result.message).toContain('warn emitted during testing-library cleanup');
+  });
+
+  it('passes a test that spies on and asserts the expected output', () => {
+    expect(fixtureResult('spied-console-error.fixture.ts').status).toBe('passed');
+  });
+
+  it('passes allowlisted messages and ungated levels', () => {
+    expect(fixtureResult('allowlisted-message.fixture.ts').status).toBe('passed');
+  });
+});

--- a/tests/unit/tooling/console-gate-fixtures.test.ts
+++ b/tests/unit/tooling/console-gate-fixtures.test.ts
@@ -74,6 +74,7 @@ describe('console gate seeded defects', () => {
       'emits-console-error.fixture.ts',
       'emits-console-warn.fixture.ts',
       'spied-console-error.fixture.ts',
+      'unrestored-spy.fixture.ts',
       'warns-during-cleanup.fixture.tsx',
     ]);
   });
@@ -104,6 +105,15 @@ describe('console gate seeded defects', () => {
 
   it('passes a test that spies on and asserts the expected output', () => {
     expect(fixtureResult('spied-console-error.fixture.ts').status).toBe('passed');
+  });
+
+  it('re-arms after a test leaves its console spy unrestored', () => {
+    const result = fixtureResult('unrestored-spy.fixture.ts');
+
+    expect(result.status).toBe('failed');
+    expect(result.message).toContain('is still gated in the next test of the same file');
+    expect(result.message).toContain('emitted after an unrestored spy');
+    expect(result.message).not.toContain('installs a console.error spy and never restores it');
   });
 
   it('passes allowlisted messages and ungated levels', () => {

--- a/tests/unit/tooling/console-gate.test.ts
+++ b/tests/unit/tooling/console-gate.test.ts
@@ -2,7 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import CONSOLE_ALLOWLIST from '@tests/console-gate/allowlist';
-import { isConsoleAllowed } from '@tests/console-gate/install';
+import { isConsoleAllowed, isConsoleAllowedBy } from '@tests/console-gate/install';
+import type { ConsoleAllowlistEntry } from '@tests/console-gate/types/console-allowlist-entry';
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
@@ -60,10 +61,33 @@ describe('console gate wiring', () => {
 });
 
 describe('console gate allowlist discipline', () => {
-  it('anchors every pattern at both ends so an entry cannot swallow unrelated output', () => {
+  it('anchors every pattern at both ends so an entry reads as a whole-message rule', () => {
     for (const entry of CONSOLE_ALLOWLIST) {
       expect(entry.pattern.source.startsWith('^')).toBe(true);
       expect(entry.pattern.source.endsWith('$')).toBe(true);
+    }
+  });
+
+  it('matches whole messages even when an entry is only partially anchored', () => {
+    const partiallyAnchored: ConsoleAllowlistEntry[] = [
+      {
+        pattern: /^an allowed warning|swallowed$/,
+        reason: 'A deliberately broken entry: alternation binds looser than the anchors.',
+        expiresWith: { packageName: '@testing-library/react', removedInMajor: 16 },
+      },
+    ];
+
+    expect(isConsoleAllowedBy('an allowed warning', partiallyAnchored)).toBe(true);
+    expect(isConsoleAllowedBy('an allowed warning plus unrelated output', partiallyAnchored)).toBe(
+      false
+    );
+    expect(isConsoleAllowedBy('unrelated output that is swallowed', partiallyAnchored)).toBe(false);
+  });
+
+  it('never lets a stateful pattern skip a message', () => {
+    for (const entry of CONSOLE_ALLOWLIST) {
+      expect(entry.pattern.global).toBe(false);
+      expect(entry.pattern.sticky).toBe(false);
     }
   });
 

--- a/tests/unit/tooling/console-gate.test.ts
+++ b/tests/unit/tooling/console-gate.test.ts
@@ -60,10 +60,23 @@ describe('console gate wiring', () => {
 });
 
 describe('console gate allowlist discipline', () => {
-  it('anchors every pattern so an entry cannot swallow unrelated output', () => {
+  it('anchors every pattern at both ends so an entry cannot swallow unrelated output', () => {
     for (const entry of CONSOLE_ALLOWLIST) {
       expect(entry.pattern.source.startsWith('^')).toBe(true);
+      expect(entry.pattern.source.endsWith('$')).toBe(true);
     }
+  });
+
+  it('rejects an allowlisted message that carries unrelated trailing output', () => {
+    const rtlActDeprecation = [
+      'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
+      'Import `act` from `react` instead of `react-dom/test-utils`.',
+      'See https://react.dev/warnings/react-dom-test-utils for more info.',
+    ].join(' ');
+
+    expect(
+      isConsoleAllowed(`${rtlActDeprecation} Warning: Each child in a list needs a key.`)
+    ).toBe(false);
   });
 
   it('documents why every entry exists', () => {
@@ -100,6 +113,7 @@ describe('console gate allowlist discipline', () => {
     const rtlActDeprecation = [
       'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
       'Import `act` from `react` instead of `react-dom/test-utils`.',
+      'See https://react.dev/warnings/react-dom-test-utils for more info.',
     ].join(' ');
 
     expect(isConsoleAllowed(rtlActDeprecation)).toBe(true);

--- a/tests/unit/tooling/console-gate.test.ts
+++ b/tests/unit/tooling/console-gate.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import path from 'path';
+
+import CONSOLE_ALLOWLIST from '@tests/console-gate/allowlist';
+import { isConsoleAllowed } from '@tests/console-gate/install';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+const readRepoFile = (relativePath: string): string =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf-8');
+
+const packageJson = JSON.parse(readRepoFile('package.json')) as {
+  devDependencies: Record<string, string>;
+};
+
+const declaredMajor = (packageName: string): number => {
+  const range = packageJson.devDependencies[packageName];
+  expect(range).toBeDefined();
+  const major = /(\d+)/.exec(range as string)?.[1];
+  expect(major).toBeDefined();
+  return Number(major);
+};
+
+describe('console gate wiring', () => {
+  it.each([
+    ['jest.setup.ts', 'installConsoleGate()'],
+    ['tests/integration/setup.ts', 'installConsoleGate()'],
+    ['tests/mutation/setup.ts', 'installConsoleGate()'],
+    ['tests/apollo-server/setup.ts', 'installConsoleGate({ failOnWarn: false })'],
+  ])('installs the gate in %s', (setupFile, expectedCall) => {
+    const source = readRepoFile(setupFile);
+
+    expect(source).toContain('console-gate/install');
+    expect(source).toContain(expectedCall);
+  });
+
+  it('wires every setup file jest.config.ts can select into setupFilesAfterEach', () => {
+    const jestConfig = readRepoFile('jest.config.ts');
+
+    expect(jestConfig).toContain('<rootDir>/tests/integration/setup.ts');
+    expect(jestConfig).toContain('<rootDir>/tests/apollo-server/setup.ts');
+    expect(jestConfig).toContain('<rootDir>/jest.setup.ts');
+    expect(readRepoFile('jest.mutation.config.ts')).toContain('<rootDir>/tests/mutation/setup.ts');
+  });
+
+  it('fails on error everywhere and on warn everywhere but the node server', () => {
+    const install = readRepoFile('tests/console-gate/install.ts');
+
+    expect(install).toContain('shouldFailOnError: true');
+    expect(install).toContain('shouldFailOnWarn: failOnWarn');
+    expect(install).toContain('failOnWarn = true');
+  });
+
+  it.each(['shouldFailOnLog', 'shouldFailOnInfo', 'shouldFailOnDebug', 'shouldFailOnAssert'])(
+    'leaves %s at its ungated default',
+    (option) => {
+      expect(readRepoFile('tests/console-gate/install.ts')).not.toContain(option);
+    }
+  );
+});
+
+describe('console gate allowlist discipline', () => {
+  it('anchors every pattern so an entry cannot swallow unrelated output', () => {
+    for (const entry of CONSOLE_ALLOWLIST) {
+      expect(entry.pattern.source.startsWith('^')).toBe(true);
+    }
+  });
+
+  it('documents why every entry exists', () => {
+    for (const entry of CONSOLE_ALLOWLIST) {
+      expect(entry.reason.trim().length).toBeGreaterThanOrEqual(40);
+    }
+  });
+
+  it('expires every entry against a declared dependency so it cannot outlive its cause', () => {
+    for (const entry of CONSOLE_ALLOWLIST) {
+      const { packageName, removedInMajor } = entry.expiresWith;
+
+      expect(packageJson.devDependencies[packageName]).toBeDefined();
+      expect(declaredMajor(packageName)).toBeLessThan(removedInMajor);
+    }
+  });
+
+  it('never allows a React warning that signals a real defect', () => {
+    const realDefects = [
+      'Warning: Each child in a list should have a unique "key" prop.',
+      'Warning: An update to TestComponent inside a test was not wrapped in act(...).',
+      'Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.',
+      'Warning: Failed prop type: The prop `value` is marked as required.',
+      'react-i18next:: You will need to pass in an i18next instance by using initReactI18next',
+      '⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates',
+    ];
+
+    for (const message of realDefects) {
+      expect(isConsoleAllowed(message)).toBe(false);
+    }
+  });
+
+  it('allows exactly the deprecation the pinned @testing-library/react emits', () => {
+    const rtlActDeprecation = [
+      'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
+      'Import `act` from `react` instead of `react-dom/test-utils`.',
+    ].join(' ');
+
+    expect(isConsoleAllowed(rtlActDeprecation)).toBe(true);
+  });
+});

--- a/tests/unit/utils/render-with-providers.tsx
+++ b/tests/unit/utils/render-with-providers.tsx
@@ -1,23 +1,15 @@
 import { ThemeProvider, createTheme, Theme } from '@mui/material/styles';
 import { render, RenderResult } from '@testing-library/react';
-import i18n, { i18n as I18nType } from 'i18next';
+import type { i18n as I18nType } from 'i18next';
 import React from 'react';
-import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 
-import enTranslations from '@/i18n/localization.json';
+import testI18n from '@tests/i18n/test-i18n';
 
-export const testI18n = i18n.createInstance();
+import ROUTER_FUTURE_FLAGS from './router-future-flags';
 
-testI18n.use(initReactI18next).init({
-  lng: 'en',
-  fallbackLng: 'en',
-  resources: {
-    en: { translation: enTranslations.en.translation },
-  },
-  interpolation: { escapeValue: false },
-  initImmediate: false, // synchronous init
-});
+export { testI18n };
 
 export const testTheme = createTheme({
   spacing: 8,
@@ -44,7 +36,7 @@ const renderWithProviders = (
   { theme = testTheme, i18nMock = testI18n }: RenderOptions = {}
 ): RenderResult =>
   render(
-    <MemoryRouter>
+    <MemoryRouter future={ROUTER_FUTURE_FLAGS}>
       <ThemeProvider theme={theme}>
         <I18nextProvider i18n={i18nMock}>{component}</I18nextProvider>
       </ThemeProvider>

--- a/tests/unit/utils/router-future-flags.ts
+++ b/tests/unit/utils/router-future-flags.ts
@@ -1,0 +1,6 @@
+export const ROUTER_FUTURE_FLAGS = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: false,
+} as const;
+
+export default ROUTER_FUTURE_FLAGS;


### PR DESCRIPTION
Placeholder — body set after push (cubic regenerates on push).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail Jest tests on unexpected `console.error`/`console.warn` by wiring `jest-fail-on-console` across all setups, closing #192. Adds a strict, whole‑message allowlist with expiry; tests now await updates or spy-and-assert intentional logs.

- **New Features**
  - Install `installConsoleGate()` in `jest.setup.ts`, `tests/integration/setup.ts`, and `tests/mutation/setup.ts` (error+warn), and in `tests/apollo-server/setup.ts` (error-only); leave `log`/`info`/`debug` ungated.
  - Make the allowlist strict: entries are `^...$`-anchored with reasons and `expiresWith`, and the boundary is enforced in code via full‑message matches (strips `g`/`y` flags). Tests pin partially anchored cases and expiry; a child‑Jest suite proves failures on unexpected error/warn (including during cleanup), success on spied‑and‑asserted calls, and ignores for `log`/`info`/`debug`.
  - Import `@testing-library/react` in setups so cleanup runs before the gate; add a shared test `i18n` instance so specs assert localized names.

- **Bug Fixes**
  - Eliminate real React warnings by awaiting updates/using `act()`, opt test routers into v7 future flags via `ROUTER_FUTURE_FLAGS`, and forward `future` through RouterProvider mocks.
  - Make network error assertions stable by matching `POST <url>`; assert exact console call counts where logs are expected.
  - Harden `fetch` Response mocks with `clone()`/`text()` to avoid parser warnings; move the faker seed notice to `process.stdout.write`.
  - Restore branch coverage by only passing `disableAnimation` when needed and asserting the region via its localized name.

<sup>Written for commit 06621482bf70766edcbf9d1f8308d8282db6a620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

