### PR TITLE
feat(#155): add locale-aware Intl formatting layer with LocaleFormatter service and ESLint gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,8 +642,8 @@ Localization files are auto-generated during build:
 - Generated via `scripts/localization-generator.js`
 - Skip generation: `SKIP_LOCALE_GEN=1`
 
-Dates, numbers, currency, and relative time are rendered through the locale-aware
-formatting layer (issue #155): `src/i18n.js` registers the `date`, `datetime`, `number`,
+Dates, numbers, currency, percentages, and relative time are rendered through the
+locale-aware formatting layer (issue #155): `src/i18n.js` registers the `date`, `datetime`, `number`,
 `currency`, `percent`, and `relativetime` i18next formatters, so translation strings use
 `{{value, datetime}}` / `{{value, currency}}`, and non-translation code uses the
 `LocaleFormatter` service. See "Important Patterns" item 10 for the full convention and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,6 +642,13 @@ Localization files are auto-generated during build:
 - Generated via `scripts/localization-generator.js`
 - Skip generation: `SKIP_LOCALE_GEN=1`
 
+Dates, numbers, currency, and relative time are rendered through the locale-aware
+formatting layer (issue #155): `src/i18n.js` registers the `date`, `datetime`, `number`,
+`currency`, `percent`, and `relativetime` i18next formatters, so translation strings use
+`{{value, datetime}}` / `{{value, currency}}`, and non-translation code uses the
+`LocaleFormatter` service. See "Important Patterns" item 10 for the full convention and
+its ESLint gate.
+
 ## Storybook
 
 ```bash
@@ -803,6 +810,31 @@ Key variables in `.env`:
    in Sentry `beforeSend`; identity is a random opaque session id only — no PII. All capture paths
    are wrapped so telemetry failure never breaks a user flow. Do not scatter direct
    `@sentry/react` calls across feature modules; consume telemetry through this boundary.
+
+10. **Locale-aware Intl formatting (issue #155)**: All user-facing dates, numbers,
+    currency amounts, percentages, and relative times are formatted through the
+    `LocaleFormatter` boundary in `src/services/locale-formatter/` — never with raw
+    `toLocaleString()` variants or ad-hoc `new Intl.*Format(...)` at call sites. Like
+    observability (pattern 9), it has two layers: (a) the container-free
+    `localeFormatterCore` singleton (cached `Intl.DateTimeFormat`, `Intl.NumberFormat`
+    for decimal/currency/percent, and `Intl.RelativeTimeFormat` instances keyed by
+    locale + options, resolving the locale from the active i18next language and falling
+    back to `rawEnv.mainLanguage()`), consumed on the paint path by `src/i18n.js`, which
+    registers the `date`, `datetime`, `number`, `currency`, `percent`, and
+    `relativetime` i18next formatters so translation strings can use
+    `{{value, datetime}}` / `{{value, currency}}`; and (b) an `@injectable()`
+    `LocaleFormatterService` adapter (token
+    `LOCALE_FORMATTER_TOKENS.LocaleFormatterService`, registered by its own
+    `di.ts` composition root per issue #109). Defaults: medium date style, short time
+    style, `UAH` with a narrow symbol, `numeric: 'auto'` relative time. An ESLint
+    `no-restricted-syntax` gate in `eslint.config.mjs` (the `noRawIntlSelectors`
+    array, scoped to `src/**` and lifted only inside
+    `src/services/locale-formatter/`) fails the build on raw `toLocale*` calls and
+    `Intl.*` member access; it runs in `make lint-eslint` and the `static testing`
+    workflow. Unit and integration tests pin exact uk/en outputs (e.g. `1234.5` →
+    `1 234,50 ₴` vs `₴1,234.50`), so locale regressions fail CI. Satisfy the gate by
+    routing through the formatter service — never with `eslint-disable`. See the
+    "Locale-aware Intl formatting" section in `agents.md` for the full convention.
 
 ## Node Version Management
 

--- a/agents.md
+++ b/agents.md
@@ -684,6 +684,10 @@ const { t } = useTranslation();
 <h1>{t('login.title')}</h1>
 ```
 
+Dates, numbers, and currency inside translations use the registered i18next formatters
+(`{{value, datetime}}`, `{{value, currency}}`) instead of pre-formatted strings — see
+"Locale-aware Intl formatting (issue #155)" under Architecture Patterns.
+
 ## Architecture Patterns
 
 ### No static methods or free functions (issues #100, #89)
@@ -719,6 +723,49 @@ superseded — dep-cruiser reasons about the import graph, not whether a module'
 classes, and the blanket ESLint ban is stricter than the helper-zone carve-out #89 sketched.
 Per #89's "honest limitation", the residual gap is **semantic** (logic hidden in an object
 literal's methods or a misplaced helper) and stays a review-gate concern.
+
+### Locale-aware Intl formatting (issue #155)
+
+The template is bilingual (uk primary, en fallback), so every user-facing date, number,
+currency amount, percentage, and relative time renders through one locale-aware boundary —
+`src/services/locale-formatter/` — never through raw `toLocaleString()` /
+`toLocaleDateString()` / `toLocaleTimeString()` calls or ad-hoc `new Intl.*Format(...)`
+construction at call sites. Scattered call-site construction drifts locales (en-US defaults
+under a uk primary locale), defeats formatter caching, and makes output impossible to pin in
+tests.
+
+How to format, by context:
+
+- **Translation strings** → use the i18next formatters registered in `src/i18n.js`
+  (`date`, `datetime`, `number`, `currency`, `percent`, `relativetime`):
+  `"updated_at": "Last updated {{value, datetime}}"`, `"price": "Price: {{value, currency}}"`
+  (see `src/features/example/i18n/`). Components pass the raw value:
+  `t('formatting.updated_at', { value: new Date(timestamp) })`.
+- **Non-translation logic (services, repositories, stores)** → inject the
+  `@injectable()` `LocaleFormatterService` adapter via
+  `LOCALE_FORMATTER_TOKENS.LocaleFormatterService` (its own `di.ts` composition root,
+  issue #109) and call `date` / `dateTime` / `number` / `currency` / `percent` /
+  `relativeTime`.
+- **Paint-path / container-free code** → import the `localeFormatterCore` module
+  singleton from `@/services/locale-formatter/locale-formatter-core` (the same two-layer
+  split as observability: the core is tsyringe-free, so `src/i18n.js` stays light).
+
+The core caches `Intl.DateTimeFormat`, `Intl.NumberFormat` (decimal, currency, percent),
+and `Intl.RelativeTimeFormat` instances keyed by locale + options, and resolves the locale
+as: explicit argument → active i18next language → `rawEnv.mainLanguage()` (default `uk`).
+Presets: medium date style, short time style, `UAH` with a narrow symbol (`currency` takes
+an optional ISO 4217 code), `numeric: 'auto'` relative time. Extend the service with a new
+preset instead of passing one-off options at call sites.
+
+Enforced by an ESLint `no-restricted-syntax` gate in `eslint.config.mjs`
+(`noRawIntlSelectors`, re-included in every overlapping block that carries the shared
+selector spreads — the type-only-file override forbids all runtime syntax, so it needs no
+Intl selectors — and lifted only inside `src/services/locale-formatter/`), run by
+`make lint-eslint` and the `static testing`
+workflow. Tests are exempt — they construct `Intl` formatters freely and pin **exact**
+uk/en outputs as fixed contracts (hardcoded literals per the Faker convention, e.g.
+`1234.5` → `1 234,50 ₴` (uk, U+00A0 separators) vs `₴1,234.50` (en)). Fix violations by
+routing through the formatter — never with `eslint-disable`.
 
 ### Dependency Injection Pattern
 

--- a/agents.md
+++ b/agents.md
@@ -684,8 +684,9 @@ const { t } = useTranslation();
 <h1>{t('login.title')}</h1>
 ```
 
-Dates, numbers, and currency inside translations use the registered i18next formatters
-(`{{value, datetime}}`, `{{value, currency}}`) instead of pre-formatted strings — see
+Dates, numbers, currency, percentages, and relative time inside translations use the
+registered i18next formatters (`{{value, datetime}}`, `{{value, currency}}`,
+`{{value, percent}}`, `{{value, relativetime}}`) instead of pre-formatted strings — see
 "Locale-aware Intl formatting (issue #155)" under Architecture Patterns.
 
 ## Architecture Patterns

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -158,6 +158,36 @@ const noProcessEnvSelectors = [
   },
 ];
 
+// Source (issue #155): locale-sensitive rendering must go through the LocaleFormatter
+// service (src/services/locale-formatter/) or the i18next formatters registered in
+// src/i18n.js — never ad-hoc `Intl.*` construction or `toLocale*` calls at call sites.
+// The service caches formatter instances and keys the locale off the active i18next
+// language; scattered call-site construction drifts locales and defeats that cache.
+// Re-included in every overlapping block because flat config replaces `no-restricted-syntax`.
+const noRawIntlSelectors = [
+  {
+    selector: 'CallExpression[callee.property.name=/^toLocale(String|DateString|TimeString)$/]',
+    message:
+      'No raw toLocale* formatting — use the LocaleFormatter service ' +
+      '(@/services/locale-formatter) or an i18next formatter such as ' +
+      '{{value, datetime}} (issue #155).',
+  },
+  {
+    selector: 'CallExpression[callee.property.value=/^toLocale(String|DateString|TimeString)$/]',
+    message:
+      'No raw toLocale* formatting via computed access — use the LocaleFormatter service ' +
+      '(@/services/locale-formatter) or an i18next formatter such as ' +
+      '{{value, datetime}} (issue #155).',
+  },
+  {
+    selector: "MemberExpression[object.name='Intl']",
+    message:
+      'No ad-hoc Intl formatter construction — use the LocaleFormatter service ' +
+      '(@/services/locale-formatter) or an i18next formatter such as ' +
+      '{{value, currency}} (issue #155).',
+  },
+];
+
 const nonReactSourceGlobs = ['src/**/*.ts'];
 const nonReactSourceIgnores = [
   '**/*.stories.*',
@@ -394,10 +424,12 @@ export default [
     },
   },
 
-  // Source: production source must not ship `data-testid` (issue #90), and logic
+  // Source: production source must not ship `data-testid` (issue #90), logic
   // files must not declare types — types live in dedicated type-only files:
-  // `types.ts` or the per-feature/area `types/**` folders (issue #88). Stories/tests/`.d.ts`
-  // and the type-only files (governed by the separate override below) are excluded.
+  // `types.ts` or the per-feature/area `types/**` folders (issue #88) — and locale-sensitive
+  // rendering must go through the LocaleFormatter service, never raw `Intl`/`toLocale*`
+  // (issue #155). Stories/tests/`.d.ts` and the type-only files (governed by the separate
+  // override below) are excluded.
   {
     files: ['src/**/*.ts', 'src/**/*.tsx', 'src/**/*.js', 'src/**/*.jsx'],
     ignores: [
@@ -410,7 +442,12 @@ export default [
       'src/**/types/**/*.tsx',
     ],
     rules: {
-      'no-restricted-syntax': ['error', ...dataTestidSelectors, ...typeDeclarationSelectors],
+      'no-restricted-syntax': [
+        'error',
+        ...dataTestidSelectors,
+        ...typeDeclarationSelectors,
+        ...noRawIntlSelectors,
+      ],
     },
   },
 
@@ -467,9 +504,10 @@ export default [
   // Source (issue #100): forbid `static` members and standalone functions in non-React
   // application code. This block matches `src/**/*.ts` only (so `.tsx` components and
   // class error boundaries are exempt) and ignores `use-*` hook files plus the type-only
-  // files (governed by the override above). It re-includes the data-testid (#90) and
-  // type-declaration (#88) selectors because flat config replaces (does not merge)
-  // `no-restricted-syntax` for files matched by multiple blocks.
+  // files (governed by the override above). It re-includes the data-testid (#90),
+  // type-declaration (#88), process.env (#112), and raw-Intl (#155) selectors because
+  // flat config replaces (does not merge) `no-restricted-syntax` for files matched by
+  // multiple blocks.
   {
     files: nonReactSourceGlobs,
     ignores: nonReactSourceIgnores,
@@ -480,14 +518,16 @@ export default [
         ...noStaticOrFreeFunctionSelectors,
         ...typeDeclarationSelectors,
         ...noProcessEnvSelectors,
+        ...noRawIntlSelectors,
       ],
     },
   },
 
   // Source (issue #112): the `src/config/env/**` module IS the sanctioned boundary that
-  // reads `process.env`, so the process.env ban is lifted here. The #90/#88/#100 selectors
-  // are re-included (flat config replaces, does not merge). Ordered after the non-React `.ts`
-  // block so it wins for env files; env type-only files stay governed by the override above.
+  // reads `process.env`, so the process.env ban is lifted here. The #90/#88/#100/#155
+  // selectors are re-included (flat config replaces, does not merge). Ordered after the
+  // non-React `.ts` block so it wins for env files; env type-only files stay governed by
+  // the override above.
   {
     files: ['src/config/env/**/*.ts'],
     ignores: [
@@ -504,13 +544,35 @@ export default [
         ...dataTestidSelectors,
         ...noStaticOrFreeFunctionSelectors,
         ...typeDeclarationSelectors,
+        ...noRawIntlSelectors,
+      ],
+    },
+  },
+
+  // Source (issue #155): the `src/services/locale-formatter/**` service IS the sanctioned
+  // Intl boundary, so the raw-Intl ban is lifted here (and only here). Every other selector
+  // — #90, #100, #88, #112 — is re-included (flat config replaces, does not merge). Ordered
+  // after the non-React `.ts` block so it wins for the formatter's files; the formatter's
+  // contract types live under `src/services/types/` and stay governed by the type-only
+  // override above.
+  {
+    files: ['src/services/locale-formatter/**/*.ts'],
+    ignores: ['**/*.stories.*', '**/*.test.*', '**/*.spec.*', '**/*.d.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...dataTestidSelectors,
+        ...noStaticOrFreeFunctionSelectors,
+        ...typeDeclarationSelectors,
+        ...noProcessEnvSelectors,
       ],
     },
   },
 
   // Source (issue #112): React hooks (`src/**/use-*.ts`) are exempt from the #100 no-free-function
   // rule (they are functions), so the non-React `.ts` block above ignores them — but they must
-  // still not read raw `process.env`. Re-include the #90/#88 selectors plus the process.env ban.
+  // still not read raw `process.env` or construct raw Intl formatters. Re-include the #90/#88
+  // selectors plus the process.env (#112) and raw-Intl (#155) bans.
   {
     files: ['src/**/use-*.ts'],
     ignores: [
@@ -527,6 +589,7 @@ export default [
         ...dataTestidSelectors,
         ...typeDeclarationSelectors,
         ...noProcessEnvSelectors,
+        ...noRawIntlSelectors,
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -182,9 +182,10 @@ const noRawIntlSelectors = [
   {
     selector: "MemberExpression[object.name='Intl']",
     message:
-      'No ad-hoc Intl formatter construction — use the LocaleFormatter service ' +
+      'No raw Intl.* usage — use the LocaleFormatter service ' +
       '(@/services/locale-formatter) or an i18next formatter such as ' +
-      '{{value, currency}} (issue #155).',
+      '{{value, currency}}, extending the service when it lacks a needed ' +
+      'Intl capability (issue #155).',
   },
 ];
 
@@ -557,7 +558,14 @@ export default [
   // override above.
   {
     files: ['src/services/locale-formatter/**/*.ts'],
-    ignores: ['**/*.stories.*', '**/*.test.*', '**/*.spec.*', '**/*.d.ts'],
+    ignores: [
+      '**/*.stories.*',
+      '**/*.test.*',
+      '**/*.spec.*',
+      '**/*.d.ts',
+      'src/services/locale-formatter/**/types.ts',
+      'src/services/locale-formatter/**/types/**/*.ts',
+    ],
     rules: {
       'no-restricted-syntax': [
         'error',

--- a/src/config/dependency-injection-config.ts
+++ b/src/config/dependency-injection-config.ts
@@ -7,6 +7,7 @@ import userModuleRegistrar from '@/modules/user/config/di';
 import errorRegistrar from '@/services/error/di';
 import errorReportingRegistrar from '@/services/error-reporting/di';
 import httpClientRegistrar from '@/services/https-client/di';
+import localeFormatterRegistrar from '@/services/locale-formatter/di';
 import observabilityRegistrar from '@/services/observability/di';
 import errorUtilsRegistrar from '@/utils/error/di';
 
@@ -15,6 +16,7 @@ const registrars: ModuleRegistrar[] = [
   errorRegistrar,
   errorReportingRegistrar,
   httpClientRegistrar,
+  localeFormatterRegistrar,
   observabilityRegistrar,
   userModuleRegistrar,
 ];

--- a/src/config/env/raw-env.ts
+++ b/src/config/env/raw-env.ts
@@ -1,4 +1,8 @@
 class RawEnv {
+  public mainLanguage(): string {
+    return this.trimmed(process.env.REACT_APP_MAIN_LANGUAGE) ?? 'uk';
+  }
+
   public mockoonUrl(): string {
     return this.trimmed(process.env.REACT_APP_MOCKOON_URL) ?? '';
   }

--- a/src/features/example/i18n/en.json
+++ b/src/features/example/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "login": {
+    "title": "Authentication",
+    "info_desc": "Sign in to your account in two clicks"
+  },
+  "formatting": {
+    "updated_at": "Last updated {{value, datetime}}",
+    "price": "Price: {{value, currency}}"
+  }
+}

--- a/src/features/example/i18n/uk.json
+++ b/src/features/example/i18n/uk.json
@@ -2,5 +2,9 @@
   "login": {
     "title": "Автентифікація",
     "info_desc": "Увійдіть до свого аккаунту за два кліки"
+  },
+  "formatting": {
+    "updated_at": "Оновлено {{value, datetime}}",
+    "price": "Ціна: {{value, currency}}"
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,6 +2,7 @@ const i18n = require('i18next');
 const { initReactI18next } = require('react-i18next');
 
 const localization = require('./i18n/localization.json');
+const { default: localeFormatter } = require('./services/locale-formatter/locale-formatter-core');
 
 const MAIN_LANGUAGE = process.env.REACT_APP_MAIN_LANGUAGE || 'uk';
 const FALLBACK_LANGUAGE = process.env.REACT_APP_FALLBACK_LANGUAGE || 'en';
@@ -14,5 +15,16 @@ i18n.use(initReactI18next).init({
     escapeValue: false,
   },
 });
+
+i18n.services.formatter.add('date', (value, lng) => localeFormatter.date(value, lng));
+i18n.services.formatter.add('datetime', (value, lng) => localeFormatter.dateTime(value, lng));
+i18n.services.formatter.add('number', (value, lng) => localeFormatter.number(value, lng));
+i18n.services.formatter.add('currency', (value, lng, options) =>
+  localeFormatter.currency(value, options.currency, lng)
+);
+i18n.services.formatter.add('percent', (value, lng) => localeFormatter.percent(value, lng));
+i18n.services.formatter.add('relativetime', (value, lng, options) =>
+  localeFormatter.relativeTime(value, options.range || 'day', lng)
+);
 
 export default i18n;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,10 +2,11 @@ const i18n = require('i18next');
 const { initReactI18next } = require('react-i18next');
 
 const localization = require('./i18n/localization.json');
+const { default: rawEnv } = require('./config/env/raw-env');
 const { default: localeFormatter } = require('./services/locale-formatter/locale-formatter-core');
 
-const MAIN_LANGUAGE = process.env.REACT_APP_MAIN_LANGUAGE || 'uk';
-const FALLBACK_LANGUAGE = process.env.REACT_APP_FALLBACK_LANGUAGE || 'en';
+const MAIN_LANGUAGE = rawEnv.mainLanguage();
+const FALLBACK_LANGUAGE = (process.env.REACT_APP_FALLBACK_LANGUAGE || '').trim() || 'en';
 
 i18n.use(initReactI18next).init({
   resources: localization,
@@ -15,6 +16,8 @@ i18n.use(initReactI18next).init({
     escapeValue: false,
   },
 });
+
+localeFormatter.bindLanguageSource(i18n);
 
 i18n.services.formatter.add('date', (value, lng) => localeFormatter.date(value, lng));
 i18n.services.formatter.add('datetime', (value, lng) => localeFormatter.dateTime(value, lng));

--- a/src/i18n/localization.json
+++ b/src/i18n/localization.json
@@ -9,6 +9,14 @@
       "route_fallback": {
         "loading": "Loading page"
       },
+      "login": {
+        "title": "Authentication",
+        "info_desc": "Sign in to your account in two clicks"
+      },
+      "formatting": {
+        "updated_at": "Last updated {{value, datetime}}",
+        "price": "Price: {{value, currency}}"
+      },
       "root_element_missing": "Root element not found",
       "buttons": {
         "back_to_main": "Back to homepage"
@@ -155,6 +163,10 @@
       "login": {
         "title": "Автентифікація",
         "info_desc": "Увійдіть до свого аккаунту за два кліки"
+      },
+      "formatting": {
+        "updated_at": "Оновлено {{value, datetime}}",
+        "price": "Ціна: {{value, currency}}"
       },
       "root_element_missing": "Кореневий елемент не знайдено",
       "buttons": {

--- a/src/services/locale-formatter/di.ts
+++ b/src/services/locale-formatter/di.ts
@@ -1,0 +1,17 @@
+import type { DependencyContainer } from 'tsyringe';
+
+import type { ModuleRegistrar } from '@/config/types/module-registrar';
+
+import LocaleFormatterService from './locale-formatter-service';
+import LOCALE_FORMATTER_TOKENS from './tokens';
+
+class LocaleFormatterRegistrar implements ModuleRegistrar {
+  public register(container: DependencyContainer): void {
+    container.registerSingleton(
+      LOCALE_FORMATTER_TOKENS.LocaleFormatterService,
+      LocaleFormatterService
+    );
+  }
+}
+
+export default new LocaleFormatterRegistrar();

--- a/src/services/locale-formatter/intl-formatter-cache.ts
+++ b/src/services/locale-formatter/intl-formatter-cache.ts
@@ -1,0 +1,48 @@
+export class IntlFormatterCache {
+  private readonly dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+  private readonly numberFormatters = new Map<string, Intl.NumberFormat>();
+
+  private readonly relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+  public dateTime(locale: string, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+    return this.remember(
+      this.dateTimeFormatters,
+      this.keyFor(locale, options),
+      (): Intl.DateTimeFormat => new Intl.DateTimeFormat(locale, options)
+    );
+  }
+
+  public number(locale: string, options: Intl.NumberFormatOptions): Intl.NumberFormat {
+    return this.remember(
+      this.numberFormatters,
+      this.keyFor(locale, options),
+      (): Intl.NumberFormat => new Intl.NumberFormat(locale, options)
+    );
+  }
+
+  public relativeTime(
+    locale: string,
+    options: Intl.RelativeTimeFormatOptions
+  ): Intl.RelativeTimeFormat {
+    return this.remember(
+      this.relativeTimeFormatters,
+      this.keyFor(locale, options),
+      (): Intl.RelativeTimeFormat => new Intl.RelativeTimeFormat(locale, options)
+    );
+  }
+
+  private keyFor(locale: string, options: object): string {
+    return `${locale}:${JSON.stringify(options)}`;
+  }
+
+  private remember<T>(store: Map<string, T>, key: string, create: () => T): T {
+    const cached = store.get(key);
+    if (cached) {
+      return cached;
+    }
+    const created = create();
+    store.set(key, created);
+    return created;
+  }
+}

--- a/src/services/locale-formatter/locale-formatter-core.ts
+++ b/src/services/locale-formatter/locale-formatter-core.ts
@@ -27,7 +27,7 @@ export class LocaleFormatterCore implements LocaleFormatter {
 
   private languageSource: LanguageSource | null = null;
 
-  public bindLanguageSource(source: LanguageSource): void {
+  public bindLanguageSource(source: LanguageSource | null): void {
     this.languageSource = source;
   }
 

--- a/src/services/locale-formatter/locale-formatter-core.ts
+++ b/src/services/locale-formatter/locale-formatter-core.ts
@@ -1,0 +1,65 @@
+import i18next from 'i18next';
+
+import rawEnv from '@/config/env/raw-env';
+import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
+
+import { IntlFormatterCache } from './intl-formatter-cache';
+
+export class LocaleFormatterCore implements LocaleFormatter {
+  private readonly cache = new IntlFormatterCache();
+
+  private readonly dateOptions: Intl.DateTimeFormatOptions = { dateStyle: 'medium' };
+
+  private readonly dateTimeOptions: Intl.DateTimeFormatOptions = {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  };
+
+  private readonly decimalOptions: Intl.NumberFormatOptions = {};
+
+  private readonly percentOptions: Intl.NumberFormatOptions = {
+    style: 'percent',
+    maximumFractionDigits: 1,
+  };
+
+  private readonly relativeTimeOptions: Intl.RelativeTimeFormatOptions = { numeric: 'auto' };
+
+  public date(value: Date | number, locale?: string): string {
+    return this.cache.dateTime(this.resolveLocale(locale), this.dateOptions).format(value);
+  }
+
+  public dateTime(value: Date | number, locale?: string): string {
+    return this.cache.dateTime(this.resolveLocale(locale), this.dateTimeOptions).format(value);
+  }
+
+  public number(value: number, locale?: string): string {
+    return this.cache.number(this.resolveLocale(locale), this.decimalOptions).format(value);
+  }
+
+  public currency(value: number, currencyCode = 'UAH', locale?: string): string {
+    const options: Intl.NumberFormatOptions = {
+      style: 'currency',
+      currency: currencyCode,
+      currencyDisplay: 'narrowSymbol',
+    };
+    return this.cache.number(this.resolveLocale(locale), options).format(value);
+  }
+
+  public percent(value: number, locale?: string): string {
+    return this.cache.number(this.resolveLocale(locale), this.percentOptions).format(value);
+  }
+
+  public relativeTime(value: number, unit: Intl.RelativeTimeFormatUnit, locale?: string): string {
+    return this.cache
+      .relativeTime(this.resolveLocale(locale), this.relativeTimeOptions)
+      .format(value, unit);
+  }
+
+  private resolveLocale(locale?: string): string {
+    return locale ?? i18next.language ?? rawEnv.mainLanguage();
+  }
+}
+
+const localeFormatterCore = new LocaleFormatterCore();
+
+export default localeFormatterCore;

--- a/src/services/locale-formatter/locale-formatter-core.ts
+++ b/src/services/locale-formatter/locale-formatter-core.ts
@@ -1,7 +1,8 @@
-import i18next from 'i18next';
-
 import rawEnv from '@/config/env/raw-env';
-import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
+import type {
+  LanguageSource,
+  LocaleFormatter,
+} from '@/services/types/locale-formatter/locale-formatter';
 
 import { IntlFormatterCache } from './intl-formatter-cache';
 
@@ -23,6 +24,12 @@ export class LocaleFormatterCore implements LocaleFormatter {
   };
 
   private readonly relativeTimeOptions: Intl.RelativeTimeFormatOptions = { numeric: 'auto' };
+
+  private languageSource: LanguageSource | null = null;
+
+  public bindLanguageSource(source: LanguageSource): void {
+    this.languageSource = source;
+  }
 
   public date(value: Date | number, locale?: string): string {
     return this.cache.dateTime(this.resolveLocale(locale), this.dateOptions).format(value);
@@ -56,7 +63,7 @@ export class LocaleFormatterCore implements LocaleFormatter {
   }
 
   private resolveLocale(locale?: string): string {
-    return locale ?? i18next.language ?? rawEnv.mainLanguage();
+    return locale ?? this.languageSource?.language ?? rawEnv.mainLanguage();
   }
 }
 

--- a/src/services/locale-formatter/locale-formatter-service.ts
+++ b/src/services/locale-formatter/locale-formatter-service.ts
@@ -1,0 +1,32 @@
+import { injectable } from 'tsyringe';
+
+import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
+
+import localeFormatterCore from './locale-formatter-core';
+
+@injectable()
+export default class LocaleFormatterService implements LocaleFormatter {
+  public date(value: Date | number, locale?: string): string {
+    return localeFormatterCore.date(value, locale);
+  }
+
+  public dateTime(value: Date | number, locale?: string): string {
+    return localeFormatterCore.dateTime(value, locale);
+  }
+
+  public number(value: number, locale?: string): string {
+    return localeFormatterCore.number(value, locale);
+  }
+
+  public currency(value: number, currencyCode?: string, locale?: string): string {
+    return localeFormatterCore.currency(value, currencyCode, locale);
+  }
+
+  public percent(value: number, locale?: string): string {
+    return localeFormatterCore.percent(value, locale);
+  }
+
+  public relativeTime(value: number, unit: Intl.RelativeTimeFormatUnit, locale?: string): string {
+    return localeFormatterCore.relativeTime(value, unit, locale);
+  }
+}

--- a/src/services/locale-formatter/tokens.ts
+++ b/src/services/locale-formatter/tokens.ts
@@ -1,0 +1,5 @@
+const LOCALE_FORMATTER_TOKENS = Object.freeze({
+  LocaleFormatterService: Symbol('LocaleFormatterService'),
+} as const);
+
+export default LOCALE_FORMATTER_TOKENS;

--- a/src/services/types/locale-formatter/locale-formatter.ts
+++ b/src/services/types/locale-formatter/locale-formatter.ts
@@ -1,0 +1,8 @@
+export interface LocaleFormatter {
+  date(value: Date | number, locale?: string): string;
+  dateTime(value: Date | number, locale?: string): string;
+  number(value: number, locale?: string): string;
+  currency(value: number, currencyCode?: string, locale?: string): string;
+  percent(value: number, locale?: string): string;
+  relativeTime(value: number, unit: Intl.RelativeTimeFormatUnit, locale?: string): string;
+}

--- a/src/services/types/locale-formatter/locale-formatter.ts
+++ b/src/services/types/locale-formatter/locale-formatter.ts
@@ -1,3 +1,7 @@
+export interface LanguageSource {
+  language?: string;
+}
+
 export interface LocaleFormatter {
   date(value: Date | number, locale?: string): string;
   dateTime(value: Date | number, locale?: string): string;

--- a/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
+++ b/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
@@ -1,12 +1,10 @@
 import 'reflect-metadata';
 
-import i18next from 'i18next';
-
 import container from '@/config/dependency-injection-config';
 import LOCALE_FORMATTER_TOKENS from '@/services/locale-formatter/tokens';
 import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
 
-const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+const JANUARY_15_2026_13_45 = new Date(2026, 0, 15, 13, 45);
 
 describe('locale formatter service (integration)', () => {
   const ORIGINAL_ENV = { ...process.env };
@@ -22,27 +20,22 @@ describe('locale formatter service (integration)', () => {
     expect(container.resolve(LOCALE_FORMATTER_TOKENS.LocaleFormatterService)).toBe(service);
   });
 
-  it('falls back to the default main language before i18next initializes', () => {
+  it('resolves the locale from the environment first, then the bound i18n language', async () => {
     delete process.env.REACT_APP_MAIN_LANGUAGE;
-
     expect(service.currency(1234.5)).toBe('1\u00A0234,50\u00A0₴');
-  });
 
-  it('honors the configured main language before i18next initializes', () => {
     process.env.REACT_APP_MAIN_LANGUAGE = 'en';
-
     expect(service.number(1234.5)).toBe('1,234.5');
-  });
 
-  it('formats with the active i18next language once i18next initializes', async () => {
-    await i18next.init({ lng: 'en', fallbackLng: 'en', resources: { en: { translation: {} } } });
-
+    const { default: i18n } = await import('@/i18n');
+    await i18n.changeLanguage('en');
+    delete process.env.REACT_APP_MAIN_LANGUAGE;
     expect(service.currency(1234.5)).toBe('₴1,234.50');
   });
 
   it('honors an explicit locale override across every formatter', () => {
-    expect(service.date(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р.');
-    expect(service.dateTime(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р., 13:45');
+    expect(service.date(JANUARY_15_2026_13_45, 'uk')).toBe('15 січ. 2026 р.');
+    expect(service.dateTime(JANUARY_15_2026_13_45, 'uk')).toBe('15 січ. 2026 р., 13:45');
     expect(service.number(1234.5, 'uk')).toBe('1\u00A0234,5');
     expect(service.currency(1234.5, 'USD', 'uk')).toBe('1\u00A0234,50\u00A0$');
     expect(service.percent(0.1234, 'uk')).toBe('12,3%');

--- a/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
+++ b/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 
 import container from '@/config/dependency-injection-config';
+import localeFormatterCore from '@/services/locale-formatter/locale-formatter-core';
 import LOCALE_FORMATTER_TOKENS from '@/services/locale-formatter/tokens';
 import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
 
@@ -14,22 +15,26 @@ describe('locale formatter service (integration)', () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    localeFormatterCore.bindLanguageSource(null);
   });
 
   it('resolves a singleton through the aggregated DI container', () => {
     expect(container.resolve(LOCALE_FORMATTER_TOKENS.LocaleFormatterService)).toBe(service);
   });
 
-  it('resolves the locale from the environment first, then the bound i18n language', async () => {
+  it('falls back to the environment main language while no language source is bound', () => {
     delete process.env.REACT_APP_MAIN_LANGUAGE;
     expect(service.currency(1234.5)).toBe('1\u00A0234,50\u00A0₴');
 
     process.env.REACT_APP_MAIN_LANGUAGE = 'en';
     expect(service.number(1234.5)).toBe('1,234.5');
+  });
 
+  it('prefers the bound i18n language over the environment main language', async () => {
     const { default: i18n } = await import('@/i18n');
     await i18n.changeLanguage('en');
-    delete process.env.REACT_APP_MAIN_LANGUAGE;
+    process.env.REACT_APP_MAIN_LANGUAGE = 'uk';
+
     expect(service.currency(1234.5)).toBe('₴1,234.50');
   });
 

--- a/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
+++ b/tests/integration/services/locale-formatter/locale-formatter-service.integration.test.ts
@@ -1,0 +1,56 @@
+import 'reflect-metadata';
+
+import i18next from 'i18next';
+
+import container from '@/config/dependency-injection-config';
+import LOCALE_FORMATTER_TOKENS from '@/services/locale-formatter/tokens';
+import type { LocaleFormatter } from '@/services/types/locale-formatter/locale-formatter';
+
+const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+
+describe('locale formatter service (integration)', () => {
+  const ORIGINAL_ENV = { ...process.env };
+  const service = container.resolve<LocaleFormatter>(
+    LOCALE_FORMATTER_TOKENS.LocaleFormatterService
+  );
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('resolves a singleton through the aggregated DI container', () => {
+    expect(container.resolve(LOCALE_FORMATTER_TOKENS.LocaleFormatterService)).toBe(service);
+  });
+
+  it('falls back to the default main language before i18next initializes', () => {
+    delete process.env.REACT_APP_MAIN_LANGUAGE;
+
+    expect(service.currency(1234.5)).toBe('1\u00A0234,50\u00A0₴');
+  });
+
+  it('honors the configured main language before i18next initializes', () => {
+    process.env.REACT_APP_MAIN_LANGUAGE = 'en';
+
+    expect(service.number(1234.5)).toBe('1,234.5');
+  });
+
+  it('formats with the active i18next language once i18next initializes', async () => {
+    await i18next.init({ lng: 'en', fallbackLng: 'en', resources: { en: { translation: {} } } });
+
+    expect(service.currency(1234.5)).toBe('₴1,234.50');
+  });
+
+  it('honors an explicit locale override across every formatter', () => {
+    expect(service.date(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р.');
+    expect(service.dateTime(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р., 13:45');
+    expect(service.number(1234.5, 'uk')).toBe('1\u00A0234,5');
+    expect(service.currency(1234.5, 'USD', 'uk')).toBe('1\u00A0234,50\u00A0$');
+    expect(service.percent(0.1234, 'uk')).toBe('12,3%');
+    expect(service.relativeTime(-2, 'day', 'uk')).toBe('позавчора');
+  });
+
+  it('serves repeated calls from the cached formatter instances', () => {
+    expect(service.percent(0.1234, 'en')).toBe('12.3%');
+    expect(service.percent(0.5, 'en')).toBe('50%');
+  });
+});

--- a/tests/unit/config/env/raw-env.test.ts
+++ b/tests/unit/config/env/raw-env.test.ts
@@ -7,6 +7,21 @@ describe('rawEnv', () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
+  describe('mainLanguage', () => {
+    it('trims the configured main language', () => {
+      process.env.REACT_APP_MAIN_LANGUAGE = '  en  ';
+      expect(rawEnv.mainLanguage()).toBe('en');
+    });
+
+    it('falls back to uk for a blank or missing main language', () => {
+      process.env.REACT_APP_MAIN_LANGUAGE = '   ';
+      expect(rawEnv.mainLanguage()).toBe('uk');
+
+      delete process.env.REACT_APP_MAIN_LANGUAGE;
+      expect(rawEnv.mainLanguage()).toBe('uk');
+    });
+  });
+
   describe('mockoonUrl', () => {
     it('trims the configured mockoon url', () => {
       process.env.REACT_APP_MOCKOON_URL = '  http://localhost:8080  ';

--- a/tests/unit/i18n-formatters.test.ts
+++ b/tests/unit/i18n-formatters.test.ts
@@ -3,7 +3,7 @@ import type { i18n as I18nType } from 'i18next';
 import i18nMod from '@/i18n';
 
 const i18n = i18nMod as unknown as I18nType;
-const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+const JANUARY_15_2026_13_45 = new Date(2026, 0, 15, 13, 45);
 
 describe('i18n formatters (issue #155)', () => {
   beforeAll(async () => {
@@ -19,13 +19,13 @@ describe('i18n formatters (issue #155)', () => {
   });
 
   it('renders {{value, datetime}} translation strings with the uk locale', () => {
-    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45_UTC, lng: 'uk' })).toBe(
+    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45, lng: 'uk' })).toBe(
       'Оновлено 15 січ. 2026 р., 13:45'
     );
   });
 
   it('renders {{value, datetime}} translation strings with the en locale', () => {
-    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45_UTC, lng: 'en' })).toBe(
+    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45, lng: 'en' })).toBe(
       'Last updated Jan 15, 2026, 1:45 PM'
     );
   });
@@ -41,9 +41,7 @@ describe('i18n formatters (issue #155)', () => {
   });
 
   it('renders the date, number, percent, and relativetime formatters through t()', () => {
-    expect(i18n.t('probe_date', { value: JANUARY_15_2026_13_45_UTC, lng: 'en' })).toBe(
-      'Jan 15, 2026'
-    );
+    expect(i18n.t('probe_date', { value: JANUARY_15_2026_13_45, lng: 'en' })).toBe('Jan 15, 2026');
     expect(i18n.t('probe_number', { value: 1234.5, lng: 'en' })).toBe('1,234.5');
     expect(i18n.t('probe_percent', { value: 0.1234, lng: 'uk' })).toBe('12,3%');
     expect(i18n.t('probe_relative', { value: -2, lng: 'uk' })).toBe('позавчора');

--- a/tests/unit/i18n-formatters.test.ts
+++ b/tests/unit/i18n-formatters.test.ts
@@ -1,0 +1,51 @@
+import type { i18n as I18nType } from 'i18next';
+
+import i18nMod from '@/i18n';
+
+const i18n = i18nMod as unknown as I18nType;
+const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+
+describe('i18n formatters (issue #155)', () => {
+  beforeAll(async () => {
+    if (!i18n.isInitialized) {
+      await new Promise((resolve) => {
+        i18n.on('initialized', resolve);
+      });
+    }
+    i18n.addResource('en', 'translation', 'probe_date', '{{value, date}}');
+    i18n.addResource('en', 'translation', 'probe_number', '{{value, number}}');
+    i18n.addResource('uk', 'translation', 'probe_percent', '{{value, percent}}');
+    i18n.addResource('uk', 'translation', 'probe_relative', '{{value, relativetime(range: day)}}');
+  });
+
+  it('renders {{value, datetime}} translation strings with the uk locale', () => {
+    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45_UTC, lng: 'uk' })).toBe(
+      'Оновлено 15 січ. 2026 р., 13:45'
+    );
+  });
+
+  it('renders {{value, datetime}} translation strings with the en locale', () => {
+    expect(i18n.t('formatting.updated_at', { value: JANUARY_15_2026_13_45_UTC, lng: 'en' })).toBe(
+      'Last updated Jan 15, 2026, 1:45 PM'
+    );
+  });
+
+  it('renders {{value, currency}} translation strings with the uk locale', () => {
+    expect(i18n.t('formatting.price', { value: 1234.5, lng: 'uk' })).toBe(
+      'Ціна: 1\u00A0234,50\u00A0₴'
+    );
+  });
+
+  it('renders {{value, currency}} translation strings with the en locale', () => {
+    expect(i18n.t('formatting.price', { value: 1234.5, lng: 'en' })).toBe('Price: ₴1,234.50');
+  });
+
+  it('renders the date, number, percent, and relativetime formatters through t()', () => {
+    expect(i18n.t('probe_date', { value: JANUARY_15_2026_13_45_UTC, lng: 'en' })).toBe(
+      'Jan 15, 2026'
+    );
+    expect(i18n.t('probe_number', { value: 1234.5, lng: 'en' })).toBe('1,234.5');
+    expect(i18n.t('probe_percent', { value: 0.1234, lng: 'uk' })).toBe('12,3%');
+    expect(i18n.t('probe_relative', { value: -2, lng: 'uk' })).toBe('позавчора');
+  });
+});

--- a/tests/unit/services/locale-formatter/intl-formatter-cache.test.ts
+++ b/tests/unit/services/locale-formatter/intl-formatter-cache.test.ts
@@ -1,0 +1,72 @@
+import { IntlFormatterCache } from '@/services/locale-formatter/intl-formatter-cache';
+
+describe('IntlFormatterCache', () => {
+  it('returns the same DateTimeFormat instance for a repeated locale and options pair', () => {
+    const cache = new IntlFormatterCache();
+
+    const first = cache.dateTime('uk', { dateStyle: 'medium' });
+
+    expect(cache.dateTime('uk', { dateStyle: 'medium' })).toBe(first);
+  });
+
+  it('creates distinct DateTimeFormat instances per locale', () => {
+    const cache = new IntlFormatterCache();
+
+    const uk = cache.dateTime('uk', { dateStyle: 'medium' });
+    const en = cache.dateTime('en', { dateStyle: 'medium' });
+
+    expect(en).not.toBe(uk);
+    expect(uk.resolvedOptions().locale).toBe('uk');
+    expect(en.resolvedOptions().locale).toBe('en');
+  });
+
+  it('creates distinct DateTimeFormat instances per options', () => {
+    const cache = new IntlFormatterCache();
+
+    const medium = cache.dateTime('uk', { dateStyle: 'medium' });
+    const short = cache.dateTime('uk', { dateStyle: 'short' });
+
+    expect(short).not.toBe(medium);
+    expect(short.resolvedOptions().dateStyle).toBe('short');
+  });
+
+  it('returns the same NumberFormat instance for a repeated locale and options pair', () => {
+    const cache = new IntlFormatterCache();
+
+    const first = cache.number('uk', { style: 'percent' });
+
+    expect(cache.number('uk', { style: 'percent' })).toBe(first);
+  });
+
+  it('creates distinct NumberFormat instances per locale and per options', () => {
+    const cache = new IntlFormatterCache();
+
+    const ukDecimal = cache.number('uk', {});
+    const enDecimal = cache.number('en', {});
+    const ukPercent = cache.number('uk', { style: 'percent' });
+
+    expect(enDecimal).not.toBe(ukDecimal);
+    expect(ukPercent).not.toBe(ukDecimal);
+    expect(ukDecimal.format(1234.5)).toBe('1\u00A0234,5');
+    expect(enDecimal.format(1234.5)).toBe('1,234.5');
+  });
+
+  it('returns the same RelativeTimeFormat instance for a repeated locale and options pair', () => {
+    const cache = new IntlFormatterCache();
+
+    const first = cache.relativeTime('uk', { numeric: 'auto' });
+
+    expect(cache.relativeTime('uk', { numeric: 'auto' })).toBe(first);
+    expect(first.format(-1, 'day')).toBe('учора');
+  });
+
+  it('caches each formatter kind independently under the same locale and options key', () => {
+    const cache = new IntlFormatterCache();
+
+    const dateTime = cache.dateTime('uk', {});
+    const numberFormat = cache.number('uk', {});
+
+    expect(numberFormat.format(1234.5)).toBe('1\u00A0234,5');
+    expect(dateTime.resolvedOptions().locale).toBe('uk');
+  });
+});

--- a/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
+++ b/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
@@ -1,0 +1,100 @@
+import i18next from 'i18next';
+
+import localeFormatterCore, {
+  LocaleFormatterCore,
+} from '@/services/locale-formatter/locale-formatter-core';
+
+jest.mock('i18next', () => ({ __esModule: true, default: { language: undefined } }));
+
+const i18nextStub = i18next as unknown as { language: string | undefined };
+const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+
+describe('LocaleFormatterCore', () => {
+  const ORIGINAL_ENV = { ...process.env };
+  const formatter = new LocaleFormatterCore();
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    i18nextStub.language = undefined;
+  });
+
+  describe('date', () => {
+    it('formats a medium date for the uk and en locales', () => {
+      expect(formatter.date(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р.');
+      expect(formatter.date(JANUARY_15_2026_13_45_UTC, 'en')).toBe('Jan 15, 2026');
+    });
+
+    it('accepts a numeric timestamp', () => {
+      expect(formatter.date(JANUARY_15_2026_13_45_UTC.getTime(), 'en')).toBe('Jan 15, 2026');
+    });
+  });
+
+  describe('dateTime', () => {
+    it('formats a medium date with short time for the uk and en locales', () => {
+      expect(formatter.dateTime(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р., 13:45');
+      expect(formatter.dateTime(JANUARY_15_2026_13_45_UTC, 'en')).toBe('Jan 15, 2026, 1:45 PM');
+    });
+  });
+
+  describe('number', () => {
+    it('formats a decimal for the uk and en locales', () => {
+      expect(formatter.number(1234.5, 'uk')).toBe('1\u00A0234,5');
+      expect(formatter.number(1234.5, 'en')).toBe('1,234.5');
+    });
+  });
+
+  describe('currency', () => {
+    it('formats hryvnia by default for the uk and en locales', () => {
+      expect(formatter.currency(1234.5, undefined, 'uk')).toBe('1\u00A0234,50\u00A0₴');
+      expect(formatter.currency(1234.5, undefined, 'en')).toBe('₴1,234.50');
+    });
+
+    it('formats an explicit currency code for the uk and en locales', () => {
+      expect(formatter.currency(1234.5, 'USD', 'uk')).toBe('1\u00A0234,50\u00A0$');
+      expect(formatter.currency(1234.5, 'USD', 'en')).toBe('$1,234.50');
+    });
+  });
+
+  describe('percent', () => {
+    it('formats a ratio as a percentage for the uk and en locales', () => {
+      expect(formatter.percent(0.1234, 'uk')).toBe('12,3%');
+      expect(formatter.percent(0.1234, 'en')).toBe('12.3%');
+    });
+  });
+
+  describe('relativeTime', () => {
+    it('formats named relative days for the uk and en locales', () => {
+      expect(formatter.relativeTime(-2, 'day', 'uk')).toBe('позавчора');
+      expect(formatter.relativeTime(-2, 'day', 'en')).toBe('2 days ago');
+    });
+
+    it('formats numeric relative minutes for the uk and en locales', () => {
+      expect(formatter.relativeTime(-5, 'minute', 'uk')).toBe('5 хвилин тому');
+      expect(formatter.relativeTime(-5, 'minute', 'en')).toBe('5 minutes ago');
+    });
+  });
+
+  describe('locale resolution', () => {
+    it('uses the active i18next language when no locale is given', () => {
+      i18nextStub.language = 'en';
+
+      expect(formatter.number(1234.5)).toBe('1,234.5');
+    });
+
+    it('falls back to the configured main language before i18next initializes', () => {
+      process.env.REACT_APP_MAIN_LANGUAGE = 'en';
+
+      expect(formatter.number(1234.5)).toBe('1,234.5');
+    });
+
+    it('defaults to uk when neither i18next nor the environment define a language', () => {
+      delete process.env.REACT_APP_MAIN_LANGUAGE;
+
+      expect(formatter.number(1234.5)).toBe('1\u00A0234,5');
+    });
+  });
+
+  it('exports a shared singleton instance', () => {
+    expect(localeFormatterCore).toBeInstanceOf(LocaleFormatterCore);
+  });
+});

--- a/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
+++ b/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
@@ -1,13 +1,8 @@
-import i18next from 'i18next';
-
 import localeFormatterCore, {
   LocaleFormatterCore,
 } from '@/services/locale-formatter/locale-formatter-core';
 
-jest.mock('i18next', () => ({ __esModule: true, default: { language: undefined } }));
-
-const i18nextStub = i18next as unknown as { language: string | undefined };
-const JANUARY_15_2026_13_45_UTC = new Date(Date.UTC(2026, 0, 15, 13, 45));
+const JANUARY_15_2026_13_45 = new Date(2026, 0, 15, 13, 45);
 
 describe('LocaleFormatterCore', () => {
   const ORIGINAL_ENV = { ...process.env };
@@ -15,23 +10,22 @@ describe('LocaleFormatterCore', () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    i18nextStub.language = undefined;
   });
 
   describe('date', () => {
     it('formats a medium date for the uk and en locales', () => {
-      expect(formatter.date(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р.');
-      expect(formatter.date(JANUARY_15_2026_13_45_UTC, 'en')).toBe('Jan 15, 2026');
+      expect(formatter.date(JANUARY_15_2026_13_45, 'uk')).toBe('15 січ. 2026 р.');
+      expect(formatter.date(JANUARY_15_2026_13_45, 'en')).toBe('Jan 15, 2026');
     });
 
     it('accepts a numeric timestamp', () => {
-      expect(formatter.date(JANUARY_15_2026_13_45_UTC.getTime(), 'en')).toBe('Jan 15, 2026');
+      expect(formatter.date(JANUARY_15_2026_13_45.getTime(), 'en')).toBe('Jan 15, 2026');
     });
   });
 
   describe('dateTime', () => {
     it('formats a medium date with short time for the uk and en locales', () => {
-      const value = JANUARY_15_2026_13_45_UTC;
+      const value = JANUARY_15_2026_13_45;
       expect(formatter.dateTime(value, 'uk')).toBe('15 січ. 2026 р., 13:45');
       expect(formatter.dateTime(value, 'en')).toBe('Jan 15, 2026, 1:45 PM');
     });
@@ -76,19 +70,28 @@ describe('LocaleFormatterCore', () => {
   });
 
   describe('locale resolution', () => {
-    it('uses the active i18next language when no locale is given', () => {
-      i18nextStub.language = 'en';
+    it('uses the bound language source when no locale is given', () => {
+      const bound = new LocaleFormatterCore();
+      bound.bindLanguageSource({ language: 'en' });
 
-      expect(formatter.number(1234.5)).toBe('1,234.5');
+      expect(bound.number(1234.5)).toBe('1,234.5');
     });
 
-    it('falls back to the configured main language before i18next initializes', () => {
+    it('falls back to the configured main language while no language source is bound', () => {
       process.env.REACT_APP_MAIN_LANGUAGE = 'en';
 
       expect(formatter.number(1234.5)).toBe('1,234.5');
     });
 
-    it('defaults to uk when neither i18next nor the environment define a language', () => {
+    it('falls back to the configured main language while the bound language is undefined', () => {
+      const bound = new LocaleFormatterCore();
+      bound.bindLanguageSource({});
+      process.env.REACT_APP_MAIN_LANGUAGE = 'en';
+
+      expect(bound.number(1234.5)).toBe('1,234.5');
+    });
+
+    it('defaults to uk when no language source defines a language', () => {
       delete process.env.REACT_APP_MAIN_LANGUAGE;
 
       expect(formatter.number(1234.5)).toBe('1\u00A0234,5');

--- a/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
+++ b/tests/unit/services/locale-formatter/locale-formatter-core.test.ts
@@ -31,8 +31,9 @@ describe('LocaleFormatterCore', () => {
 
   describe('dateTime', () => {
     it('formats a medium date with short time for the uk and en locales', () => {
-      expect(formatter.dateTime(JANUARY_15_2026_13_45_UTC, 'uk')).toBe('15 січ. 2026 р., 13:45');
-      expect(formatter.dateTime(JANUARY_15_2026_13_45_UTC, 'en')).toBe('Jan 15, 2026, 1:45 PM');
+      const value = JANUARY_15_2026_13_45_UTC;
+      expect(formatter.dateTime(value, 'uk')).toBe('15 січ. 2026 р., 13:45');
+      expect(formatter.dateTime(value, 'en')).toBe('Jan 15, 2026, 1:45 PM');
     });
   });
 

--- a/tests/unit/services/locale-formatter/locale-formatter-service.test.ts
+++ b/tests/unit/services/locale-formatter/locale-formatter-service.test.ts
@@ -1,0 +1,55 @@
+import localeFormatterCore from '@/services/locale-formatter/locale-formatter-core';
+import LocaleFormatterService from '@/services/locale-formatter/locale-formatter-service';
+
+jest.mock('@/services/locale-formatter/locale-formatter-core', () => ({
+  __esModule: true,
+  default: {
+    date: jest.fn().mockReturnValue('date-result'),
+    dateTime: jest.fn().mockReturnValue('date-time-result'),
+    number: jest.fn().mockReturnValue('number-result'),
+    currency: jest.fn().mockReturnValue('currency-result'),
+    percent: jest.fn().mockReturnValue('percent-result'),
+    relativeTime: jest.fn().mockReturnValue('relative-time-result'),
+  },
+}));
+
+const core = jest.mocked(localeFormatterCore);
+const JANUARY_15_2026_UTC = new Date(Date.UTC(2026, 0, 15));
+
+describe('LocaleFormatterService', () => {
+  const service = new LocaleFormatterService();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates date to the core formatter', () => {
+    expect(service.date(JANUARY_15_2026_UTC, 'uk')).toBe('date-result');
+    expect(core.date).toHaveBeenCalledWith(JANUARY_15_2026_UTC, 'uk');
+  });
+
+  it('delegates dateTime to the core formatter', () => {
+    expect(service.dateTime(JANUARY_15_2026_UTC, 'en')).toBe('date-time-result');
+    expect(core.dateTime).toHaveBeenCalledWith(JANUARY_15_2026_UTC, 'en');
+  });
+
+  it('delegates number to the core formatter', () => {
+    expect(service.number(1234.5, 'uk')).toBe('number-result');
+    expect(core.number).toHaveBeenCalledWith(1234.5, 'uk');
+  });
+
+  it('delegates currency to the core formatter', () => {
+    expect(service.currency(1234.5, 'USD', 'en')).toBe('currency-result');
+    expect(core.currency).toHaveBeenCalledWith(1234.5, 'USD', 'en');
+  });
+
+  it('delegates percent to the core formatter', () => {
+    expect(service.percent(0.5, 'en')).toBe('percent-result');
+    expect(core.percent).toHaveBeenCalledWith(0.5, 'en');
+  });
+
+  it('delegates relativeTime to the core formatter', () => {
+    expect(service.relativeTime(-2, 'day', 'uk')).toBe('relative-time-result');
+    expect(core.relativeTime).toHaveBeenCalledWith(-2, 'day', 'uk');
+  });
+});


### PR DESCRIPTION
Closes #155

## Summary

Establishes the locale-aware Intl formatting standard for dates, numbers, currency,
percentages, and relative time before CRM modules land, following the two-layer
paint-safe pattern from observability (#115) and per-area DI composition roots (#109).

### LocaleFormatter service (`src/services/locale-formatter/`)

- **Container-free core** — `localeFormatterCore` singleton with an `IntlFormatterCache`
  that caches `Intl.DateTimeFormat`, `Intl.NumberFormat` (decimal / currency / percent),
  and `Intl.RelativeTimeFormat` instances keyed by locale + options. Locale resolution:
  explicit argument → active i18next language → `rawEnv.mainLanguage()` (default `uk`).
- **DI adapter** — `@injectable()` `LocaleFormatterService` registered by its own
  `di.ts` composition root against `LOCALE_FORMATTER_TOKENS.LocaleFormatterService`.
- Defaults: medium date style, short time style, `UAH` with a narrow symbol,
  `numeric: 'auto'` relative time.

### i18next formatters (`src/i18n.js`)

Registers `date`, `datetime`, `number`, `currency`, `percent`, and `relativetime`
formatters backed by the core, and uses them in translation strings
(`formatting.updated_at` with `{{value, datetime}}`, `formatting.price` with
`{{value, currency}}`) in both `uk` and `en`.

### ESLint gate

A `no-restricted-syntax` gate (`noRawIntlSelectors` in `eslint.config.mjs`) fails the
build on raw `toLocale*` calls (dot and computed spellings) and `Intl.*` member access
in `src/**`, lifted only inside `src/services/locale-formatter/`. Runs in
`make lint-eslint` and the `static testing` workflow.

### Tests

Unit + integration suites pin exact uk/en outputs (e.g. `1234.5` → `1 234,50 ₴` uk vs
`₴1,234.50` en), cover cache identity, locale fallback chain, DI resolution through the
aggregated container, and the i18next formatters through `t()`.

### Docs

Convention documented in `CLAUDE.md` (Important Patterns item 10 + Localization section)
and `agents.md` (Locale-aware Intl formatting section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a locale-aware Intl formatting boundary and ESLint gate so all dates, numbers, currency, percentages, and relative time render in the active language. Previously callers used raw toLocale*/Intl.*; now they must use the `LocaleFormatter` service or the registered `i18next` formatters, and ESLint blocks raw usage.

- `localeFormatterCore` singleton caches `Intl.DateTimeFormat`, `Intl.NumberFormat` (decimal/currency/percent), and `Intl.RelativeTimeFormat`. Locale resolution: explicit argument → bound `i18next.language` → `rawEnv.mainLanguage()` (default `uk`). Exposes `bindLanguageSource(i18n)` and accepts `null` to unbind. Presets: medium date, short time, `UAH` narrow symbol, percent with 1 fraction digit, relative time `numeric: 'auto'`.
- `LocaleFormatterService` registered under `LOCALE_FORMATTER_TOKENS.LocaleFormatterService` via its own `di.ts` and added to the aggregated container.
- `i18next` formatters `date`, `datetime`, `number`, `currency`, `percent`, `relativetime` registered in `src/i18n.js`; `i18n` initializes `lng` from `rawEnv.mainLanguage()` and trims the fallback language.
- ESLint `noRawIntlSelectors` bans raw toLocale* (dot and computed) and all `Intl.*` member access in `src/**`, lifted only in `src/services/locale-formatter/**`; tests and type-only globs are exempt. Runs in the static checks workflow.
- Tests pin exact `uk`/`en` outputs and cache identity; integration suite isolates locale precedence (bound language wins over env). Docs updated in `CLAUDE.md` and `agents.md`. Addresses issue #155.

**Migration**
- Replace all `toLocaleString`/`toLocaleDateString`/`toLocaleTimeString` and `new Intl.*Format(...)` with `LocaleFormatterService` or `i18next` formatters.
- Inject via `LOCALE_FORMATTER_TOKENS.LocaleFormatterService`; do not disable the ESLint rule.
- In translations, use `{{value, datetime}}`, `{{value, currency}}`, etc.; elsewhere call the service.
- Pass a currency code to `currency(value, code)` when you need something other than UAH.

<sup>Written for commit b123511a77bf90fce1c4376e3af03b3c43de0001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/crm/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

